### PR TITLE
Do not copy libman.json into output directories

### DIFF
--- a/src/JoinRpg.Portal/JoinRpg.Portal.csproj
+++ b/src/JoinRpg.Portal/JoinRpg.Portal.csproj
@@ -51,6 +51,11 @@
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
   <ItemGroup>
+    <Content Update="libman.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <None Update="Dockerfile">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/JoinRpg.WebComponents/JoinRpg.WebComponents.csproj
+++ b/src/JoinRpg.WebComponents/JoinRpg.WebComponents.csproj
@@ -22,4 +22,10 @@
     <Folder Include="wwwroot\lib\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="libman.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Reason: /usr/share/dotnet/sdk/6.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ConflictResolution.targets(112,5): error NETSDK1152: Found multiple publish output files with the same relative path: /app/src/JoinRpg.WebComponents/libman.json, /app/src/JoinRpg.Portal/libman.json. [/app/src/JoinRpg.Portal/JoinRpg.Portal.csproj]
