### PR TITLE
feat: typed Blazor components for user contacts 

### DIFF
--- a/src/JoinRpg.Common.PrimitiveTypes/Users/LiveJournalId.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/Users/LiveJournalId.cs
@@ -1,0 +1,4 @@
+namespace JoinRpg.Common.PrimitiveTypes;
+
+[TypedStringValue]
+public partial record LiveJournalId(string Value);

--- a/src/JoinRpg.Common.PrimitiveTypes/Users/PhoneNumber.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/Users/PhoneNumber.cs
@@ -1,0 +1,4 @@
+namespace JoinRpg.Common.PrimitiveTypes;
+
+[TypedStringValue]
+public partial record PhoneNumber(string Value);

--- a/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
@@ -14,29 +14,29 @@
             {
                 <br /> @Model.FullName
             }
-            @if (!string.IsNullOrWhiteSpace(Model.Email))
+            @if (Model.Email is not null)
             {
-                <br /> @Html.DisplayFor(model => model.Email)
+                <br /><component type="typeof(EmailLink)" render-mode="Static" param-Contact="@Model.Email" />
                 @if (!Model.EmailConfirmed && Model.ViewAsAdmin)
                 {
                     <component type="typeof(InfoIcon)" render-mode="Static" param-Title="@("Email не подтвержден")" />
                 }
             }
-            @if (!string.IsNullOrWhiteSpace(Model.PhoneNumber))
+            @if (Model.PhoneNumber is not null)
             {
-                <br /> @Html.DisplayFor(model => model.PhoneNumber) 
+                <br /><component type="typeof(PhoneLink)" render-mode="Static" param-Contact="@Model.PhoneNumber" />
             }
-            @if (!string.IsNullOrWhiteSpace(Model.Telegram))
+            @if (Model.Telegram?.UserName is not null)
             {
-                <br />@Html.DisplayFor(model => model.Telegram) 
+                <br /><component type="typeof(TelegramLink)" render-mode="Static" param-Contact="@Model.Telegram" />
             }
-            @if (!string.IsNullOrWhiteSpace(Model.Livejournal))
+            @if (Model.Livejournal is not null)
             {
-                <br /> @Html.DisplayFor(model => model.Livejournal) 
+                <br /><component type="typeof(LiveJournalLink)" render-mode="Static" param-Contact="@Model.Livejournal" />
             }
-            @if (!string.IsNullOrWhiteSpace(Model.Vk))
+            @if (Model.Vk is not null)
             {
-                <br /> @Html.DisplayFor(model => model.Vk) 
+                <br /><component type="typeof(VkLink)" render-mode="Static" param-Contact="@Model.Vk" />
             }
             @if (Model.AllrpgId != null && Model.AllrpgId != 0)
             {
@@ -48,5 +48,5 @@
               <p>Игрок предпочитает сохранять анонимность.</p>
             }
         </td>
-    </tr>    
+    </tr>
 </table>

--- a/src/JoinRpg.WebComponents.Test/ContactComponentsTest.cs
+++ b/src/JoinRpg.WebComponents.Test/ContactComponentsTest.cs
@@ -1,0 +1,102 @@
+using JoinRpg.Common.PrimitiveTypes;
+
+namespace JoinRpg.WebComponents.Test;
+
+public class ContactComponentsTest
+{
+    [Fact]
+    public void EmailLink_Null_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<EmailLink>(p => p.Add(x => x.Contact, null));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void EmailLink_WithValue_RendersMailtoLink()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<EmailLink>(p => p.Add(x => x.Contact, new Email("test@example.com")));
+        cut.Markup.ShouldContain("href=\"mailto:test@example.com\"");
+        cut.Markup.ShouldContain("test@example.com");
+        cut.Markup.ShouldContain("glyphicon-envelope");
+    }
+
+    [Fact]
+    public void PhoneLink_Null_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<PhoneLink>(p => p.Add(x => x.Contact, null));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void PhoneLink_WithValue_RendersPhoneNumber()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<PhoneLink>(p => p.Add(x => x.Contact, new PhoneNumber("+79161234567")));
+        cut.Markup.ShouldContain("+79161234567");
+        cut.Markup.ShouldContain("glyphicon-phone");
+    }
+
+    [Fact]
+    public void TelegramLink_Null_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<TelegramLink>(p => p.Add(x => x.Contact, null));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TelegramLink_WithoutUserName_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var contact = new TelegramId(123456, null);
+        var cut = ctx.Render<TelegramLink>(p => p.Add(x => x.Contact, contact));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TelegramLink_WithUserName_RendersLink()
+    {
+        using var ctx = new BunitContext();
+        var contact = new TelegramId(123456, new PrefferedName("joinrpg"));
+        var cut = ctx.Render<TelegramLink>(p => p.Add(x => x.Contact, contact));
+        cut.Markup.ShouldContain("https://t.me/joinrpg");
+        cut.Markup.ShouldContain("glyphicon-send");
+    }
+
+    [Fact]
+    public void LiveJournalLink_Null_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<LiveJournalLink>(p => p.Add(x => x.Contact, null));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void LiveJournalLink_WithValue_RendersLjLink()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<LiveJournalLink>(p => p.Add(x => x.Contact, new LiveJournalId("someuser")));
+        cut.Markup.ShouldContain("https://someuser.lj.ru");
+        cut.Markup.ShouldContain("ЖЖ:");
+    }
+
+    [Fact]
+    public void VkLink_Null_RendersNothing()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, null));
+        cut.Markup.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void VkLink_WithValue_RendersVkLink()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, new VkId("id123")));
+        cut.Markup.ShouldContain("https://vk.com/id123");
+        cut.Markup.ShouldContain("ВК:");
+    }
+}

--- a/src/JoinRpg.WebComponents/EmailLink.razor
+++ b/src/JoinRpg.WebComponents/EmailLink.razor
@@ -1,0 +1,9 @@
+@if (Contact is not null)
+{
+    <text><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>&nbsp;<a href="mailto:@Contact.Value">@Contact.Value.Trim()</a></text>
+}
+
+@code {
+    [Parameter]
+    public Email? Contact { get; set; }
+}

--- a/src/JoinRpg.WebComponents/LiveJournalLink.razor
+++ b/src/JoinRpg.WebComponents/LiveJournalLink.razor
@@ -1,0 +1,9 @@
+@if (Contact is not null)
+{
+    <text>ЖЖ:&nbsp;<a href="https://@(Contact.Value).lj.ru">@Contact.Value</a></text>
+}
+
+@code {
+    [Parameter]
+    public LiveJournalId? Contact { get; set; }
+}

--- a/src/JoinRpg.WebComponents/PhoneLink.razor
+++ b/src/JoinRpg.WebComponents/PhoneLink.razor
@@ -1,0 +1,9 @@
+@if (Contact is not null)
+{
+    <span style="white-space: nowrap"><span class="glyphicon glyphicon-phone"></span> @Contact.Value</span>
+}
+
+@code {
+    [Parameter]
+    public PhoneNumber? Contact { get; set; }
+}

--- a/src/JoinRpg.WebComponents/TelegramLink.razor
+++ b/src/JoinRpg.WebComponents/TelegramLink.razor
@@ -1,0 +1,6 @@
+<TelegramIcon Link="@(Contact?.UserName?.Value)" />
+
+@code {
+    [Parameter]
+    public TelegramId? Contact { get; set; }
+}

--- a/src/JoinRpg.WebComponents/VkLink.razor
+++ b/src/JoinRpg.WebComponents/VkLink.razor
@@ -1,0 +1,9 @@
+@if (Contact is not null)
+{
+    <text>ВК:&nbsp;<a href="https://vk.com/@Contact.Value">@Contact.Value</a></text>
+}
+
+@code {
+    [Parameter]
+    public VkId? Contact { get; set; }
+}

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -40,18 +40,16 @@ public record class UserAdminOperationsViewModel(Uri LogLink, bool IsAdmin);
 
 public class UserProfileDetailsViewModel
 {
-    [Display(Name = "Номер телефона"), DataType(DataType.PhoneNumber), UIHint("PhoneNumber")]
-    public string? PhoneNumber { get; }
+    [Display(Name = "Номер телефона"), DataType(DataType.PhoneNumber)]
+    public PhoneNumber? PhoneNumber { get; }
     [Display(Name = "Skype"), UIHint("Skype")]
     public string? Skype { get; }
-    [Display(Name = "Telegram"), UIHint("Telegram")]
-    public string? Telegram { get; }
-    [Display(Name = "ЖЖ"), UIHint("Livejournal")]
-    public string? Livejournal { get; }
-    [Display(Name = "VK"), UIHint("Vkontakte")]
-    public string? Vk { get; }
-    [UIHint("Email")]
-    public string? Email { get; }
+    public TelegramId? Telegram { get; }
+    [Display(Name = "ЖЖ")]
+    public LiveJournalId? Livejournal { get; }
+    [Display(Name = "VK")]
+    public VkId? Vk { get; }
+    public Email? Email { get; }
     public bool EmailConfirmed { get; }
     [DisplayName("ФИО")]
     public string? FullName { get; }
@@ -94,15 +92,15 @@ public class UserProfileDetailsViewModel
             Email = user.Email;
             EmailConfirmed = user.EmailConfirmed;
             FullName = user.UserFullName.FullName;
-            PhoneNumber = user.PhoneNumber;
+            PhoneNumber = PhoneNumber.FromOptional(user.PhoneNumber);
             IsVerifiedUser = user.VerifiedProfileFlag;
         }
         if (Reason != AccessReasonView.NoAccess || user.Social.SocialNetworksAccess == ContactsAccessType.Public)
         {
-            Vk = user.Social.VkId;
+            Vk = VkId.FromOptional(user.Social.VkId);
             AllrpgId = user.Social.AllrpgInfoId;
-            Telegram = user.Social.TelegramId?.UserName?.Value;
-            Livejournal = user.Social.LiveJournal;
+            Telegram = user.Social.TelegramId;
+            Livejournal = LiveJournalId.FromOptional(user.Social.LiveJournal);
             HasSocialAccess = true;
         }
 


### PR DESCRIPTION
(email, phone, Telegram, LJ, VK)

- Add PhoneNumber and LiveJournalId PrimitiveTypes with [TypedStringValue]
- Add EmailLink, PhoneLink, TelegramLink, LiveJournalLink, VkLink Blazor components accepting typed PrimitiveType parameters
- Update UserProfileDetailsViewModel to use typed contact properties instead of string? (Email, PhoneNumber, TelegramId, LiveJournalId, VkId)
- Replace Html.DisplayFor with typed <component> tags in UserProfileDetailsViewModel.cshtml
- Add bUnit tests for all new components (null and non-null cases)