### PR TITLE
Fix BooleanRequired attribute front-end validation

### DIFF
--- a/src/JoinRpg.Helpers.Web/BooleanRequired.cs
+++ b/src/JoinRpg.Helpers.Web/BooleanRequired.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
@@ -7,7 +8,20 @@ namespace JoinRpg.Helpers.Web
     public class BooleanRequired : RequiredAttribute, IClientModelValidator
     {
         /// <inheritdoc />
-        public override bool IsValid(object value) => value != null && (bool)value;
+        public override bool IsValid(object value)
+        {
+            if (value is null)
+            {
+                return false;
+            }
+
+            if (value.GetType() != typeof(bool))
+            {
+                throw new InvalidOperationException("Can only be used on boolean properties.");
+            }
+
+            return (bool) value;
+        }
 
         private bool MergeAttribute(IDictionary<string, string> attributes, string key, string value)
         {
@@ -22,6 +36,11 @@ namespace JoinRpg.Helpers.Web
 
         public void AddValidation(ClientModelValidationContext context)
         {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             MergeAttribute(context.Attributes, "data-val", "true");
             MergeAttribute(context.Attributes, "data-val-brequired", ErrorMessage);
         }

--- a/src/JoinRpg.Helpers.Web/BooleanRequired.cs
+++ b/src/JoinRpg.Helpers.Web/BooleanRequired.cs
@@ -42,7 +42,7 @@ namespace JoinRpg.Helpers.Web
             }
 
             MergeAttribute(context.Attributes, "data-val", "true");
-            MergeAttribute(context.Attributes, "data-val-brequired", ErrorMessage);
+            MergeAttribute(context.Attributes, "data-val-enforcetrue", ErrorMessage);
         }
     }
 }

--- a/src/JoinRpg.Helpers.Web/BooleanRequired.cs
+++ b/src/JoinRpg.Helpers.Web/BooleanRequired.cs
@@ -5,7 +5,14 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace JoinRpg.Helpers.Web
 {
-    public class BooleanRequired : RequiredAttribute, IClientModelValidator
+    /// <summary>
+    /// Makes boolean fields required (i.e. checkbox must be checked)
+    /// </summary>
+    /// <remarks>
+    /// Includes [Required] attribute logic, therefore no sense to use both attributes at once
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class BooleanRequiredAttribute : RequiredAttribute, IClientModelValidator
     {
         /// <inheritdoc />
         public override bool IsValid(object value)
@@ -34,6 +41,7 @@ namespace JoinRpg.Helpers.Web
             return true;
         }
 
+        /// <inheritdoc cref="IClientModelValidator.AddValidation"/>
         public void AddValidation(ClientModelValidationContext context)
         {
             if (context is null)

--- a/src/JoinRpg.Helpers.Web/BooleanRequired.cs
+++ b/src/JoinRpg.Helpers.Web/BooleanRequired.cs
@@ -27,7 +27,7 @@ namespace JoinRpg.Helpers.Web
                 throw new InvalidOperationException("Can only be used on boolean properties.");
             }
 
-            return (bool) value;
+            return (bool)value;
         }
 
         private bool MergeAttribute(IDictionary<string, string> attributes, string key, string value)

--- a/src/JoinRpg.Portal/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -10,3 +10,9 @@
     </script>
 </environment>
 <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+<script>
+  jQuery.validator.addMethod("enforcetrue", function (value, element, param) {
+    return element.checked;
+  });
+  jQuery.validator.unobtrusive.adapters.addBool("enforcetrue");
+</script>

--- a/src/JoinRpg.WebPortal.Models/AccountViewModels.cs
+++ b/src/JoinRpg.WebPortal.Models/AccountViewModels.cs
@@ -7,7 +7,6 @@ namespace JoinRpg.Web.Models
 {
     public class ExternalLoginConfirmationViewModel
     {
-        [Required]
         [Display(Name = "Согласен с правилами")]
         [BooleanRequired(ErrorMessage = "Согласитесь с правилами, чтобы продолжить")]
         public bool RulesApproved { get; set; }
@@ -72,9 +71,8 @@ namespace JoinRpg.Web.Models
         [Compare("Password", ErrorMessage = "Пароли не совпадают")]
         public string ConfirmPassword { get; set; }
 
-        [Required()]
-        [Display(Name = "Согласен с правилами")]
         [BooleanRequired(ErrorMessage = "Согласитесь с правилами, чтобы продолжить")]
+        [Display(Name = "Согласен с правилами")]
         public bool RulesApproved { get; set; }
 
         [Editable(false)]

--- a/src/JoinRpg.WebPortal.Models/ProjectCreateViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/ProjectCreateViewModel.cs
@@ -13,7 +13,6 @@ namespace JoinRpg.Web.Models
              MinimumLength = 5)]
         public string ProjectName { get; set; }
 
-        [Required]
         [Display(Name = "Согласен с правилами")]
         [BooleanRequired(ErrorMessage = "Согласитесь с правилами, чтобы продолжить")]
         public bool RulesApproved { get; set; }


### PR DESCRIPTION
## Problem
Properties marked by BooleanRequired Attribute should be validated by `jquery.validate` at the front-end side, but they validates only at server-side

## Solution
Added new `jquery.validate` rule for our attribute, which targeted at boolean values for checkboxes.

### A little refactoring

- [x] Renamed Attribute class under C# Attributes convention
- [x] Added some XML docs, to fix CS1591 warnings
- [x] Throw an exception if attribute was used to not valid data type
- [x] Remove use of Required attribute together with BooleanRequired, because BooleanRequiredAttribute inherits RequiredAttribue logic.