### PR TITLE
Проверять dotnet publish на PR (#3979)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -71,6 +71,13 @@ jobs:
         name: test-results
         path: TestResults
 
+    - name: Verify publish
+      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      run: |
+        dotnet publish --no-restore --os linux --arch x64 -c Release ${APP_PROJECT} -p:Version=${{ env.CALCULATED_VERSION }}
+        dotnet publish --no-restore --os linux --arch x64 -c Release ${MIGRATOR_PROJECT} -p:Version=${{ env.CALCULATED_VERSION }}
+        dotnet publish --no-restore --os linux --arch x64 -c Release ${IDPORTAL_PROJECT} -p:Version=${{ env.CALCULATED_VERSION }}
+
     #Rest of the pipeline implies write api privileges and can't be run on PRs
 
     - name: Log in to Yandex Container Registry


### PR DESCRIPTION
## Summary

Closes #3979

Добавлен шаг **Verify publish** в CI workflow `build_and_publish.yml`, который запускает `dotnet publish` для всех трёх проектов (Portal, Migrator, IdPortal) на PR и merge_group **без** `/t:PublishContainer`.

## Что изменено

- Новый шаг `Verify publish` после тестов и перед контейнерными publish-шагами
- Условие: `github.event_name == 'pull_request' || github.event_name == 'merge_group'` — зеркальное к существующим publish-шагам
- На master/tag publish проверяется существующими шагами с `/t:PublishContainer`, дублирование не нужно

## Зачем

Сейчас ошибки publish (Blazor WASM, статические файлы, конфигурация публикации) обнаруживаются только после мержа в master. Этот шаг ловит такие проблемы на этапе PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)