### PR TITLE
fix: обрезать пробелы в поисковом запросе

### DIFF
--- a/src/JoinRpg.Portal/Controllers/SearchController.cs
+++ b/src/JoinRpg.Portal/Controllers/SearchController.cs
@@ -17,6 +17,7 @@ public class SearchController(
 {
     public async Task<ActionResult> Index(string? searchString)
     {
+        searchString = searchString?.Trim();
         var searchResults =
             string.IsNullOrEmpty(searchString)
                 ? []


### PR DESCRIPTION
Closes #412

Добавлен `searchString = searchString?.Trim();` в `SearchController.Index` перед проверкой на пустоту.

Generated with [Claude Code](https://claude.ai/code)