### PR TITLE
Добавить claude права на поиск в сети

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,10 @@
       "Bash(dotnet restore*)",
       "Bash(dotnet publish*)",
       "Bash(dotnet ef*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(gh run view:*)",
+      "WebFetch",
+      "WebSearch"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Добавляет Claude разрешения на поиск и получение информации из сети в файле конфигурации .claude/settings.json.

Изменения в .claude/settings.json:
- Добавлено разрешение WebFetch — позволяет Claude получать содержимое веб-страниц
- Добавлено разрешение WebSearch — позволяет Claude выполнять поиск в интернете
- Добавлено разрешение Bash(gh run view:*) — позволяет Claude просматривать статус запусков GitHub Actions