### PR TITLE
Remove LangVersion=13 because EF was fixed

### DIFF
--- a/src/JoinRpg.Dal.Impl/JoinRpg.Dal.Impl.csproj
+++ b/src/JoinRpg.Dal.Impl/JoinRpg.Dal.Impl.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
-    <LangVersion>13</LangVersion> <!-- First-class span support causes translation failure with Contains https://github.com/dotnet/ef6/issues/2322 -->
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.Data.Interfaces\JoinRpg.Data.Interfaces.csproj" />


### PR DESCRIPTION
В #4178 обновился EF6, теперь он поддерживает ReadOnlySpan и не нужно теперь хаков