### PR TITLE
Исправить сохранение query string в PlotLegacyRedirect (#4024)

### DIFF
--- a/src/JoinRpg.Portal.Test/IntegrationTestPortalFactory.cs
+++ b/src/JoinRpg.Portal.Test/IntegrationTestPortalFactory.cs
@@ -1,10 +1,18 @@
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JoinRpg.Portal.Test;
 
 public sealed class IntegrationTestPortalFactory : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
-        => builder.UseEnvironment("IntegrationTest");
+    {
+        builder.UseEnvironment("IntegrationTest");
+        builder.ConfigureServices(services =>
+        {
+            services.AddDataProtection().UseEphemeralDataProtectionProvider();
+        });
+    }
 }

--- a/src/JoinRpg.Portal.Test/PlotLegacyRedirectTests.cs
+++ b/src/JoinRpg.Portal.Test/PlotLegacyRedirectTests.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace JoinRpg.Portal.Test;
+
+public class PlotLegacyRedirectTests(IntegrationTestPortalFactory factory)
+    : IClassFixture<IntegrationTestPortalFactory>
+{
+    [Theory]
+    [InlineData("1/plot/edit", "/1/plots/edit")]
+    [InlineData("1/plot/edit?PlotFolderId=132", "/1/plots/edit?PlotFolderId=132")]
+    [InlineData("1/plot/edit?PlotFolderId=132&foo=bar", "/1/plots/edit?PlotFolderId=132&foo=bar")]
+    public async Task LegacyPlotUrlRedirectsPermanently(string requestPath, string expectedLocation)
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var response = await client.GetAsync(requestPath);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.MovedPermanently);
+        response.Headers.Location?.OriginalString.ShouldBe(expectedLocation);
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/PlotLegacyRedirectController.cs
+++ b/src/JoinRpg.Portal/Controllers/PlotLegacyRedirectController.cs
@@ -8,5 +8,5 @@ public class PlotLegacyRedirectController : Controller
 {
     [HttpGet("{**path}")]
     public IActionResult LegacyRedirect(int projectId, string? path = null)
-        => RedirectPermanent($"/{projectId}/plots/{path}");
+        => RedirectPermanent($"/{projectId}/plots/{path}{Request.QueryString}");
 }

--- a/src/JoinRpg.Web.Games/Projects/ProjectCards.razor
+++ b/src/JoinRpg.Web.Games/Projects/ProjectCards.razor
@@ -33,7 +33,7 @@
 
                     @if (!project.IsMaster && project.PublishPlot)
                     {
-                        <a href="/@(project.ProjectId.Value)/plot/index"
+                        <a href="/@(project.ProjectId.Value)/plots/index"
                            class="btn btn-info btn-sm"
                            role="button">
                             Материалы

--- a/src/JoinRpg.Web.Plots/EditPlotElementButton.razor
+++ b/src/JoinRpg.Web.Plots/EditPlotElementButton.razor
@@ -14,6 +14,6 @@ Size="SizeStyleEnum.Small"
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        uri = $"{Id.ProjectId.Value}/plot/edit?PlotFolderId={Id.PlotFolderId.PlotFolderId}#panelPlotElement{Id.PlotElementId}";
+        uri = $"{Id.ProjectId.Value}/plots/edit?PlotFolderId={Id.PlotFolderId.PlotFolderId}#panelPlotElement{Id.PlotElementId}";
     }
 }

--- a/src/JoinRpg.Web.Plots/PlotElementsView.razor
+++ b/src/JoinRpg.Web.Plots/PlotElementsView.razor
@@ -73,7 +73,7 @@
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        endpoint = $"/{CharacterId.ProjectId.Value}/plot/ReorderByCharacter?characterId={CharacterId.CharacterId}";
+        endpoint = $"/{CharacterId.ProjectId.Value}/plots/ReorderByCharacter?characterId={CharacterId.CharacterId}";
         itemIds = [.. PlotTexts.Select(x => x.PlotVersionId.PlotElementId.ToString())];
     }
 }

--- a/src/JoinRpg.Web.Plots/PlotFolderListItemRow.razor
+++ b/src/JoinRpg.Web.Plots/PlotFolderListItemRow.razor
@@ -15,7 +15,7 @@
                     <br />
                     foreach (var tagName in Item.TagNames)
                     {
-                        <a href="@("/" + Item.PlotFolderId.ProjectId.Value.ToString() + "/plot/bytag?tagName=" + tagName)">#@tagName</a>
+                        <a href="@("/" + Item.PlotFolderId.ProjectId.Value.ToString() + "/plots/bytag?tagName=" + tagName)">#@tagName</a>
                         <text> </text>
                     }
                 }
@@ -70,8 +70,8 @@
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        createElementUri = $"/{Item.PlotFolderId.ProjectId.Value}/plot/createelement?PlotFolderId={Item.PlotFolderId.PlotFolderId}";
-        deletePlotUri = $"/{Item.PlotFolderId.ProjectId.Value}/plot/delete?PlotFolderId={Item.PlotFolderId.PlotFolderId}";
-        reorderPlotUri = $"/{Item.PlotFolderId.ProjectId.Value}/plot/reorderfolder";
+        createElementUri = $"/{Item.PlotFolderId.ProjectId.Value}/plots/createelement?PlotFolderId={Item.PlotFolderId.PlotFolderId}";
+        deletePlotUri = $"/{Item.PlotFolderId.ProjectId.Value}/plots/delete?PlotFolderId={Item.PlotFolderId.PlotFolderId}";
+        reorderPlotUri = $"/{Item.PlotFolderId.ProjectId.Value}/plots/reorderfolder";
     }
 }


### PR DESCRIPTION
## Summary
- `PlotLegacyRedirectController` теперь передаёт `Request.QueryString` в redirect URL (301)
- Обновлены хардкод-ссылки `/plot/` → `/plots/` в Blazor-компонентах (`ProjectCards`, `EditPlotElementButton`, `PlotElementsView`, `PlotFolderListItemRow`)
- Добавлены интеграционные тесты на 301-редирект с сохранением query string
- `IntegrationTestPortalFactory` теперь использует ephemeral DataProtection для работы без БД

Fixes #4024

## Test plan
- [ ] Проверить вручную: `/{projectId}/plot/edit?PlotFolderId=123` → 301 → `/{projectId}/plots/edit?PlotFolderId=123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)