### PR TITLE
fix(SenderJobService): include job name in successful send log

### DIFF
--- a/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
@@ -147,7 +147,7 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
 
                 numberOfSuccessCounter.Add(1);
                 SuccessCounter++;
-                logger.LogInformation("Сообщение {messageId} отправлено", nextMessage.MessageId);
+                logger.LogInformation("Сообщение {messageId} отправлено через {senderJobName}", nextMessage.MessageId, JobName);
 
                 if (SuccessCounter >= WorkerOptions.MinSubsequentSuccessesToStopFailureCounting)
                 {


### PR DESCRIPTION
Updated the success log in `SenderJobService` to include the job name, so successful sends via email, Telegram and in-app notifications can be distinguished in logs.

Closes #4324

Generated with [Claude Code](https://claude.ai/code)