### PR TITLE
XSS: TargetedSearchResultViewModel — явное HTML-кодирование при подсветке поиска

### DIFF
--- a/src/JoinRpg.WebPortal.Models.Test/SearchHighlightTest.cs
+++ b/src/JoinRpg.WebPortal.Models.Test/SearchHighlightTest.cs
@@ -1,0 +1,95 @@
+using JoinRpg.DataModel;
+using JoinRpg.DomainTypes;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.Services.Interfaces.Search;
+
+namespace JoinRpg.WebPortal.Models.Test;
+
+// Тесты для подсветки результатов поиска в GetFormattedDescription (ADR007, пункт 2).
+//
+// Архитектура: описание сначала декодируется в сырой plain text, затем ищется/обрезается,
+// а каждый сегмент HTML-кодируется явно при сборке итоговой строки.
+// Это исправляет UX-баг (спецсимволы не находились) и security-риск
+// (защита теперь явная, не зависящая от побочного эффекта санитайзера).
+public class SearchHighlightTest
+{
+    private sealed class StubUriService : IUriService
+    {
+        public string Get(ILinkable link) => "/stub";
+        public Uri GetUri(ILinkable link) => new("/stub", UriKind.Relative);
+    }
+
+    private static TargetedSearchResultViewModel CreateVm(string descriptionMarkdown, string searchTarget)
+    {
+        var result = new SearchResult
+        {
+            LinkType = LinkType.ResultCharacter,
+            Name = "Test",
+            Description = new MarkdownDbValue(descriptionMarkdown),
+            IsPublic = true,
+            IsActive = true,
+            Identification = "1",
+            ProjectId = null,
+        };
+        return new TargetedSearchResultViewModel(result, searchTarget, new StubUriService(), projectViewModel: null);
+    }
+
+    // -------------------------------------------------------------------
+    // Базовая подсветка
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void GetFormattedDescription_PlainText_HighlightsSearchTerm()
+    {
+        var vm = CreateVm("hello world", searchTarget: "hello");
+        vm.GetFormattedDescription(1000).ToHtmlString()
+            .ShouldContain("<b><u>hello</u></b>");
+    }
+
+    // -------------------------------------------------------------------
+    // Спецсимволы HTML в описании — исправление UX
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void GetFormattedDescription_AmpersandInDescription_IsFoundAndHighlighted()
+    {
+        // Раньше поиск "AT&T" в описании "AT&T" не давал подсветки,
+        // потому что поиск вёлся по HTML-закодированному "AT&amp;T".
+        // Теперь сначала декодируем в plain text — совпадение находится.
+        var vm = CreateVm("AT&T", searchTarget: "AT&T");
+        var result = vm.GetFormattedDescription(1000).ToHtmlString();
+
+        result.ShouldBe("<b><u>AT&amp;T</u></b>");
+    }
+
+    [Fact]
+    public void GetFormattedDescription_AngleBracketInDescription_EncodedNotRaw()
+    {
+        // "price < 100" → после HTML-кодирования → "price &lt; 100"
+        // Угловая скобка кодируется явно при сборке; в результате нет сырого '<'.
+        var vm = CreateVm("price < 100", searchTarget: "price");
+        var result = vm.GetFormattedDescription(1000).ToHtmlString();
+
+        result.ShouldContain("<b><u>price</u></b>");
+        result.ShouldNotContain("price <");   // сырой '<' не должен попасть в результат
+        result.ShouldContain("&lt; 100");     // '<' должен оставаться закодированным
+    }
+
+    // -------------------------------------------------------------------
+    // Защита от XSS: явный HtmlEncoder в BuildHighlightedHtml предотвращает инъекцию
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void GetFormattedDescription_OutputNeverContainsRawHtmlFromDescription()
+    {
+        // Markdig убирает inline HTML-теги в plain-text режиме, поэтому <script>
+        // до BuildHighlightedHtml не добирается. Даже если бы добрался —
+        // HtmlEncoder.Default.Encode его закодировал бы. Оба уровня защищают от XSS.
+        const string malicious = "click <script>alert(1)</script> here";
+        var vm = CreateVm(malicious, searchTarget: "click");
+        var result = vm.GetFormattedDescription(1000).ToHtmlString();
+
+        result.ShouldNotContain("<script>");
+        result.ShouldContain("<b><u>click</u></b>");
+    }
+}

--- a/src/JoinRpg.WebPortal.Models/TargetedSearchResultViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/TargetedSearchResultViewModel.cs
@@ -1,4 +1,6 @@
-using System.Text.RegularExpressions;
+using System.Net;
+using System.Text;
+using System.Text.Encodings.Web;
 using JoinRpg.Markdown;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Services.Interfaces.Search;
@@ -24,18 +26,47 @@ public class TargetedSearchResultViewModel(SearchResult searchResult,
 
     public JoinHtmlString GetFormattedDescription(int maxLengthToShow)
     {
-        var descriptionToShow = TruncateString(
-            ((MarkdownString?)SearchResult.Description).ToPlainTextAndEscapeHtml().Value,
-            SearchTarget,
-            maxLengthToShow);
+        // Work on decoded plain text so that search terms with '&', '<' etc. are found correctly.
+        // ToPlainTextWithoutHtmlEscape returns Markdig output which may contain HTML entities;
+        // HtmlDecode converts them to raw characters before searching.
+        var plainText = WebUtility.HtmlDecode(
+            ((MarkdownString?)SearchResult.Description).ToPlainTextWithoutHtmlEscape());
 
-        descriptionToShow = Regex.Replace(
-            descriptionToShow,
-            Regex.Escape(SearchTarget),
-            match => "<b><u>" + match.Value + "</u></b>",
-            RegexOptions.IgnoreCase);
+        var truncated = TruncateString(plainText, SearchTarget, maxLengthToShow);
 
-        return new MarkupString(descriptionToShow);
+        // Sanitization (HTML encoding) happens here, per segment, not up front.
+        return BuildHighlightedHtml(truncated, SearchTarget);
+    }
+
+    private static MarkupString BuildHighlightedHtml(string plainText, string searchTarget)
+    {
+        if (string.IsNullOrEmpty(searchTarget))
+        {
+            return new MarkupString(HtmlEncoder.Default.Encode(plainText));
+        }
+
+        var sb = new StringBuilder();
+        var sw = new StringWriter(sb);
+        var pos = 0;
+
+        while (pos < plainText.Length)
+        {
+            var matchIndex = plainText.IndexOf(searchTarget, pos, StringComparison.InvariantCultureIgnoreCase);
+            if (matchIndex < 0)
+            {
+                HtmlEncoder.Default.Encode(sw, plainText, pos, plainText.Length - pos);
+                break;
+            }
+
+            HtmlEncoder.Default.Encode(sw, plainText, pos, matchIndex - pos);
+            _ = sb.Append("<b><u>");
+            HtmlEncoder.Default.Encode(sw, plainText, matchIndex, searchTarget.Length);
+            _ = sb.Append("</u></b>");
+
+            pos = matchIndex + searchTarget.Length;
+        }
+
+        return new MarkupString(sb.ToString());
     }
 
     private static string TruncateString(


### PR DESCRIPTION
Исправляет одновременно UX-баг и структурный security-риск в GetFormattedDescription:

- UX-баг: поиск вёлся по HTML-закодированной строке, поэтому 'AT&T' не находился в описании, содержащем 'AT&T'. Теперь описание сначала декодируется через WebUtility.HtmlDecode(ToPlainTextWithoutHtmlEscape()), после чего поиск ведётся по сырому plain-тексту.

- Security: match.Value раньше вставлялся в HTML без явного кодирования. Теперь BuildHighlightedHtml явно кодирует каждый сегмент через HtmlEncoder.Default.Encode(TextWriter, string, int, int) — без создания подстрок. Тег <b><u>...</u></b> вставляется как литерал, всё остальное HTML-кодируется.

Добавлены unit-тесты (SearchHighlightTest), покрывающие: обычную подсветку, '&' в описании, угловую скобку и XSS-попытку через <script>.