### PR TITLE
Квотировать display-name в FormatAddress по RFC 5322

### DIFF
--- a/src/JoinRpg.Services.Notifications.Tests/FormatAddressTest.cs
+++ b/src/JoinRpg.Services.Notifications.Tests/FormatAddressTest.cs
@@ -1,0 +1,18 @@
+using JoinRpg.Services.Notifications.Senders.PostboxEmail;
+using Shouldly;
+
+namespace JoinRpg.Services.Notifications.Tests;
+
+public class FormatAddressTest
+{
+    [Theory]
+    [InlineData("Master", "foo@bar.ru", "Master <foo@bar.ru>")]
+    [InlineData("Ivan Ivanov", "x@y.ru", "Ivan Ivanov <x@y.ru>")]
+    [InlineData("user@example.com", "user@example.com", "\"user@example.com\" <user@example.com>")]
+    [InlineData("Ivanov, Ivan", "x@y.ru", "\"Ivanov, Ivan\" <x@y.ru>")]
+    [InlineData("O\"Brien", "x@y.ru", "\"O\\\"Brien\" <x@y.ru>")]
+    public void FormatAddress(string displayName, string email, string expected)
+    {
+        PostboxSenderJobService.FormatAddress(displayName, email).ShouldBe(expected);
+    }
+}

--- a/src/JoinRpg.Services.Notifications/Senders/PostboxEmail/PostboxSenderJobService.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/PostboxEmail/PostboxSenderJobService.cs
@@ -100,5 +100,14 @@ internal class PostboxSenderJobService(
         };
     }
 
-    private static string FormatAddress(string addressName, string email) => $"{addressName} <{email}>";
+    internal static string FormatAddress(string addressName, string email)
+    {
+        // RFC 5322 §3.2.3 specials — display-name must be quoted when it contains any of these
+        const string specials = "()<>[]:;@\\,.\"";
+        var needsQuoting = addressName.Any(specials.Contains);
+        var formattedName = needsQuoting
+            ? $"\"{addressName.Replace("\\", "\\\\").Replace("\"", "\\\"")}\""
+            : addressName;
+        return $"{formattedName} <{email}>";
+    }
 }


### PR DESCRIPTION
Если display-name содержит спецсимволы (@, ., запятую и др.), адрес вида user@example.com <user@example.com> невалиден. Теперь такие имена оборачиваются в кавычки: "user@example.com" <user@example.com>.