### PR TITLE
Allow use width and heigth with <img> in markdown

### DIFF
--- a/Joinrpg.Markdown/HtmlSanitizers.cs
+++ b/Joinrpg.Markdown/HtmlSanitizers.cs
@@ -37,6 +37,8 @@ namespace Joinrpg.Markdown
         {
             var sanitizer = HtmlSanitizer.SimpleHtml5Sanitizer();
             sanitizer.Tag("img").AllowAttributes("src");
+            sanitizer.Tag("img").AllowAttributes("height");
+            sanitizer.Tag("img").AllowAttributes("width");
             sanitizer.Tag("hr");
             sanitizer.Tag("blockquote");
             sanitizer.Tag("s");


### PR DESCRIPTION
This should allow to specify height/width in markdown