### PR TITLE
Возвращать 404 при некорректном ID пользователя

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
@@ -18,7 +18,11 @@ public class UserController(IUserRepository userRepository, ICurrentUserAccessor
     [AllowAnonymous]
     public async Task<ActionResult> Details(UserIdentification userId)
     {
-        var user = await userRepository.GetUserInfo(userId) ?? throw new JoinRpgEntityNotFoundException([userId], "User");
+        var user = await userRepository.GetUserInfo(userId);
+        if (user is null)
+        {
+            return NotFound();
+        }
 
         var userProjects = await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.AllProjectsWithMasterAccess(userId));
 


### PR DESCRIPTION
## Summary

- При переходе на `/user/<несуществующий_id>` сервер возвращал 500 (исключение `JoinRpgEntityNotFoundException`), теперь возвращает 404
- Заменён `throw` на `return NotFound()` в `UserController.Details`

Fixes joinrpg/joinrpg-net#3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)