### PR TITLE
Добавлены traceId, spanId и Activity.Tags в логи

### DIFF
--- a/src/JoinRpg.Portal/Infrastructure/DailyJobs/BackgroundServiceActivity.cs
+++ b/src/JoinRpg.Portal/Infrastructure/DailyJobs/BackgroundServiceActivity.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+namespace JoinRpg.Portal.Infrastructure.DailyJobs;
+
+public static class BackgroundServiceActivity
+{
+    public const string ActivitySourceName = "BackgroundJobService";
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+}

--- a/src/JoinRpg.Portal/Infrastructure/DailyJobs/MidnightJobBackgroundService.cs
+++ b/src/JoinRpg.Portal/Infrastructure/DailyJobs/MidnightJobBackgroundService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using JoinRpg.Data.Write.Interfaces;
 using JoinRpg.Interfaces;
 using Microsoft.Extensions.Options;
@@ -14,7 +13,6 @@ public class MidnightJobBackgroundService<TJob>(
 {
     private static readonly string JobName = typeof(TJob).FullName!;
     private bool skipWait = options.Value.DebugDailyJobMode;
-    private static ActivitySource activitySource = new ActivitySource(nameof(JoinRpg.Portal.Infrastructure.DailyJobs.MidnightJobBackgroundService<TJob>));
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -25,7 +23,8 @@ public class MidnightJobBackgroundService<TJob>(
             stoppingToken.ThrowIfCancellationRequested();
 
             using var scope = serviceProvider.CreateScope();
-            using var activity = activitySource.StartActivity($"Run of {JobName}");
+            using var activity = BackgroundServiceActivity.ActivitySource.StartActivity($"Run of {JobName}");
+            activity?.AddTag("jobName", JobName);
             var dailyJobRepository = scope.ServiceProvider.GetRequiredService<IDailyJobRepository>();
 
             var jobId = new JobId(JobName, DateOnly.FromDateTime(DateTime.Now));

--- a/src/JoinRpg.Portal/Infrastructure/Logging/ActivityTagEnricher.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/ActivityTagEnricher.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace JoinRpg.Portal.Infrastructure.Logging;
+
+public class ActivityTagsEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var activity = Activity.Current;
+
+        if (activity is null)
+        {
+            return;
+        }
+
+        foreach (var item in activity.Tags)
+        {
+            logEvent.AddOrUpdateProperty(new LogEventProperty(item.Key, new ScalarValue(item.Value)));
+        }
+    }
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/CustomJsonFormatter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/CustomJsonFormatter.cs
@@ -1,9 +1,8 @@
 using Serilog.Events;
 using Serilog.Extensions.Logging;
-using Serilog.Formatting.Elasticsearch;
 using Serilog.Parsing;
 
-namespace JoinRpg.Portal.Infrastructure.Logging;
+namespace JoinRpg.Portal.Infrastructure.Logging.Formatting;
 
 internal class CustomJsonFormatter : ElasticsearchJsonFormatter
 {
@@ -18,7 +17,7 @@ internal class CustomJsonFormatter : ElasticsearchJsonFormatter
 
     protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
     {
-        WriteJsonProperty("@timestamp", (object)timestamp.ToUniversalTime().ToString(DateTimeFormat), ref delim, output);
+        WriteJsonProperty("@timestamp", timestamp.ToUniversalTime().ToString(DateTimeFormat), ref delim, output);
     }
 
     protected override void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/DefaultJsonFormatter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/DefaultJsonFormatter.cs
@@ -1,0 +1,415 @@
+// Copyright 2013-2016 Serilog Contributors
+// Adapted from https://github.com/serilog-contrib/serilog-sinks-elasticsearch/blob/1e9777c3034c2d8d078f60822c77b9caad5b7870/src/Serilog.Formatting.Elasticsearch/DefaultJsonFormatter.cs#L1
+
+using System.Collections;
+using System.Globalization;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+
+namespace JoinRpg.Portal.Infrastructure.Logging.Formatting;
+
+/// <summary>
+/// Formats log events in a simple JSON structure. Instances of this class
+/// are safe for concurrent access by multiple threads.
+/// </summary>
+/// <remarks>Migrated from the original Serilog.Formatting.Json.JsonFormatter implementation.</remarks>
+public abstract class DefaultJsonFormatter : ITextFormatter
+{
+    readonly bool _omitEnclosingObject;
+    readonly string _closingDelimiter;
+    readonly bool _renderMessage;
+    readonly bool _renderMessageTemplate;
+    readonly IFormatProvider _formatProvider;
+    readonly IDictionary<Type, Action<object, bool, TextWriter>> _literalWriters;
+
+    /// <summary>
+    /// Construct a <see cref="DefaultJsonFormatter"/>.
+    /// </summary>
+    /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
+    /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
+    /// JSON object.</param>
+    /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
+    /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
+    /// is true.</param>
+    /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
+    /// property named RenderedMessage.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <param name="renderMessageTemplate">If true, the message template will be rendered and written to the output as a
+    /// property named RenderedMessageTemplate.</param>
+    protected DefaultJsonFormatter(
+        bool omitEnclosingObject = false,
+        string closingDelimiter = null,
+        bool renderMessage = true,
+        IFormatProvider formatProvider = null,
+        bool renderMessageTemplate = true)
+    {
+        _omitEnclosingObject = omitEnclosingObject;
+        _closingDelimiter = closingDelimiter ?? Environment.NewLine;
+        _renderMessage = renderMessage;
+        _renderMessageTemplate = renderMessageTemplate;
+        _formatProvider = formatProvider;
+
+        _literalWriters = new Dictionary<Type, Action<object, bool, TextWriter>>
+        {
+            { typeof(bool), (v, q, w) => WriteBoolean((bool)v, w) },
+            { typeof(char), (v, q, w) => WriteString(((char)v).ToString(), w) },
+            { typeof(byte), WriteToString },
+            { typeof(sbyte), WriteToString },
+            { typeof(short), WriteToString },
+            { typeof(ushort), WriteToString },
+            { typeof(int), WriteToString },
+            { typeof(uint), WriteToString },
+            { typeof(long), WriteToString },
+            { typeof(ulong), WriteToString },
+            { typeof(float), (v, q, w) => WriteSingle((float)v, w) },
+            { typeof(double), (v, q, w) => WriteDouble((double)v, w) },
+            { typeof(decimal), WriteToString },
+            { typeof(string), (v, q, w) => WriteString((string)v, w) },
+            { typeof(DateTime), (v, q, w) => WriteDateTime((DateTime)v, w) },
+            { typeof(DateTimeOffset), (v, q, w) => WriteOffset((DateTimeOffset)v, w) },
+            { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w, q) },
+            { typeof(SequenceValue), (v, q, w) => WriteSequence(((SequenceValue)v).Elements, w) },
+            { typeof(DictionaryValue), (v, q, w) => WriteDictionary(((DictionaryValue)v).Elements, w) },
+            { typeof(StructureValue), (v, q, w) => WriteStructure(((StructureValue)v).TypeTag, ((StructureValue)v).Properties, w) },
+        };
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+        if (output == null) throw new ArgumentNullException(nameof(output));
+
+        if (!_omitEnclosingObject)
+            output.Write("{");
+
+        var delim = "";
+        WriteTimestamp(logEvent.Timestamp, ref delim, output);
+        WriteLevel(logEvent.Level, ref delim, output);
+
+        if (_renderMessageTemplate)
+        {
+            WriteMessageTemplate(logEvent.MessageTemplate.Text, ref delim, output);
+        }
+
+        if (_renderMessage)
+        {
+            var message = logEvent.RenderMessage(_formatProvider);
+            WriteRenderedMessage(message, ref delim, output);
+        }
+
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
+        }
+
+        if (logEvent.Exception != null)
+            WriteException(logEvent.Exception, ref delim, output);
+
+        if (logEvent.Properties.Count != 0)
+            WriteProperties(logEvent.Properties, output);
+
+        var tokensWithFormat = logEvent.MessageTemplate.Tokens
+            .OfType<PropertyToken>()
+            .Where(pt => pt.Format != null)
+            .GroupBy(pt => pt.PropertyName)
+            .ToArray();
+
+        if (tokensWithFormat.Length != 0)
+        {
+            WriteRenderings(tokensWithFormat, logEvent.Properties, output);
+        }
+
+        if (!_omitEnclosingObject)
+        {
+            output.Write("}");
+            output.Write(_closingDelimiter);
+        }
+    }
+
+    /// <summary>
+    /// Adds a writer function for a given type.
+    /// </summary>
+    /// <param name="type">The type of values, which <paramref name="writer" /> handles.</param>
+    /// <param name="writer">The function, which writes the values.</param>
+    protected void AddLiteralWriter(Type type, Action<object, TextWriter> writer)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        if (writer == null) throw new ArgumentNullException(nameof(writer));
+
+        _literalWriters[type] = (v, _, w) => writer(v, w);
+    }
+
+    /// <summary>
+    /// Writes out individual renderings of attached properties
+    /// </summary>
+    protected virtual void WriteRenderings(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        output.Write(",\"{0}\":{{", "Renderings");
+        WriteRenderingsValues(tokensWithFormat, properties, output);
+        output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out the values of individual renderings of attached properties
+    /// </summary>
+    protected virtual void WriteRenderingsValues(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        var rdelim = "";
+        foreach (var ptoken in tokensWithFormat)
+        {
+            output.Write(rdelim);
+            rdelim = ",";
+            output.Write("\"");
+            output.Write(ptoken.Key);
+            output.Write("\":[");
+
+            var fdelim = "";
+            foreach (var format in ptoken)
+            {
+                output.Write(fdelim);
+                fdelim = ",";
+
+                output.Write("{");
+                var eldelim = "";
+
+                WriteJsonProperty("Format", format.Format, ref eldelim, output);
+
+                var sw = new StringWriter();
+                format.Render(properties, sw);
+                WriteJsonProperty("Rendering", sw.ToString(), ref eldelim, output);
+
+                output.Write("}");
+            }
+
+            output.Write("]");
+        }
+    }
+
+    /// <summary>
+    /// Writes out the attached properties
+    /// </summary>
+    protected virtual void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        output.Write(",\"{0}\":{{", "Properties");
+        WritePropertiesValues(properties, output);
+        output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out the attached properties values
+    /// </summary>
+    protected virtual void WritePropertiesValues(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        var precedingDelimiter = "";
+        foreach (var property in properties)
+        {
+            WriteJsonProperty(property.Key, property.Value, ref precedingDelimiter, output);
+        }
+    }
+
+    /// <summary>
+    /// Writes out the attached exception
+    /// </summary>
+    protected virtual void WriteException(Exception exception, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("Exception", exception, ref delim, output);
+    }
+
+    /// <summary>
+    /// (Optionally) writes out the rendered message
+    /// </summary>
+    protected virtual void WriteRenderedMessage(string message, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("RenderedMessage", message, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the message template for the logevent.
+    /// </summary>
+    protected virtual void WriteMessageTemplate(string template, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("MessageTemplate", template, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the log level
+    /// </summary>
+    protected virtual void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("Level", level, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the log timestamp
+    /// </summary>
+    protected virtual void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty("Timestamp", timestamp, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out a structure property
+    /// </summary>
+    protected virtual void WriteStructure(string typeTag, IEnumerable<LogEventProperty> properties, TextWriter output)
+    {
+        output.Write("{");
+
+        var delim = "";
+        if (typeTag != null)
+            WriteJsonProperty("_typeTag", typeTag, ref delim, output);
+
+        foreach (var property in properties)
+            WriteJsonProperty(property.Name, property.Value, ref delim, output);
+
+        output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out a sequence property
+    /// </summary>
+    protected virtual void WriteSequence(IEnumerable elements, TextWriter output)
+    {
+        output.Write("[");
+        var delim = "";
+        foreach (var value in elements)
+        {
+            output.Write(delim);
+            delim = ",";
+            WriteLiteral(value, output);
+        }
+        output.Write("]");
+    }
+
+    /// <summary>
+    /// Writes out a dictionary
+    /// </summary>
+    protected virtual void WriteDictionary(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
+    {
+        output.Write("{");
+        var delim = "";
+        foreach (var e in elements)
+        {
+            output.Write(delim);
+            delim = ",";
+            WriteLiteral(e.Key, output, true);
+            output.Write(":");
+            WriteLiteral(e.Value, output);
+        }
+        output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out a json property with the specified value on output writer
+    /// </summary>
+    protected virtual void WriteJsonProperty(string name, object value, ref string precedingDelimiter, TextWriter output)
+    {
+        output.Write(precedingDelimiter);
+        output.Write("\"");
+        output.Write(name);
+        output.Write("\":");
+        WriteLiteral(value, output);
+        precedingDelimiter = ",";
+    }
+
+    /// <summary>
+    /// Writes out a json property with an array as the value
+    /// </summary>
+    protected virtual void WriteJsonArrayProperty(string name, IEnumerable sequence, ref string precedingDelimiter, TextWriter output)
+    {
+        output.Write(precedingDelimiter);
+        output.Write("\"");
+        output.Write(name);
+        output.Write("\":");
+        WriteSequence(sequence, output);
+        precedingDelimiter = ",";
+    }
+
+    /// <summary>
+    /// Allows a subclass to write out objects that have no configured literal writer.
+    /// </summary>
+    /// <param name="value">The value to be written as a json construct</param>
+    /// <param name="output">The writer to write on</param>
+    protected virtual void WriteLiteralValue(object value, TextWriter output)
+    {
+        WriteString(value.ToString(), output);
+    }
+
+    void WriteLiteral(object value, TextWriter output, bool forceQuotation = false)
+    {
+        if (value == null)
+        {
+            output.Write("null");
+            return;
+        }
+
+        Action<object, bool, TextWriter> writer;
+        if (_literalWriters.TryGetValue(value.GetType(), out writer))
+        {
+            writer(value, forceQuotation, output);
+            return;
+        }
+
+        WriteLiteralValue(value, output);
+    }
+
+    static void WriteToString(object number, bool quote, TextWriter output)
+    {
+        if (quote) output.Write('"');
+
+        var fmt = number as IFormattable;
+        if (fmt != null)
+            output.Write(fmt.ToString(null, CultureInfo.InvariantCulture));
+        else
+            output.Write(number.ToString());
+
+        if (quote) output.Write('"');
+    }
+
+    static void WriteBoolean(bool value, TextWriter output)
+    {
+        output.Write(value ? "true" : "false");
+    }
+
+    static void WriteSingle(float value, TextWriter output)
+    {
+        output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    static void WriteDouble(double value, TextWriter output)
+    {
+        output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    static void WriteOffset(DateTimeOffset value, TextWriter output)
+    {
+        output.Write("\"");
+        output.Write(value.ToString("o"));
+        output.Write("\"");
+    }
+
+    static void WriteDateTime(DateTime value, TextWriter output)
+    {
+        output.Write("\"");
+        output.Write(value.ToString("o"));
+        output.Write("\"");
+    }
+
+    static void WriteString(string value, TextWriter output)
+    {
+        JsonValueFormatter.WriteQuotedJsonString(value, output);
+    }
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/ElasticsearchJsonFormatter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/Formatting/ElasticsearchJsonFormatter.cs
@@ -1,0 +1,271 @@
+// Copyright 2014 Serilog Contributors
+// 
+// Adapted from https://github.com/serilog-contrib/serilog-sinks-elasticsearch/blob/1e9777c3034c2d8d078f60822c77b9caad5b7870/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
+
+using System.Globalization;
+using System.Reflection;
+#if !NO_SERIALIZATION
+using System.Runtime.Serialization;
+
+#endif
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace JoinRpg.Portal.Infrastructure.Logging.Formatting;
+
+/// <summary>
+/// Custom Json formatter that respects the configured property name handling and forces 'Timestamp' to @timestamp
+/// </summary>
+public class ElasticsearchJsonFormatter : DefaultJsonFormatter
+{
+    readonly bool _inlineFields;
+    readonly bool _formatStackTraceAsArray;
+
+    /// <summary>
+    /// Render message property name
+    /// </summary>
+    public const string RenderedMessagePropertyName = "message";
+    /// <summary>
+    /// Message template property name
+    /// </summary>
+    public const string MessageTemplatePropertyName = "messageTemplate";
+    /// <summary>
+    /// Exception property name
+    /// </summary>
+    public const string ExceptionPropertyName = "Exception";
+    /// <summary>
+    /// Level property name
+    /// </summary>
+    public const string LevelPropertyName = "level";
+    /// <summary>
+    /// Timestamp property name
+    /// </summary>
+    public const string TimestampPropertyName = "@timestamp";
+
+    /// <summary>
+    /// Construct a <see cref="ElasticsearchJsonFormatter"/>.
+    /// </summary>
+    /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
+    /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
+    /// JSON object.</param>
+    /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
+    /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
+    /// is true.</param>
+    /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
+    /// property named RenderedMessage.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <param name="serializer">Inject a serializer to force objects to be serialized over being ToString()</param>
+    /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
+    /// <param name="renderMessageTemplate">If true, the message template will be rendered and written to the output as a
+    /// property named RenderedMessageTemplate.</param>
+    /// <param name="formatStackTraceAsArray">If true, splits the StackTrace by new line and writes it as a an array of strings</param>
+    public ElasticsearchJsonFormatter(
+        bool omitEnclosingObject = false,
+        string closingDelimiter = null,
+        bool renderMessage = true,
+        IFormatProvider formatProvider = null,
+        bool inlineFields = false,
+        bool renderMessageTemplate = true,
+        bool formatStackTraceAsArray = false)
+        : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider, renderMessageTemplate)
+    {
+        _inlineFields = inlineFields;
+        _formatStackTraceAsArray = formatStackTraceAsArray;
+    }
+
+    /// <summary>
+    /// Writes out individual renderings of attached properties
+    /// </summary>
+    protected override void WriteRenderings(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        output.Write(",\"{0}\":{{", "renderings");
+        WriteRenderingsValues(tokensWithFormat, properties, output);
+        output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out the attached properties
+    /// </summary>
+    protected override void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    {
+        if (!_inlineFields)
+            output.Write(",\"{0}\":{{", "fields");
+        else
+            output.Write(",");
+
+        WritePropertiesValues(properties, output);
+
+        if (!_inlineFields)
+            output.Write("}");
+    }
+
+    /// <summary>
+    /// Writes out the attached exception
+    /// </summary>
+    protected override void WriteException(Exception exception, ref string delim, TextWriter output)
+    {
+        output.Write(delim);
+        output.Write("\"");
+        output.Write("exceptions");
+        output.Write("\":[");
+
+        delim = "";
+        WriteExceptionSerializationInfo(exception, ref delim, output, depth: 0);
+        output.Write("]");
+    }
+
+    private void WriteExceptionSerializationInfo(Exception exception, ref string delim, TextWriter output, int depth)
+    {
+        while (true)
+        {
+            output.Write(delim);
+            output.Write("{");
+            delim = "";
+            WriteSingleException(exception, ref delim, output, depth);
+            output.Write("}");
+
+            delim = ",";
+            if (exception.InnerException != null && depth < 20)
+            {
+                exception = exception.InnerException;
+                depth = ++depth;
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    /// <summary>
+    /// Writes the properties of a single exception, without inner exceptions
+    /// Callers are expected to open and close the json object themselves.
+    /// </summary>
+    /// <param name="exception"></param>
+    /// <param name="delim"></param>
+    /// <param name="output"></param>
+    /// <param name="depth"></param>
+    protected void WriteSingleException(Exception exception, ref string delim, TextWriter output, int depth)
+    {
+#if NO_SERIALIZATION
+        var helpUrl = exception.HelpLink;
+        var stackTrace = exception.StackTrace;
+        var remoteStackTrace = string.Empty;
+        var remoteStackIndex = -1;
+        var exceptionMethod = string.Empty;
+        var hresult = exception.HResult;
+        var source = exception.Source;
+        var className = string.Empty;
+
+#else
+        var si = new SerializationInfo(exception.GetType(), new FormatterConverter());
+        var sc = new StreamingContext();
+        exception.GetObjectData(si, sc);
+
+        var helpUrl = si.GetString("HelpURL");
+        var stackTrace = si.GetString("StackTraceString");
+        var remoteStackTrace = si.GetString("RemoteStackTraceString");
+        var remoteStackIndex = si.GetInt32("RemoteStackIndex");
+        var exceptionMethod = si.GetString("ExceptionMethod");
+        var hresult = si.GetInt32("HResult");
+        var source = si.GetString("Source");
+        var className = si.GetString("ClassName");
+#endif
+
+        //TODO Loop over ISerializable data
+
+
+        WriteJsonProperty("Depth", depth, ref delim, output);
+        WriteJsonProperty("ClassName", className, ref delim, output);
+        WriteJsonProperty("Message", exception.Message, ref delim, output);
+        WriteJsonProperty("Source", source, ref delim, output);
+        if (_formatStackTraceAsArray)
+        {
+            WriteMultilineString("StackTrace", stackTrace, ref delim, output);
+            WriteMultilineString("RemoteStackTrace", stackTrace, ref delim, output);
+        }
+        else
+        {
+            WriteJsonProperty("StackTraceString", stackTrace, ref delim, output);
+            WriteJsonProperty("RemoteStackTraceString", remoteStackTrace, ref delim, output);
+        }
+        WriteJsonProperty("RemoteStackIndex", remoteStackIndex, ref delim, output);
+        WriteStructuredExceptionMethod(exceptionMethod, ref delim, output);
+        WriteJsonProperty("HResult", hresult, ref delim, output);
+        WriteJsonProperty("HelpURL", helpUrl, ref delim, output);
+
+        //writing byte[] will fall back to serializer and they differ in output 
+        //JsonNET assumes string, simplejson writes array of numerics.
+        //Skip for now
+        //this.WriteJsonProperty("WatsonBuckets", watsonBuckets, ref delim, output);
+    }
+
+    private void WriteMultilineString(string name, string value, ref string delimeter, TextWriter output)
+    {
+        var lines = value?.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries) ?? new string[] { };
+        WriteJsonArrayProperty(name, lines, ref delimeter, output);
+    }
+
+    private void WriteStructuredExceptionMethod(string exceptionMethodString, ref string delim, TextWriter output)
+    {
+        if (string.IsNullOrWhiteSpace(exceptionMethodString)) return;
+
+        var args = exceptionMethodString.Split('\0', '\n');
+
+        if (args.Length != 5) return;
+
+        var memberType = int.Parse(args[0], CultureInfo.InvariantCulture);
+        var name = args[1];
+        var assemblyName = args[2];
+        var className = args[3];
+        var signature = args[4];
+        var an = new AssemblyName(assemblyName);
+        output.Write(delim);
+        output.Write("\"");
+        output.Write("ExceptionMethod");
+        output.Write("\":{");
+        delim = "";
+        WriteJsonProperty("Name", name, ref delim, output);
+        WriteJsonProperty("AssemblyName", an.Name, ref delim, output);
+        WriteJsonProperty("AssemblyVersion", an.Version.ToString(), ref delim, output);
+        WriteJsonProperty("AssemblyCulture", an.CultureName, ref delim, output);
+        WriteJsonProperty("ClassName", className, ref delim, output);
+        WriteJsonProperty("Signature", signature, ref delim, output);
+        WriteJsonProperty("MemberType", memberType, ref delim, output);
+
+        output.Write("}");
+        delim = ",";
+    }
+
+    /// <summary>
+    /// (Optionally) writes out the rendered message
+    /// </summary>
+    protected override void WriteRenderedMessage(string message, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty(RenderedMessagePropertyName, message, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the message template for the logevent.
+    /// </summary>
+    protected override void WriteMessageTemplate(string template, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty(MessageTemplatePropertyName, template, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the log level
+    /// </summary>
+    protected override void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)
+    {
+        var stringLevel = Enum.GetName(typeof(LogEventLevel), level);
+        WriteJsonProperty(LevelPropertyName, stringLevel, ref delim, output);
+    }
+
+    /// <summary>
+    /// Writes out the log timestamp
+    /// </summary>
+    protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
+    {
+        WriteJsonProperty(TimestampPropertyName, timestamp, ref delim, output);
+    }
+}

--- a/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Logging/SerilogExtensions.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Portal.Infrastructure.Logging.Formatting;
 using Serilog;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -23,6 +24,7 @@ public static class SerilogExtensions
             .Enrich.WithMachineName()
             .Enrich.With<YcLevelEnricher>()
             .Enrich.With<LoggedUserEnricher>()
+            .Enrich.With<ActivityTagsEnricher>()
             .Enrich.WithProperty("AppName", "JoinRpg.Portal");
 
         foreach (var (@namespace, logLevel) in serilogOptions.LogLevel)
@@ -42,7 +44,7 @@ public static class SerilogExtensions
                 "Host", "Protocol", "Scheme", "ResponseContentType", "RequestMethod", "RequestPath",
                 "StatusCode", "Elapsed", "SourceContext", "RequestId", "ConnectionId", "EndpointName",
                 "RouteData", "ActionName", "ActionId", "ValidationState", "RazorPageHandler", "YcLevel",
-                "QueryString", "ViewComponentName", "ViewComponentId", "LoggedUser", "ProjectId",
+                "QueryString", "ViewComponentName", "ViewComponentId", "LoggedUser", "ProjectId", "jobName", "EventId"
             };
 
             loggerConfiguration.WriteTo.Console(formatter: new CustomJsonFormatter(topLevelPropertiesNames));

--- a/src/JoinRpg.Portal/Infrastructure/OpenTelemetryRegistration.cs
+++ b/src/JoinRpg.Portal/Infrastructure/OpenTelemetryRegistration.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JoinRpg.Portal.Infrastructure.DailyJobs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -10,7 +11,7 @@ public static class OpenTelemetryRegistration
     public static void AddJoinOpenTelemetry(this IServiceCollection services)
     {
         const string serviceName = "JoinRpg";
-        services.AddOpenTelemetry()
+        _ = services.AddOpenTelemetry()
             .ConfigureResource(builder =>
             {
 
@@ -18,6 +19,7 @@ public static class OpenTelemetryRegistration
             })
             .WithTracing(tracing =>
             {
+                tracing.AddSource(BackgroundServiceActivity.ActivitySourceName);
                 tracing
                 .AddHttpClientInstrumentation()
                 .AddAspNetCoreInstrumentation();

--- a/src/JoinRpg.Portal/JoinRpg.Portal.csproj
+++ b/src/JoinRpg.Portal/JoinRpg.Portal.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" /> <!-- Bump up implicitly, so transtitive dependiencies would not warn -->
   </ItemGroup>
   <ItemGroup>

--- a/src/JoinRpg.Portal/Pages/Admin/Jobs.cshtml
+++ b/src/JoinRpg.Portal/Pages/Admin/Jobs.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model JoinRpg.Portal.Pages.Admin.JobsModel
 <h3>Джобы</h3>
 @foreach (var job in Model.Jobs)
@@ -12,6 +12,10 @@
 
                             <input type="submit" value="Запустить джобу" class="btn btn-success" />
             </form>
+            @{
+                var link = $"https://console.yandex.cloud/folders/b1g1a4nj5oq5sv996tcv/logging/group/e2371utkp5mj3oltko4r/logs?from=now-1d&to=now&size=100&linesInRow=1&query=jobName+%3D+%22{job.Name}%22";
+            }
+            <a href="@link">[Логи]</a>
     </div>
     </div>
 }


### PR DESCRIPTION
- https://github.com/serilog-contrib/serilog-sinks-elasticsearch больше не развивается
- Из него нам был нужен только форматтер, а его форматтер был форком оригинального и не писал TraceId/SpanId
- Перенес форматтер к нам в код, начал писать TraceId/SpanId 
- Добавил енричер на Activity.Tags
- Удалил зависимость от serilog-sinks-elasticsearch

В будущем надо:
- Посмотреть, нельзя ли вернуться на оригинальный форматтер или еще лучше на компактный
- Посмотреть, точно ли хочу, чтобы писался Activity.Tags или прокидывать имя джобы отдельно