### PR TITLE
fix: SetCharacterFields принимает произвольные JSON-значения (#4025)

### DIFF
--- a/src/JoinRpg.Portal.Test/XGameApi/FieldValueConverterTest.cs
+++ b/src/JoinRpg.Portal.Test/XGameApi/FieldValueConverterTest.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using JoinRpg.Portal.Controllers.XGameApi;
+
+namespace JoinRpg.Portal.Test.XGameApi;
+
+public class FieldValueConverterTest
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void StringPassthrough()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("\"hello\"") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("hello");
+    }
+
+    [Fact]
+    public void IntegerToString()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("42") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("42");
+    }
+
+    [Fact]
+    public void NullToNull()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("null") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public void FloatToExactString()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("3.14") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("3.14");
+    }
+
+    [Fact]
+    public void LargeInteger()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("9999999999999") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("9999999999999");
+    }
+
+    [Fact]
+    public void BooleanTrue()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("true") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("true");
+    }
+
+    [Fact]
+    public void BooleanFalse()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("false") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("false");
+    }
+
+    [Fact]
+    public void ArrayOfInts()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("[1,2,3]") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("1,2,3");
+    }
+
+    [Fact]
+    public void ArrayOfStrings()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("[\"a\",\"b\"]") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("a,b");
+    }
+
+    [Fact]
+    public void EmptyArray()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("[]") };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("");
+    }
+
+    [Fact]
+    public void MixedTypesInDict()
+    {
+        var input = new Dictionary<int, JsonElement>
+        {
+            [1] = Parse("\"text\""),
+            [2] = Parse("42"),
+            [3] = Parse("null"),
+            [4] = Parse("[1,2]"),
+        };
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result[1].ShouldBe("text");
+        result[2].ShouldBe("42");
+        result[3].ShouldBeNull();
+        result[4].ShouldBe("1,2");
+    }
+
+    [Fact]
+    public void ObjectValueThrows()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("{\"a\":1}") };
+        Should.Throw<ArgumentException>(() => FieldValueConverter.ConvertToStringValues(input));
+    }
+
+    [Fact]
+    public void ArrayWithObjectThrows()
+    {
+        var input = new Dictionary<int, JsonElement> { [1] = Parse("[{\"a\":1}]") };
+        Should.Throw<ArgumentException>(() => FieldValueConverter.ConvertToStringValues(input));
+    }
+
+    [Fact]
+    public void EmptyDictionary()
+    {
+        var input = new Dictionary<int, JsonElement>();
+        var result = FieldValueConverter.ConvertToStringValues(input);
+        result.ShouldBeEmpty();
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.Domain;
 using JoinRpg.Portal.Infrastructure.Authorization;
@@ -5,6 +6,7 @@ using JoinRpg.PrimitiveTypes;
 using JoinRpg.Services.Interfaces.Characters;
 using JoinRpg.Web.Models.Characters;
 using JoinRpg.XGameApi.Contract;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using CharacterHeader = JoinRpg.XGameApi.Contract.CharacterHeader;
 
@@ -85,9 +87,21 @@ public class CharacterApiController(
     /// Skipped values will be left unchanged</param>
     [HttpPost]
     [Route("{characterId}/fields")]
-    public async Task<string> SetCharacterFields(int projectId, int characterId, Dictionary<int, string?> fieldValues)
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult<string>> SetCharacterFields(int projectId, int characterId, [FromBody] Dictionary<int, JsonElement> fieldValues)
     {
-        await characterService.SetFields(new CharacterIdentification(projectId, characterId), fieldValues);
+        Dictionary<int, string?> converted;
+        try
+        {
+            converted = FieldValueConverter.ConvertToStringValues(fieldValues);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        await characterService.SetFields(new CharacterIdentification(projectId, characterId), converted);
         return "ok";
     }
 

--- a/src/JoinRpg.Portal/Controllers/XGameApi/FieldValueConverter.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/FieldValueConverter.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+
+namespace JoinRpg.Portal.Controllers.XGameApi;
+
+public static class FieldValueConverter
+{
+    public static Dictionary<int, string?> ConvertToStringValues(Dictionary<int, JsonElement> fieldValues)
+    {
+        var result = new Dictionary<int, string?>(fieldValues.Count);
+        foreach (var (key, value) in fieldValues)
+        {
+            result[key] = ConvertElement(value);
+        }
+        return result;
+    }
+
+    private static string? ConvertElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Array => ConvertArray(element),
+            JsonValueKind.Object => throw new ArgumentException("Object values are not supported"),
+            _ => throw new ArgumentException($"Unsupported JSON value kind: {element.ValueKind}"),
+        };
+    }
+
+    private static string ConvertArray(JsonElement element)
+    {
+        var items = new List<string>();
+        foreach (var item in element.EnumerateArray())
+        {
+            if (item.ValueKind is JsonValueKind.Object or JsonValueKind.Array)
+            {
+                throw new ArgumentException("Array elements must be primitive values");
+            }
+            var converted = ConvertElement(item);
+            if (converted is not null)
+            {
+                items.Add(converted);
+            }
+        }
+        return string.Join(",", items);
+    }
+}


### PR DESCRIPTION
Параметр fieldValues изменён с Dictionary<int, string?> на Dictionary<int, JsonElement>. Числа, булевы, null и массивы автоматически конвертируются в строки. Некорректные значения (объекты) возвращают 400 Bad Request.