### PR TITLE
Не показывать email даже мастерам в сетке ролей

### DIFF
--- a/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
@@ -132,6 +132,34 @@ public class ProjectRoleGridViewModelBuilderTests
     }
 
     [Fact]
+    public void Build_PublicOnly_HidesEmail()
+    {
+        var character = _mock.CreateCharacter("Вася");
+        _mock.Player.Extra = new UserExtra
+        {
+            Vk = "vasya",
+            Telegram = "vasya_tg",
+            Livejournal = "vasya_lj",
+            SocialNetworksAccess = ContactsAccessType.Public,
+        };
+        _mock.Player.ExternalLogins.Add(new UserExternalLogin
+        {
+            Provider = UserExternalLogin.TelegramProvider,
+            Key = "12345",
+        });
+        _mock.CreateApprovedClaim(character, _mock.Player);
+
+        var result = ProjectRoleGridViewModelBuilder.Build(
+            Config(contacts: ProjectRolesListVisibilityMode.PublicOnly), null, canEditSettings: false, [character], _mock.ProjectInfo);
+
+        var contacts = result.Rows.ShouldHaveSingleItem().Player!.Contacts.ShouldNotBeNull();
+        contacts.Email.ShouldBeNull();
+        contacts.Vk.ShouldNotBeNull();
+        contacts.Telegram.ShouldNotBeNull();
+        contacts.LiveJournal.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void Build_ArchivedProject_NeverShowsContacts()
     {
         var character = _mock.CreateCharacter("Вася");

--- a/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
+++ b/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
@@ -117,9 +117,10 @@ internal static class ProjectRoleGridViewModelBuilder
             player.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key,
             PrefferedName.FromOptional(player.Extra?.Telegram));
 
+        // Email — непубличный контакт, показывается только в режиме All.
         // VkVerified не проверяем (как в markdown-рендерере).
         return new UserContacts(
-            Email.FromOptional(player.Email),
+            contactsColumn == ProjectRolesListVisibilityMode.All ? Email.FromOptional(player.Email) : null,
             VkId.FromOptional(player.Extra?.Vk),
             telegram,
             LiveJournalId.FromOptional(player.Extra?.Livejournal));


### PR DESCRIPTION
Если выбраны «только публичные контакты», Email показываться не должен.