### PR TITLE
New ProjectMetadata type

### DIFF
--- a/src/JoinRpg.Data.Interfaces/IProjectMetadataRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IProjectMetadataRepository.cs
@@ -1,0 +1,9 @@
+using JoinRpg.PrimitiveTypes;
+using JoinRpg.PrimitiveTypes.ProjectMetadata;
+
+namespace JoinRpg.Data.Interfaces;
+
+public interface IProjectMetadataRepository
+{
+    Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId);
+}

--- a/src/JoinRpg.Helpers/PerRequestCache.cs
+++ b/src/JoinRpg.Helpers/PerRequestCache.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+
+namespace JoinRpg.Helpers;
+
+public class PerRequestCache<TKey, TValue>
+    where TKey : notnull, IEquatable<TKey>
+    where TValue : class
+{
+    private readonly ConcurrentDictionary<TKey, TValue> cache = new();
+    public TValue? TryGet(TKey key)
+    {
+        if (cache.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public void Set(TKey key, TValue value)
+    {
+        _ = cache.TryAdd(key, value);
+    }
+
+
+}

--- a/src/JoinRpg.Helpers/SingletonCache.cs
+++ b/src/JoinRpg.Helpers/SingletonCache.cs
@@ -1,0 +1,13 @@
+using System.Collections.Concurrent;
+
+namespace JoinRpg.Helpers;
+
+public class SingletonCache<TKey, TValue>
+    where TKey : notnull, IEquatable<TKey>
+    where TValue : class
+{
+    private readonly ConcurrentDictionary<TKey, TValue> cache = new();
+    public TValue? TryGet(TKey key) => cache.TryGetValue(key, out var value) ? value : null;
+
+    public void Set(TKey key, TValue value) => _ = cache.TryAdd(key, value);
+}

--- a/src/JoinRpg.Portal/JoinRpgPortalModule.cs
+++ b/src/JoinRpg.Portal/JoinRpgPortalModule.cs
@@ -1,10 +1,13 @@
 using Autofac;
 using BitArmory.ReCaptcha;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Helpers;
 using JoinRpg.Portal.Identity;
 using JoinRpg.Portal.Infrastructure;
 using JoinRpg.Portal.Infrastructure.Authentication;
 using JoinRpg.Portal.Infrastructure.Authentication.Avatars;
 using JoinRpg.Web.Helpers;
+using JoinRpg.WebPortal.Managers;
 using Microsoft.AspNetCore.Authorization;
 using CurrentProjectAccessor = JoinRpg.Portal.Infrastructure.CurrentProjectAccessor;
 
@@ -30,6 +33,11 @@ internal class JoinRpgPortalModule : Module
         builder.RegisterType<AvatarLoader>().AsImplementedInterfaces();
         builder.RegisterDecorator<AvatarCacheDecoractor, IAvatarLoader>();
         builder.RegisterType<AvatarCacheDecoractor>().AsSelf();
+
+        builder.RegisterGeneric(typeof(PerRequestCache<,>)).AsSelf().InstancePerLifetimeScope();
+        builder.RegisterGeneric(typeof(SingletonCache<,>)).AsSelf().SingleInstance();
+
+        builder.RegisterDecorator<ProjectMetadataRepositoryCacheDecorator, IProjectMetadataRepository>();
 
         builder.RegisterAssemblyTypes(typeof(JoinRpgPortalModule).Assembly)
             .Where(type => typeof(IAuthorizationHandler).IsAssignableFrom(type)).As<IAuthorizationHandler>();

--- a/src/JoinRpg.PrimitiveTypes/ProjectFieldVariantIdentification.cs
+++ b/src/JoinRpg.PrimitiveTypes/ProjectFieldVariantIdentification.cs
@@ -1,0 +1,14 @@
+namespace JoinRpg.PrimitiveTypes;
+
+public record ProjectFieldVariantIdentification(ProjectFieldIdentification FieldId, int ProjectFieldVariantId)
+{
+    public static ProjectFieldVariantIdentification? FromOptional(ProjectFieldIdentification? fieldId, int? projectFieldVariantId)
+    {
+        return (fieldId, projectFieldVariantId) switch
+        {
+            (_, null) => null,
+            (null, _) => null,
+            _ => new(fieldId, projectFieldVariantId.Value)
+        };
+    }
+}

--- a/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldInfo.cs
+++ b/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldInfo.cs
@@ -1,0 +1,105 @@
+using JoinRpg.DataModel;
+using JoinRpg.Domain;
+using JoinRpg.Helpers;
+
+namespace JoinRpg.PrimitiveTypes.ProjectMetadata;
+public record class ProjectFieldInfo(
+    ProjectFieldIdentification Id,
+    string Name,
+    ProjectFieldType Type,
+    FieldBoundTo BoundTo,
+    IReadOnlyCollection<ProjectFieldVariant> Variants,
+    string Ordering,
+    int Price,
+    bool CanPlayerEdit,
+    bool ShowOnUnApprovedClaims,
+    bool IsPublic,
+    bool CanPlayerView,
+    MandatoryStatus MandatoryStatus,
+    bool ValidForNpc,
+    bool IsActive,
+    IReadOnlyCollection<int> GroupsAvailableForIds,
+    MarkdownString Description,
+    MarkdownString MasterDescription,
+    bool IncludeInPrint,
+    ProjectFieldSettings FieldSettings,
+    string? ProgrammaticValue)
+    : IOrderableEntity
+{
+    private const string CheckboxValueOn = "on";
+
+    private readonly Lazy<VirtualOrderContainer<ProjectFieldVariant>> container
+        = VirtualOrderContainerFacade.CreateLazy(Variants, Ordering);
+
+    public IReadOnlyList<ProjectFieldVariant> SortedVariants => container.Value.OrderedItems;
+
+    public string GetDisplayValue(string? value, IReadOnlyList<int>? selectedIDs)
+    {
+        if (Type == ProjectFieldType.Checkbox)
+        {
+            return value?.StartsWith(CheckboxValueOn) == true ? "☑️" : "☐";
+        }
+
+        if (HasValueList)
+        {
+            return Variants.Where(dv => selectedIDs!.Contains(dv.Id.ProjectFieldVariantId))
+                    .Select(dv => dv.Label)
+                    .JoinStrings(", ");
+        }
+
+        return value ?? "";
+    }
+
+    public bool HasValueList => Type.HasValuesList();
+    public bool SupportsMassAdding => Type.SupportsMassAdding();
+    public bool SupportsMarkdown => Type == ProjectFieldType.Text;
+    public bool HasSpecialGroup => HasValueList && BoundTo == FieldBoundTo.Character;
+
+    public bool CanHaveValue => Type != ProjectFieldType.Header;
+
+    public bool SupportsPricing => Type.SupportsPricing();
+
+    public bool SupportsPricingOnField => Type.SupportsPricingOnField();
+
+    public bool HasPrice => SupportsPricing &&
+               ((SupportsPricingOnField && Price != 0)
+                || (!SupportsPricingOnField &&
+                    Variants.Any(v => v.Price != 0)));
+
+    public bool IsName { get; } = FieldSettings.NameField == Id;
+
+    public bool IsDescription { get; } = FieldSettings.DescriptionField == Id;
+
+    public IEnumerable<ProjectFieldVariant> GetPossibleVariants(
+        AccessArguments accessArguments,
+        IReadOnlyCollection<int> selectedIds)
+        => Variants.Where(v =>
+            selectedIds.Contains(v.Id.ProjectFieldVariantId) ||
+            (v.IsActive && (v.IsPlayerSelectable || accessArguments.MasterAccess))
+            );
+
+    int IOrderableEntity.Id => Id.ProjectFieldId;
+
+    public bool HasEditAccess(AccessArguments accessArguments)
+    {
+        return accessArguments.MasterAccess
+               ||
+               (accessArguments.PlayerAccessToCharacter && CanPlayerEdit &&
+                BoundTo == FieldBoundTo.Character)
+               ||
+               (accessArguments.PlayerAccesToClaim && CanPlayerEdit &&
+               (ShowOnUnApprovedClaims || accessArguments.PlayerAccessToCharacter));
+    }
+
+    public bool HasViewAccess(AccessArguments accessArguments)
+    {
+        return IsPublic
+          || accessArguments.MasterAccess
+          ||
+          (accessArguments.PlayerAccessToCharacter && CanPlayerView &&
+           BoundTo == FieldBoundTo.Character)
+          ||
+          (accessArguments.PlayerAccesToClaim && CanPlayerView &&
+           BoundTo == FieldBoundTo.Claim);
+    }
+}

--- a/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldSettings.cs
+++ b/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldSettings.cs
@@ -1,0 +1,7 @@
+namespace JoinRpg.PrimitiveTypes.ProjectMetadata;
+
+public record class ProjectFieldSettings(
+    ProjectFieldIdentification? NameField,
+    ProjectFieldIdentification? DescriptionField)
+{
+}

--- a/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldVariant.cs
+++ b/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectFieldVariant.cs
@@ -1,0 +1,19 @@
+using JoinRpg.DataModel;
+using JoinRpg.Helpers;
+
+namespace JoinRpg.PrimitiveTypes.ProjectMetadata;
+
+public record class ProjectFieldVariant(
+    ProjectFieldVariantIdentification Id,
+    string Label,
+    int Price,
+    bool IsPlayerSelectable,
+    bool IsActive,
+    int? CharacterGroupId,
+    MarkdownString Description,
+    MarkdownString MasterDescription,
+    string? ProgrammaticValue
+    ) : IOrderableEntity
+{
+    int IOrderableEntity.Id => Id.ProjectFieldVariantId;
+}

--- a/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectInfo.cs
+++ b/src/JoinRpg.PrimitiveTypes/ProjectMetadata/ProjectInfo.cs
@@ -1,0 +1,51 @@
+using JoinRpg.Helpers;
+
+namespace JoinRpg.PrimitiveTypes.ProjectMetadata;
+public record class ProjectInfo
+{
+    private readonly Lazy<VirtualOrderContainer<ProjectFieldInfo>> container;
+
+    public IReadOnlyList<ProjectFieldInfo> SortedFields => container.Value.OrderedItems;
+
+    public ProjectIdentification ProjectId { get; }
+    public string ProjectName { get; }
+    public IReadOnlyCollection<ProjectFieldInfo> UnsortedFields { get; }
+    public ProjectFieldInfo? CharacterNameField { get; }
+    public ProjectFieldInfo? CharacterDescriptionField { get; }
+
+    public ProjectFieldSettings ProjectFieldSettings { get; }
+
+    public ProjectInfo(
+        ProjectIdentification projectId,
+        string projectName,
+        string ordering,
+        IReadOnlyCollection<ProjectFieldInfo> fields,
+        ProjectFieldSettings projectFieldSettings
+        )
+    {
+        UnsortedFields = fields;
+        ProjectId = projectId;
+        ProjectName = projectName;
+        container = VirtualOrderContainerFacade.CreateLazy(fields, ordering);
+        ProjectFieldSettings = projectFieldSettings;
+
+        if (projectFieldSettings.NameField is ProjectFieldIdentification nameField)
+        {
+            CharacterNameField = GetFieldById(nameField);
+        }
+
+        if (projectFieldSettings.DescriptionField is ProjectFieldIdentification descriptionField)
+        {
+            CharacterDescriptionField = GetFieldById(descriptionField);
+        }
+    }
+
+    public ProjectFieldInfo GetFieldById(ProjectFieldIdentification id)
+    {
+        if (id.ProjectId != ProjectId)
+        {
+            throw new InvalidOperationException();
+        }
+        return UnsortedFields.Single(f => f.Id.ProjectFieldId == id.ProjectFieldId);
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/ProjectMetadataRepositoryCacheDecorator.cs
+++ b/src/JoinRpg.WebPortal.Managers/ProjectMetadataRepositoryCacheDecorator.cs
@@ -1,0 +1,28 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Helpers;
+using JoinRpg.PrimitiveTypes;
+using JoinRpg.PrimitiveTypes.ProjectMetadata;
+
+namespace JoinRpg.WebPortal.Managers;
+public class ProjectMetadataRepositoryCacheDecorator : IProjectMetadataRepository
+{
+    private readonly IProjectMetadataRepository repository;
+    private readonly PerRequestCache<ProjectIdentification, ProjectInfo> cache;
+
+    public ProjectMetadataRepositoryCacheDecorator(IProjectMetadataRepository repository, PerRequestCache<ProjectIdentification, ProjectInfo> cache)
+    {
+        this.repository = repository;
+        this.cache = cache;
+    }
+
+    public async Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId)
+    {
+        var projectInfo = cache.TryGet(projectId);
+        if (projectInfo == null)
+        {
+            projectInfo = await repository.GetProjectMetadata(projectId);
+            cache.Set(projectId, projectInfo);
+        }
+        return projectInfo;
+    }
+}


### PR DESCRIPTION
Идея в том, чтобы создать некий доменный иммутабельный тип с данными по проекту, которые нужны почти всегда.
Он отвязан от EF и не имеет зависимостей на перситенс. Плюсы:
 - можно избегаем того, что с каждым объектом тянется ссылка на проект, и от него запрашивается для каждого объекта определенный набор данных с шансом на LazyLoad.
 - кешируем сортировку полей (при загрузке 1000 персонажей это повторялось для каждого персонажа).
 - отвязываемся от перситенса в использовании полей

Пока что это нигде не используется (только в одном месте).

Планы:
 - Перенести сохранение полей на использование этого кода
 - Добавить туда информацию по финансам
 - Начать делать доменные объекты для персонажей (после того, как удалим заявки в группу)