### PR TITLE
Fix typo in a e-mail sent when player leaves the room

### DIFF
--- a/JoinRpg.Services.Email/EmailServiceImpl.cs
+++ b/JoinRpg.Services.Email/EmailServiceImpl.cs
@@ -195,7 +195,7 @@ namespace JoinRpg.Services.Email
 
         public async Task Email(LeaveRoomEmail email)
         {
-            string body = $"{email.Claim?.Player?.GetDisplayName()} покинул комнату, так как его заявка была отзована или отклонена.";
+            string body = $"{email.Claim?.Player?.GetDisplayName()} покинул комнату, так как его заявка была отозвана или отклонена.";
             if (email.Room.GetAllInhabitants().Any())
             {
                 body += $"\n\nОстались в комнате:{email.Room.GetAllInhabitants().GetPlayerList()}";


### PR DESCRIPTION
BTW вся строка у меня выгляди так:
"Изменен состав жителей комнаты 6-местный коттедж 2 (Экзопланетологи)
покинул комнату, так как его заявка была отзована или отклонена."

Т.е. имени игрока нет (и вообще не вполне очевидно что оно там подразумевается).