### PR TITLE
Реализовать структурное логгирование с Serilog

### DIFF
--- a/src/JoinRpg.Portal/Infrastructure/Logging/CustomJsonFormatter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/CustomJsonFormatter.cs
@@ -1,0 +1,53 @@
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+using Serilog.Formatting.Elasticsearch;
+using Serilog.Parsing;
+
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+internal class CustomJsonFormatter : ElasticsearchJsonFormatter
+{
+    private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+    private readonly HashSet<string> _topLevelPropertiesNames;
+
+    public CustomJsonFormatter(HashSet<string> topLevelPropertiesNames) : base(renderMessage: true, renderMessageTemplate: false)
+    {
+        _topLevelPropertiesNames = topLevelPropertiesNames;
+    }
+
+    protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("@timestamp", (object) timestamp.ToUniversalTime().ToString(DateTimeFormat), ref delim, output);
+    }
+
+    protected override void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("Level", LevelConvert.ToExtensionsLevel(level), ref delim, output);
+    }
+
+    protected override void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        var precedingDelimiter = ",";
+        foreach (var kv in properties.Where(pair => _topLevelPropertiesNames.Contains(pair.Key)))
+        {
+            WriteJsonProperty(kv.Key, kv.Value, ref precedingDelimiter, output);
+        }
+
+        output.Write(",\"{0}\":{{", "fields");
+
+        precedingDelimiter = "";
+        foreach (var kv in properties.Where(pair => !_topLevelPropertiesNames.Contains(pair.Key)))
+        {
+            WriteJsonProperty(kv.Key, kv.Value, ref precedingDelimiter, output);
+        }
+
+        output.Write("}");
+    }
+
+    protected override void WriteRenderings(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+        TextWriter output)
+    {
+        // Don't write information about template renderings
+    }
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/CustomJsonFormatter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/CustomJsonFormatter.cs
@@ -18,7 +18,7 @@ internal class CustomJsonFormatter : ElasticsearchJsonFormatter
 
     protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
     {
-        WriteJsonProperty("@timestamp", (object) timestamp.ToUniversalTime().ToString(DateTimeFormat), ref delim, output);
+        WriteJsonProperty("@timestamp", (object)timestamp.ToUniversalTime().ToString(DateTimeFormat), ref delim, output);
     }
 
     protected override void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Serilog;
+
+namespace JoinRpg.Portal.Infrastructure.Logging.Filters;
+
+public class SerilogMvcFilter : IActionFilter
+{
+    private readonly IDiagnosticContext _diagnosticContext;
+    public SerilogMvcFilter(IDiagnosticContext diagnosticContext)
+    {
+        _diagnosticContext = diagnosticContext;
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        _diagnosticContext.Set("RouteData", context.ActionDescriptor.RouteValues);
+        _diagnosticContext.Set("ActionName", context.ActionDescriptor.DisplayName);
+        _diagnosticContext.Set("ActionId", context.ActionDescriptor.Id);
+        _diagnosticContext.Set("ValidationState", context.ModelState.IsValid);
+    }
+
+    // Required by the interface
+    public void OnActionExecuted(ActionExecutedContext context){}
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
@@ -17,6 +17,10 @@ public class SerilogMvcFilter : IActionFilter
         _diagnosticContext.Set("ActionName", context.ActionDescriptor.DisplayName);
         _diagnosticContext.Set("ActionId", context.ActionDescriptor.Id);
         _diagnosticContext.Set("ValidationState", context.ModelState.IsValid);
+        if (context.HttpContext.Items.TryGetValue(DiscoverFilters.Constants.ProjectIdName, out var projectId))
+        {
+            _diagnosticContext.Set("ProjectId", projectId);
+        }
     }
 
     // Required by the interface

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogMvcFilter.cs
@@ -20,5 +20,5 @@ public class SerilogMvcFilter : IActionFilter
     }
 
     // Required by the interface
-    public void OnActionExecuted(ActionExecutedContext context){}
+    public void OnActionExecuted(ActionExecutedContext context) { }
 }

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
@@ -26,6 +26,6 @@ public class SerilogRazorPagesFilter : IPageFilter
     }
 
     // Required by the interface
-    public void OnPageHandlerExecuted(PageHandlerExecutedContext context){}
-    public void OnPageHandlerExecuting(PageHandlerExecutingContext context) {}
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context) { }
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context) { }
 }

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Serilog;
+
+namespace JoinRpg.Portal.Infrastructure.Logging.Filters;
+
+public class SerilogRazorPagesFilter : IPageFilter
+{
+    private readonly IDiagnosticContext _diagnosticContext;
+    public SerilogRazorPagesFilter(IDiagnosticContext diagnosticContext)
+    {
+        _diagnosticContext = diagnosticContext;
+    }
+
+    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+    {
+        var name = context.HandlerMethod?.Name ?? context.HandlerMethod?.MethodInfo.Name;
+        if (name != null)
+        {
+            _diagnosticContext.Set("RazorPageHandler", name);
+        }
+
+        _diagnosticContext.Set("RouteData", context.ActionDescriptor.RouteValues);
+        _diagnosticContext.Set("ActionName", context.ActionDescriptor.DisplayName);
+        _diagnosticContext.Set("ActionId", context.ActionDescriptor.Id);
+        _diagnosticContext.Set("ValidationState", context.ModelState.IsValid);
+    }
+
+    // Required by the interface
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context){}
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context) {}
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Filters/SerilogRazorPagesFilter.cs
@@ -23,6 +23,11 @@ public class SerilogRazorPagesFilter : IPageFilter
         _diagnosticContext.Set("ActionName", context.ActionDescriptor.DisplayName);
         _diagnosticContext.Set("ActionId", context.ActionDescriptor.Id);
         _diagnosticContext.Set("ValidationState", context.ModelState.IsValid);
+
+        if (context.HttpContext.Items.TryGetValue(DiscoverFilters.Constants.ProjectIdName, out var projectId))
+        {
+            _diagnosticContext.Set("ProjectId", projectId);
+        }
     }
 
     // Required by the interface

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -1,0 +1,60 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
+
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+public static class SerilogExtensions
+{
+    public static void ConfigureLogger(this LoggerConfiguration loggerConfiguration, SerilogOptions serilogOptions)
+    {
+        serilogOptions.LogLevel.TryAdd("Default", LogLevel.Information);
+        serilogOptions.LogLevel.TryAdd("Microsoft", LogLevel.Information);
+        serilogOptions.LogLevel.TryAdd("Microsoft.AspNetCore", LogLevel.Warning);
+
+        var globalMinimumLogLevelSerilog = LevelConvert.ToSerilogLevel(serilogOptions.LogLevel["Default"]);
+
+        loggerConfiguration.MinimumLevel
+            .ControlledBy(new LoggingLevelSwitch(globalMinimumLogLevelSerilog))
+            .Enrich.FromLogContext()
+            .Enrich.WithMachineName()
+            .Enrich.With<YcLevelEnricher>()
+            .Enrich.WithProperty("AppName", "JoinRpg.Portal");
+
+        foreach (var (@namespace, logLevel) in serilogOptions.LogLevel)
+        {
+            if (@namespace == "Default")
+            {
+                continue;
+            }
+            loggerConfiguration = loggerConfiguration.MinimumLevel.Override(@namespace,  LevelConvert.ToSerilogLevel(logLevel));
+        }
+
+        if (serilogOptions.Structured)
+        {
+            var topLevelPropertiesNames = new HashSet<string>()
+            {
+                "AppName", "TokenId", "UserId", "UserName", "TraceId", "SpanId", "MachineName",
+                "Host", "Protocol", "Scheme", "ResponseContentType", "RequestMethod", "RequestPath",
+                "StatusCode", "Elapsed", "SourceContext", "RequestId", "ConnectionId", "EndpointName",
+                "RouteData", "ActionName", "ActionId", "ValidationState", "RazorPageHandler", "YcLevel"
+            };
+
+            loggerConfiguration.WriteTo.Console(formatter: new CustomJsonFormatter(topLevelPropertiesNames));
+        }
+        else
+        {
+            var template = "[{UtcDateTime(@t):dd-MM-yyyy HH:mm:ss.fff} {#if @l='Verbose'}Trace{#else if @l='Fatal'}Critical{#else}{@l}{#end} ({SourceContext})] {@m}\n{@x}";
+            loggerConfiguration.WriteTo.Console(formatter: new ExpressionTemplate(template: template, theme: TemplateTheme.Code));
+        }
+
+        if (serilogOptions.SelfLogEnabled)
+        {
+            SelfLog.Enable(Console.Error);
+        }
+    }
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -1,7 +1,6 @@
 using Serilog;
 using Serilog.Core;
 using Serilog.Debugging;
-using Serilog.Events;
 using Serilog.Extensions.Logging;
 using Serilog.Templates;
 using Serilog.Templates.Themes;

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -40,7 +40,8 @@ public static class SerilogExtensions
                 "AppName", "TokenId", "UserId", "UserName", "TraceId", "SpanId", "MachineName",
                 "Host", "Protocol", "Scheme", "ResponseContentType", "RequestMethod", "RequestPath",
                 "StatusCode", "Elapsed", "SourceContext", "RequestId", "ConnectionId", "EndpointName",
-                "RouteData", "ActionName", "ActionId", "ValidationState", "RazorPageHandler", "YcLevel"
+                "RouteData", "ActionName", "ActionId", "ValidationState", "RazorPageHandler", "YcLevel",
+                "QueryString", "ViewComponentName", "ViewComponentId", "LoggedUser", "ProjectId",
             };
 
             loggerConfiguration.WriteTo.Console(formatter: new CustomJsonFormatter(topLevelPropertiesNames));

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -18,8 +18,8 @@ public static class SerilogExtensions
 
         var globalMinimumLogLevelSerilog = LevelConvert.ToSerilogLevel(serilogOptions.LogLevel["Default"]);
 
-        loggerConfiguration.MinimumLevel
-            .ControlledBy(new LoggingLevelSwitch(globalMinimumLogLevelSerilog))
+        loggerConfiguration
+            .MinimumLevel.ControlledBy(new LoggingLevelSwitch(globalMinimumLogLevelSerilog))
             .Enrich.FromLogContext()
             .Enrich.WithMachineName()
             .Enrich.With<YcLevelEnricher>()

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -31,7 +31,7 @@ public static class SerilogExtensions
             {
                 continue;
             }
-            loggerConfiguration = loggerConfiguration.MinimumLevel.Override(@namespace,  LevelConvert.ToSerilogLevel(logLevel));
+            loggerConfiguration = loggerConfiguration.MinimumLevel.Override(@namespace, LevelConvert.ToSerilogLevel(logLevel));
         }
 
         if (serilogOptions.Structured)

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Serilog;
 using Serilog.Events;
 
@@ -28,6 +29,15 @@ public static class SerilogHelper
         if (endpoint is not null)
         {
             diagnosticContext.Set("EndpointName", endpoint.DisplayName);
+        }
+
+        if (httpContext.User.Identity?.IsAuthenticated == true)
+        {
+            diagnosticContext.Set("LoggedUser", httpContext.User.FindFirst(ClaimTypes.Email)!.Value);
+        }
+        else
+        {
+            diagnosticContext.Set("LoggedUser", "null");
         }
     }
     private static bool IsHealthCheckEndpoint(HttpContext ctx)

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
@@ -1,0 +1,53 @@
+using Serilog;
+using Serilog.Events;
+
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+public static class SerilogHelper
+{
+    public static void EnrichFromRequest(IDiagnosticContext diagnosticContext, HttpContext httpContext)
+    {
+        var request = httpContext.Request;
+
+        // Set all the common properties available for every request
+        diagnosticContext.Set("Host", request.Host);
+        diagnosticContext.Set("Protocol", request.Protocol);
+        diagnosticContext.Set("Scheme", request.Scheme);
+
+        // Only set it if available. You're not sending sensitive data in a querystring right?!
+        if (request.QueryString.HasValue)
+        {
+            diagnosticContext.Set("QueryString", request.QueryString.Value);
+        }
+
+        // Set the content-type of the Response at this point
+        diagnosticContext.Set("ResponseContentType", httpContext.Response.ContentType);
+
+        // Retrieve the IEndpointFeature selected for the request
+        var endpoint = httpContext.GetEndpoint();
+        if (endpoint is object) // endpoint != null
+        {
+            diagnosticContext.Set("EndpointName", endpoint.DisplayName);
+        }
+    }
+    private static bool IsHealthCheckEndpoint(HttpContext ctx)
+    {
+        var endpoint = ctx.GetEndpoint();
+        if (endpoint is object) // same as !(endpoint is null)
+        {
+            return string.Equals(endpoint.DisplayName, "Health checks", StringComparison.Ordinal);
+        }
+
+        // No endpoint, so not a health check endpoint
+        return false;
+    }
+
+    public static LogEventLevel ExcludeHealthChecks(HttpContext ctx, double _, Exception ex) =>
+        ex != null
+            ? LogEventLevel.Error
+            : ctx.Response.StatusCode > 499
+                ? LogEventLevel.Error
+                : IsHealthCheckEndpoint(ctx) // Not an error, check if it was a health check
+                    ? LogEventLevel.Verbose // Was a health check, use Verbose
+                    : LogEventLevel.Information;
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogHelper.cs
@@ -25,7 +25,7 @@ public static class SerilogHelper
 
         // Retrieve the IEndpointFeature selected for the request
         var endpoint = httpContext.GetEndpoint();
-        if (endpoint is object) // endpoint != null
+        if (endpoint is not null)
         {
             diagnosticContext.Set("EndpointName", endpoint.DisplayName);
         }
@@ -33,7 +33,7 @@ public static class SerilogHelper
     private static bool IsHealthCheckEndpoint(HttpContext ctx)
     {
         var endpoint = ctx.GetEndpoint();
-        if (endpoint is object) // same as !(endpoint is null)
+        if (endpoint is not null)
         {
             return string.Equals(endpoint.DisplayName, "Health checks", StringComparison.Ordinal);
         }
@@ -42,7 +42,7 @@ public static class SerilogHelper
         return false;
     }
 
-    public static LogEventLevel ExcludeHealthChecks(HttpContext ctx, double _, Exception ex) =>
+    public static LogEventLevel ExcludeHealthChecks(HttpContext ctx, double _, Exception? ex) =>
         ex != null
             ? LogEventLevel.Error
             : ctx.Response.StatusCode > 499

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogOptions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogOptions.cs
@@ -1,0 +1,8 @@
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+public class SerilogOptions
+{
+    public Dictionary<string, LogLevel> LogLevel { get; set; } = new();
+    public bool Structured { get; set; } = false;
+    public bool SelfLogEnabled { get; set; } = false;
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/YcLevelEnricher.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/YcLevelEnricher.cs
@@ -1,0 +1,25 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+public class YcLevelEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("YcLevel", YcLogLevelConverter(logEvent.Level)));
+    }
+
+    //https://cloud.yandex.ru/docs/logging/concepts/filter#parameters -> level
+    private static string YcLogLevelConverter(LogEventLevel level) =>
+        level switch
+        {
+            LogEventLevel.Verbose => "TRACE",
+            LogEventLevel.Debug => "DEBUG",
+            LogEventLevel.Information => "INFO",
+            LogEventLevel.Warning => "WARN",
+            LogEventLevel.Error => "ERROR",
+            LogEventLevel.Fatal => "FATAL",
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level,  $@"Unknown {nameof(LogEventLevel)} kind: {level}")
+        };
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/YcLevelEnricher.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/YcLevelEnricher.cs
@@ -20,6 +20,6 @@ public class YcLevelEnricher : ILogEventEnricher
             LogEventLevel.Warning => "WARN",
             LogEventLevel.Error => "ERROR",
             LogEventLevel.Fatal => "FATAL",
-            _ => throw new ArgumentOutOfRangeException(nameof(level), level,  $@"Unknown {nameof(LogEventLevel)} kind: {level}")
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, $@"Unknown {nameof(LogEventLevel)} kind: {level}")
         };
 }

--- a/src/JoinRpg.Portal/JoinRpg.Portal.csproj
+++ b/src/JoinRpg.Portal/JoinRpg.Portal.csproj
@@ -34,10 +34,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.8" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="8.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/JoinRpg.Portal/Program.cs
+++ b/src/JoinRpg.Portal/Program.cs
@@ -1,16 +1,40 @@
 using Autofac.Extensions.DependencyInjection;
+using JoinRpg.Portal.Infrastructure.Logging;
+using Serilog;
 
 namespace JoinRpg.Portal;
 
 public class Program
 {
-    public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
+    public static void Main(string[] args)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .CreateBootstrapLogger(); //Will be reconfigured after host initialization
+
+        try
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+        catch (Exception e)
+        {
+            Log.Fatal(e, "Host terminated unexpectedly");
+            Environment.ExitCode = 1;
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
+    }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>
         Host
             .CreateDefaultBuilder(args)
             .UseServiceProviderFactory(new AutofacServiceProviderFactory())
-            .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
-            .ConfigureLogging(logging => logging.AddEventSourceLogger())
-        ;
+            .UseSerilog((context, _, configuration) =>
+            {
+                var loggerOptions = context.Configuration.GetSection("Logging").Get<SerilogOptions>();
+                configuration.ConfigureLogger(loggerOptions);
+            })
+            .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
 }

--- a/src/JoinRpg.Portal/Startup.cs
+++ b/src/JoinRpg.Portal/Startup.cs
@@ -192,6 +192,12 @@ public class Startup
               }
           });
 
+        _ = app.UseSerilogRequestLogging(opts =>
+        {
+            opts.EnrichDiagnosticContext = SerilogHelper.EnrichFromRequest;
+            opts.GetLevel = SerilogHelper.ExcludeHealthChecks;
+        });
+
         _ = app
             .UseSwagger(Swagger.Configure)
             .UseSwaggerUI(Swagger.ConfigureUI);
@@ -203,12 +209,6 @@ public class Startup
 
         _ = app.UseStaticFiles()
                .UseBlazorFrameworkFiles();
-
-        _ = app.UseSerilogRequestLogging(opts =>
-        {
-            opts.EnrichDiagnosticContext = SerilogHelper.EnrichFromRequest;
-            opts.GetLevel = SerilogHelper.ExcludeHealthChecks;
-        });
 
         _ = app.UseRouting();
 

--- a/src/JoinRpg.Portal/appsettings.Development.json
+++ b/src/JoinRpg.Portal/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Logging": {
+    "Structured": "False"
+  }
+}

--- a/src/JoinRpg.Portal/appsettings.json
+++ b/src/JoinRpg.Portal/appsettings.json
@@ -1,12 +1,13 @@
 {
   "Logging": {
+    "Structured": "True",
     "LogLevel": {
       "Default": "Information"
     }
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=(LocalDb)\\MSSQLLocalDB;Integrated Security=True;MultipleActiveResultSets=True;Initial Catalog=joinrpg",
-    "DataProtection": "Host=localhost;port=5432;database=aspnet-data-protection;username=postgres_user;password=qwerty" // Small DB used by ASP.net to share sessions between instances. 
+    "DataProtection": "Host=localhost;port=5432;database=aspnet-data-protection;username=postgres_user;password=qwerty" // Small DB used by ASP.net to share sessions between instances.
   },
   "AllowedHosts": "*",
   "PaymentProviders": {


### PR DESCRIPTION
Серилог в качестве основного логера. 2 режима  вывода - структурный(prod) и обычный (dev)

Дополнительно:

- По [туториалу](https://andrewlock.net/using-serilog-aspnetcore-in-asp-net-core-3-reducing-log-verbosity/)  добавлена  RequestLoggingMiddleware
- В настройках и выводе используются [стандартные уровни логирования](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel), а не уровни серилога
- Для структурного режима используется кастомный json форматер на основе [serilog.formatting.elasticsearch](https://www.nuget.org/packages/serilog.formatting.elasticsearch/). Важные стандартные поля выведены на верхний уровень из контейнейра `fields`
- Добавлено поле YcLevel с уровнями логирования совместимыми с Yandex Cloud Logging

Особенности:
 Не смотря на то, что конфигурация уровней логирования мимикрирует под стандартную из `Microsoft.Extensions.Logging`, работает она немного иначе:
В отличии от вышеназванного `Microsoft.Extensions.Logging`, настройка `Logging:LogLevel:Default` задаёт минимальный уровень логирования, настройки для нэймспейсов могут иметь только более подробный (больший) уровень. Так устроена настройка и переопределения уровней в Serilog
