### PR TITLE
Fix XSS: PlotRenderer.TodoField — сменить тип с MarkupString на string

### DIFF
--- a/src/JoinRpg.Web.Plots/PlotElementViewModel.cs
+++ b/src/JoinRpg.Web.Plots/PlotElementViewModel.cs
@@ -3,7 +3,7 @@ using static JoinRpg.Web.Plots.PlotStatus;
 
 namespace JoinRpg.Web.Plots;
 
-public record class PlotRenderedTextViewModel(MarkupString Content, MarkupString? Todo, PlotVersionIdentification PlotVersionId, PlotStatus? PlotStatus, TargetsInfo? Target)
+public record class PlotRenderedTextViewModel(MarkupString Content, string? Todo, PlotVersionIdentification PlotVersionId, PlotStatus? PlotStatus, TargetsInfo? Target)
 {
-    public bool HasWorkTodo => !string.IsNullOrWhiteSpace(Todo?.Value) || PlotStatus == InWork || PlotStatus == HasNewVersion;
+    public bool HasWorkTodo => !string.IsNullOrWhiteSpace(Todo) || PlotStatus == InWork || PlotStatus == HasNewVersion;
 }

--- a/src/JoinRpg.Web.Plots/PlotElementsView.razor
+++ b/src/JoinRpg.Web.Plots/PlotElementsView.razor
@@ -40,7 +40,7 @@
                     }
                 </div>
 
-                @if (!string.IsNullOrWhiteSpace(plotText.Todo?.Value))
+                @if (!string.IsNullOrWhiteSpace(plotText.Todo))
                 {
                     <p><b>Доделать</b>: @plotText.Todo</p>
                 }

--- a/src/JoinRpg.WebPortal.Models/Plot/PlotRenderer.cs
+++ b/src/JoinRpg.WebPortal.Models/Plot/PlotRenderer.cs
@@ -3,7 +3,6 @@ using JoinRpg.Domain;
 using JoinRpg.Interfaces;
 using JoinRpg.Markdown;
 using JoinRpg.Web.Plots;
-using Microsoft.AspNetCore.Components;
 
 namespace JoinRpg.Web.Models.Plot;
 
@@ -15,7 +14,7 @@ public static class PlotRenderer
         var masterOrPublishAccess = masterAccess || projectInfo.PublishPlot;
         return new PlotRenderedTextViewModel(
             ((MarkdownString?)self.Content).ToHtmlString(linkRenderer),
-            masterAccess ? new MarkupString(self.TodoField) : null,
+            masterAccess ? self.TodoField : null,
             self.Id,
             masterOrPublishAccess ? self.GetStatus() : null,
             masterOrPublishAccess ? self.Target : null);


### PR DESCRIPTION
TodoField содержит plain text, но оборачивался в MarkupString без HTML-кодирования, что позволяло внедрить произвольный HTML/JS.

Решение: тип поля Todo в PlotRenderedTextViewModel изменён с MarkupString? на string?. Blazor автоматически HTML-кодирует string при рендере через @, защита гарантируется системой типов, а не ручным вызовом энкодера.