### PR TITLE
Заменить IProjectRepository для полей на IProjectMetadataRepository

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectMetadataRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectMetadataRepository.cs
@@ -106,7 +106,8 @@ internal class ProjectMetadataRepository(MyDbContext ctx) : IProjectMetadataRepo
                     fieldSettings,
                         field.ProgrammaticValue,
                         CreateProjectFieldVisibility(field),
-                    CharacterGroupIdentification.FromOptional(projectId, field.CharacterGroupId));
+                    CharacterGroupIdentification.FromOptional(projectId, field.CharacterGroupId),
+                    WasEverUsed: field.WasEverUsed);
             }
 
             static ProjectFieldVisibility CreateProjectFieldVisibility(ProjectField field)
@@ -136,7 +137,8 @@ internal class ProjectMetadataRepository(MyDbContext ctx) : IProjectMetadataRepo
                             CharacterGroupIdentification.FromOptional(projectId, variant.CharacterGroupId),
                             variant.Description,
                             variant.MasterDescription,
-                            variant.ProgrammaticValue
+                            variant.ProgrammaticValue,
+                            wasEverUsed: variant.WasEverUsed
                         );
                 }
             }
@@ -153,7 +155,8 @@ internal class ProjectMetadataRepository(MyDbContext ctx) : IProjectMetadataRepo
                             CharacterGroupIdentification.FromOptional(projectId, variant.CharacterGroupId),
                             variant.Description,
                             variant.MasterDescription,
-                            variant.ProgrammaticValue
+                            variant.ProgrammaticValue,
+                            WasEverUsed: variant.WasEverUsed
                         );
                 }
             }

--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
@@ -70,26 +70,13 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
         return await Ctx.Set<CharacterGroup>().Where(cg => cg.ProjectId == projectId && ids.Contains(cg.CharacterGroupId)).ToListAsync();
     }
 
-    public Task<ProjectField> GetProjectField(ProjectFieldIdentification id) => GetProjectField(id.ProjectId, id.ProjectFieldId);
+    [Obsolete]
     public Task<ProjectField> GetProjectField(int projectId, int projectCharacterFieldId)
     {
         return Ctx.Set<ProjectField>()
           .Include(f => f.Project)
           .Include(f => f.DropdownValues)
           .SingleOrDefaultAsync(f => f.ProjectFieldId == projectCharacterFieldId && f.ProjectId == projectId);
-    }
-
-    public Task<ProjectFieldDropdownValue> GetFieldValue(ProjectFieldIdentification id, int variantId) => GetFieldValue(id.ProjectId, id.ProjectFieldId, variantId);
-    public async Task<ProjectFieldDropdownValue> GetFieldValue(int projectId, int projectFieldId, int projectCharacterFieldDropdownValueId)
-    {
-        return await Ctx.Set<ProjectFieldDropdownValue>()
-          .Include(f => f.Project)
-          .Include(f => f.ProjectField)
-          .SingleOrDefaultAsync(
-            f =>
-              f.ProjectId == projectId &&
-              f.ProjectFieldId == projectFieldId &&
-              f.ProjectFieldDropdownValueId == projectCharacterFieldDropdownValueId);
     }
 
     public Task<Project> GetProjectWithFinances(int projectid)
@@ -105,18 +92,6 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
         .Include(p => p.ProjectFeeSettings)
         .Include(p => p.FinanceOperations)
         .SingleOrDefaultAsync(p => p.ProjectId == projectid);
-
-    public async Task<CharacterGroup> LoadGroupWithTreeSlimAsync(int projectId)
-    {
-        var project1 = await Ctx.ProjectsSet
-          .Include(p => p.CharacterGroups)
-          .Include(p => p.Characters)
-          .Include(p => p.Details)
-          .Where(p => p.ProjectId == projectId)
-          .SingleOrDefaultAsync(p => p.ProjectId == projectId);
-
-        return project1.RootGroup;
-    }
 
     public async Task<IReadOnlyCollection<ProjectWithUpdateDateDto>> GetStaleProjects(
         DateTime inActiveSince)

--- a/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
@@ -15,21 +15,12 @@ public interface IProjectRepository : IDisposable
     Task<CharacterGroup?> GetGroupAsync(CharacterGroupIdentification characterGroupId);
 
     Task<CharacterGroup?> LoadGroupWithTreeAsync(int projectId, int? characterGroupId = null);
-    Task<CharacterGroup> LoadGroupWithTreeSlimAsync(int projectId);
     Task<CharacterGroup> LoadGroupWithChildsAsync(int projectId, int characterGroupId);
 
     Task<IList<CharacterGroup>> LoadGroups(IReadOnlyCollection<CharacterGroupIdentification> groupIds);
 
+    [Obsolete]
     Task<ProjectField> GetProjectField(int projectId, int projectCharacterFieldId);
-
-    Task<ProjectField> GetProjectField(ProjectFieldIdentification projectFieldId);
-
-    Task<ProjectFieldDropdownValue> GetFieldValue(int projectId,
-        int projectFieldId,
-        int projectCharacterFieldDropdownValueId);
-
-    Task<ProjectFieldDropdownValue> GetFieldValue(ProjectFieldIdentification projectFieldId,
-    int projectCharacterFieldDropdownValueId);
 
     Task<Project> GetProjectWithFinances(int projectid);
     Task<Project> GetProjectForFinanceSetup(int projectid);

--- a/src/JoinRpg.DataModel.Mocks/MockedProject.cs
+++ b/src/JoinRpg.DataModel.Mocks/MockedProject.cs
@@ -80,7 +80,8 @@ public class MockedProject
             IncludeInPrint: true, FieldSettings: ProjectInfo.ProjectFieldSettings,
             ProgrammaticValue: null,
             ProjectFieldVisibility: projectFieldVisibility,
-            SpecialGroupId: null
+            SpecialGroupId: null,
+            WasEverUsed: false
             );
 
         ProjectInfo = ProjectInfo.WithAddedField(field);

--- a/src/JoinRpg.Domain.Test/ProjectFieldTypeTests.cs
+++ b/src/JoinRpg.Domain.Test/ProjectFieldTypeTests.cs
@@ -21,7 +21,7 @@ public class ProjectFieldTypeTests
     [ClassData(typeof(EnumTheoryDataGenerator<ProjectFieldType>))]
     public void ShouldBeAbleToCalculatePricing(ProjectFieldType projectFieldType)
     {
-        var field = new ProjectFieldInfo(new ProjectFieldIdentification(new ProjectIdentification(-1), -1), "", projectFieldType, FieldBoundTo.Character, new ProjectFieldVariant[] { }, null!, 1, true, true, MandatoryStatus.Optional, false, true, null!, null!, null!, false, new ProjectFieldSettings(null, null), null, ProjectFieldVisibility.PlayerAndMaster, null);
+        var field = new ProjectFieldInfo(new ProjectFieldIdentification(new ProjectIdentification(-1), -1), "", projectFieldType, FieldBoundTo.Character, new ProjectFieldVariant[] { }, null!, 1, true, true, MandatoryStatus.Optional, false, true, null!, null!, null!, false, new ProjectFieldSettings(null, null), null, ProjectFieldVisibility.PlayerAndMaster, null, WasEverUsed: false);
         var fieldWithValue = new FieldWithValue(field, null);
         _ = Should.NotThrow(fieldWithValue.GetCurrentFee);
     }

--- a/src/JoinRpg.DomainTypes.Test/FieldLayerContainerTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/FieldLayerContainerTest.cs
@@ -573,7 +573,8 @@ ordering,
             new ProjectFieldSettings(null, null),
             null,
             visibility,
-            null
+            null,
+            WasEverUsed: false
         );
     }
 

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectFieldInfo.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectFieldInfo.cs
@@ -24,7 +24,8 @@ public record class ProjectFieldInfo(
     ProjectFieldSettings FieldSettings,
     string? ProgrammaticValue,
     ProjectFieldVisibility ProjectFieldVisibility,
-    CharacterGroupIdentification? SpecialGroupId)
+    CharacterGroupIdentification? SpecialGroupId,
+    bool WasEverUsed)
     : IProjectEntityWithId
 {
     private const string CheckboxValueOn = "on";

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectFieldVariant.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectFieldVariant.cs
@@ -11,7 +11,8 @@ public record class ProjectFieldVariant(
     CharacterGroupIdentification? CharacterGroupId,
     MarkdownString? Description,
     MarkdownString? MasterDescription,
-    string? ProgrammaticValue
+    string? ProgrammaticValue,
+    bool WasEverUsed
     ) : IOrderableEntity
 {
     int IOrderableEntity.Id => Id.ProjectFieldVariantId;

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/TimeSlotFieldVariant.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/TimeSlotFieldVariant.cs
@@ -14,8 +14,9 @@ public record class TimeSlotFieldVariant : ProjectFieldVariant
     CharacterGroupIdentification? CharacterGroupId,
     MarkdownString? Description,
     MarkdownString? MasterDescription,
-    string? ProgrammaticValue)
-        : base(Id, Label, Price, IsPlayerSelectable, IsActive, CharacterGroupId, Description, MasterDescription, ProgrammaticValue)
+    string? ProgrammaticValue,
+    bool wasEverUsed)
+        : base(Id, Label, Price, IsPlayerSelectable, IsActive, CharacterGroupId, Description, MasterDescription, ProgrammaticValue, wasEverUsed)
     {
         if (ProgrammaticValue is not null)
         {

--- a/src/JoinRpg.Integrations.KogdaIgra/SyncKogdaIgraJob.cs
+++ b/src/JoinRpg.Integrations.KogdaIgra/SyncKogdaIgraJob.cs
@@ -12,7 +12,7 @@ internal class SyncKogdaIgraJob(
         logger.LogInformation("Starting KogdaIgra synchronization job");
 
         var status = await kogdaIgraSyncService.GetSyncStatus();
-        var beforePending = int.MaxValue;
+        int beforePending;
         do
         {
             beforePending = status.PendingGamesCount;

--- a/src/JoinRpg.Portal/Controllers/GameFieldController.cs
+++ b/src/JoinRpg.Portal/Controllers/GameFieldController.cs
@@ -1,5 +1,4 @@
 using JoinRpg.Data.Interfaces;
-using JoinRpg.DataModel;
 using JoinRpg.Interfaces;
 using JoinRpg.Portal.Controllers.Common;
 using JoinRpg.Portal.Infrastructure.Authorization;
@@ -30,13 +29,13 @@ public class GameFieldController(
     private RedirectToActionResult ReturnToIndex()
         => RedirectToAction("Index", new { ProjectId = currentProjectAccessor.ProjectId.Value });
 
-    private RedirectToActionResult ReturnToField(ProjectField value)
-        => RedirectToAction("Edit", new { ProjectId = currentProjectAccessor.ProjectId.Value, projectFieldId = value.ProjectFieldId });
+    private RedirectToActionResult ReturnToField(ProjectFieldIdentification projectFieldId)
+        => RedirectToAction("Edit", new { ProjectId = projectFieldId.ProjectId.Value, projectFieldId.ProjectFieldId });
 
 
     [HttpGet("/{ProjectId}/fields/")]
     [MasterAuthorize]
-    public async Task<ActionResult> Index(int projectId)
+    public async Task<ActionResult> Index(ProjectIdentification projectId)
     {
         var model = await Manager.GetActiveAsync();
         return ViewIfFound(model);
@@ -44,7 +43,7 @@ public class GameFieldController(
 
     [HttpGet("/{ProjectId}/fields/archive")]
     [MasterAuthorize]
-    public async Task<ActionResult> DeletedList(int projectId)
+    public async Task<ActionResult> DeletedList(ProjectIdentification projectId)
     {
         var model = await Manager.GetInActiveAsync();
         return ViewIfFound("Index", model);
@@ -52,7 +51,7 @@ public class GameFieldController(
 
     [HttpGet]
     [MasterAuthorize(Permission.CanChangeFields)]
-    public async Task<ActionResult> Create(int projectId)
+    public async Task<ActionResult> Create(ProjectIdentification projectId)
     {
         var model = await Manager.CreatePageAsync();
         return ViewIfFound(model);
@@ -138,21 +137,21 @@ public class GameFieldController(
     [ValidateAntiForgeryToken]
     public async Task<ActionResult> Edit(GameFieldEditViewModel viewModel)
     {
-        var project = await projectRepository.GetProjectAsync(viewModel.ProjectId);
-        var field = project.ProjectFields.SingleOrDefault(e => e.ProjectFieldId == viewModel.ProjectFieldId);
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(viewModel.ProjectId));
+        var field = projectInfo.UnsortedFields.SingleOrDefault(f => f.Id.ProjectFieldId == viewModel.ProjectFieldId);
 
-        if (field == null)
+        if (field is null)
         {
             return NotFound();
         }
         if (!ModelState.IsValid)
         {
-            viewModel.FillNotEditable(field, currentUserAccessor.UserIdentification);
+            viewModel.FillNotEditable(field, projectInfo, currentUserAccessor.UserIdentification);
             return View(viewModel);
         }
         try
         {
-            var request = new UpdateFieldRequest(new ProjectFieldIdentification(new ProjectIdentification(project.ProjectId), field.ProjectFieldId),
+            var request = new UpdateFieldRequest(new ProjectFieldIdentification(new ProjectIdentification(projectInfo.ProjectId), field.Id.ProjectFieldId),
                 viewModel.Name,
                 viewModel.DescriptionEditable,
                 viewModel.CanPlayerEdit,
@@ -174,7 +173,7 @@ public class GameFieldController(
         catch (Exception exception)
         {
             AddModelException(exception);
-            viewModel.FillNotEditable(field, currentUserAccessor.UserIdentification);
+            viewModel.FillNotEditable(field, projectInfo, currentUserAccessor.UserIdentification);
             return View(viewModel);
         }
     }
@@ -182,7 +181,6 @@ public class GameFieldController(
     [HttpPost]
     [ValidateAntiForgeryToken]
     [MasterAuthorize(Permission.CanChangeFields)]
-    // ReSharper disable once UnusedParameter.Global
     public async Task<ActionResult> Delete(int projectId, int projectFieldId, IFormCollection collection)
     {
         var field = await projectRepository.GetProjectField(projectId, projectFieldId);
@@ -216,14 +214,16 @@ public class GameFieldController(
     {
         try
         {
-            var field = await projectRepository.GetProjectField(viewModel.ProjectId, viewModel.ProjectFieldId);
+            var id = new ProjectFieldIdentification(new(viewModel.ProjectId), viewModel.ProjectFieldId);
+            var metadata = await projectMetadataRepository.GetProjectMetadata(id.ProjectId);
+            var field = metadata.GetFieldById(id);
 
-            var timeSlotOptions = viewModel.GetTimeSlotRequest(field, Request.Form["TimeSlotStartTime"].FirstOrDefault());
+            var timeSlotOptions = viewModel.GetTimeSlotRequest(field.IsTimeSlot, Request.Form["TimeSlotStartTime"].FirstOrDefault());
 
             await
                 fieldSetupService.CreateFieldValueVariant(
                     new CreateFieldValueVariantRequest(
-                        new(new ProjectIdentification(viewModel.ProjectId), viewModel.ProjectFieldId),
+                        id,
                         viewModel.Label,
                         viewModel.Description,
                         viewModel.MasterDescription,
@@ -263,9 +263,12 @@ public class GameFieldController(
     {
         try
         {
-            var field = await projectRepository.GetProjectField(viewModel.ProjectId, viewModel.ProjectFieldId);
+            var id = new ProjectFieldIdentification(new(viewModel.ProjectId), viewModel.ProjectFieldId);
+            var metadata = await projectMetadataRepository.GetProjectMetadata(id.ProjectId);
+            var field = metadata.GetFieldById(id);
+
             await fieldSetupService.UpdateFieldValueVariant(new UpdateFieldValueVariantRequest(
-                new(new ProjectIdentification(viewModel.ProjectId), viewModel.ProjectFieldId),
+                id,
                 viewModel.ProjectFieldDropdownValueId,
                 viewModel.Label,
                 viewModel.Description,
@@ -273,7 +276,7 @@ public class GameFieldController(
                 viewModel.ProgrammaticValue,
                 viewModel.Price,
                 viewModel.PlayerSelectable,
-                viewModel.GetTimeSlotRequest(field, Request.Form["TimeSlotStartTime"].FirstOrDefault())
+                viewModel.GetTimeSlotRequest(field.IsTimeSlot, Request.Form["TimeSlotStartTime"].FirstOrDefault())
                 ));
 
             return RedirectToAction("Edit", new { viewModel.ProjectId, projectFieldId = viewModel.ProjectFieldId });
@@ -305,15 +308,20 @@ public class GameFieldController(
     {
         try
         {
-            var value = await projectRepository.GetFieldValue(projectId, projectFieldId, valueId);
-
-            if (value == null)
+            var metadata = await projectMetadataRepository.GetProjectMetadata(new(projectId));
+            var field = metadata.UnsortedFields.SingleOrDefault(f => f.Id.ProjectFieldId == projectFieldId);
+            if (field is null)
+            {
+                return NotFound();
+            }
+            var variant = field.Variants.SingleOrDefault(v => v.Id.ProjectFieldVariantId == valueId);
+            if (variant is null)
             {
                 return NotFound();
             }
 
-            _ = await fieldSetupService.DeleteFieldValueVariant(value.ProjectId, value.ProjectFieldId, value.ProjectFieldDropdownValueId);
-            return value.IsActive
+            _ = await fieldSetupService.DeleteFieldValueVariant(projectId, projectFieldId, valueId);
+            return variant.IsActive
                 ? Ok()
                 : StatusCode(250);
         }
@@ -330,9 +338,8 @@ public class GameFieldController(
     [HttpGet("~/{projectId:int}/fields/{listItemId:int}/move/{direction:int}")]
     public async Task<ActionResult> Move(int projectId, int listItemId, int direction)
     {
-        var value = await projectRepository.GetProjectField(projectId, listItemId);
-
-        if (value == null)
+        var metadata = await projectMetadataRepository.GetProjectMetadata(new(projectId));
+        if (metadata.UnsortedFields.All(f => f.Id.ProjectFieldId != listItemId))
         {
             return NotFound();
         }
@@ -352,11 +359,10 @@ public class GameFieldController(
     [MasterAuthorize(Permission.CanChangeFields)]
     // TODO: Refactor to HEAD request (require UI fixes)
     [HttpGet("~/{projectId:int}/fields/{parentObjectId:int}/values/{listItemId:int}/move/{direction:int}")]
-    public async Task<ActionResult> MoveValue(int projectId, int listItemId, int parentObjectId, int direction)
+    public async Task<ActionResult> MoveValue(ProjectIdentification projectId, int listItemId, int parentObjectId, int direction)
     {
-        var value = await projectRepository.GetProjectField(projectId, parentObjectId);
-
-        if (value == null)
+        var metadata = await projectMetadataRepository.GetProjectMetadata(projectId);
+        if (metadata.UnsortedFields.All(f => f.Id.ProjectFieldId != parentObjectId))
         {
             return NotFound();
         }
@@ -365,12 +371,11 @@ public class GameFieldController(
         {
             await fieldSetupService.MoveFieldVariant(projectId, parentObjectId, listItemId, (short)direction);
 
-
-            return ReturnToField(value);
+            return ReturnToField(new ProjectFieldIdentification(projectId, parentObjectId));
         }
         catch
         {
-            return ReturnToField(value);
+            return ReturnToField(new ProjectFieldIdentification(projectId, parentObjectId));
         }
     }
 
@@ -378,9 +383,8 @@ public class GameFieldController(
     public async Task<ActionResult> MassCreateValueVariants(int projectId, int projectFieldId, string valuesToAdd)
     {
         var id = new ProjectFieldIdentification(new(projectId), projectFieldId);
-        var value = await projectRepository.GetProjectField(id);
-
-        if (value == null)
+        var metadata = await projectMetadataRepository.GetProjectMetadata(id.ProjectId);
+        if (metadata.UnsortedFields.All(f => f.Id.ProjectFieldId != id.ProjectFieldId))
         {
             return NotFound();
         }
@@ -389,21 +393,19 @@ public class GameFieldController(
         {
             await fieldSetupService.CreateFieldValueVariants(id, valuesToAdd);
 
-
-            return ReturnToField(value);
+            return ReturnToField(id);
         }
         catch
         {
-            return ReturnToField(value);
+            return ReturnToField(id);
         }
     }
 
     [HttpPost, MasterAuthorize(Permission.CanChangeFields)]
     public async Task<ActionResult> MoveFast(int projectId, int projectFieldId, int? afterFieldId)
     {
-        var value = await projectRepository.GetProjectField(projectId, projectFieldId);
-
-        if (value == null)
+        var metadata = await projectMetadataRepository.GetProjectMetadata(new(projectId));
+        if (metadata.UnsortedFields.All(f => f.Id.ProjectFieldId != projectFieldId))
         {
             return NotFound();
         }
@@ -417,7 +419,6 @@ public class GameFieldController(
         {
             await fieldSetupService.MoveFieldAfter(projectId, projectFieldId, afterFieldId);
 
-
             return ReturnToIndex();
         }
         catch
@@ -430,9 +431,8 @@ public class GameFieldController(
     [HttpPost("~/{projectId:int}/fields/{projectFieldId:int}/sortvariants")]
     public async Task<ActionResult> SortVariants(int projectId, int projectFieldId)
     {
-        var value = await projectRepository.GetProjectField(projectId, projectFieldId);
-
-        if (value == null)
+        var metadata = await projectMetadataRepository.GetProjectMetadata(new(projectId));
+        if (metadata.UnsortedFields.All(f => f.Id.ProjectFieldId != projectFieldId))
         {
             return NotFound();
         }
@@ -440,7 +440,6 @@ public class GameFieldController(
         try
         {
             await fieldSetupService.SortFieldVariants(projectId, projectFieldId);
-
 
             return ReturnToIndex();
         }

--- a/src/JoinRpg.Services.Impl/Projects/IProjectPropsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/IProjectPropsService.cs
@@ -62,4 +62,4 @@ internal interface IProjectPropsService
         [CallerMemberName] string operationName = "");
 }
 
-record ProjectOperationContext<TArgs>(Project Project, ProjectInfo ProjectInfo, DateTimeOffset Now, ICurrentUserAccessor CurrentUser, TArgs Request);
+internal record ProjectOperationContext<TArgs>(Project Project, ProjectInfo ProjectInfo, DateTimeOffset Now, ICurrentUserAccessor CurrentUser, TArgs Request);

--- a/src/JoinRpg.WebPortal.Managers/Fields/FieldSetupManager.cs
+++ b/src/JoinRpg.WebPortal.Managers/Fields/FieldSetupManager.cs
@@ -1,6 +1,4 @@
 using JoinRpg.Data.Interfaces;
-using JoinRpg.DataModel;
-using JoinRpg.Domain;
 using JoinRpg.Interfaces;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.CommonTypes;
@@ -15,7 +13,7 @@ namespace JoinRpg.WebPortal.Managers;
 public class FieldSetupManager
 {
     private ICurrentUserAccessor CurrentUser { get; }
-    private IProjectRepository ProjectRepository { get; }
+    private IProjectMetadataRepository ProjectMetadataRepository { get; }
     private ICurrentProjectAccessor CurrentProject { get; }
     private IFieldSetupService Service { get; }
 
@@ -24,13 +22,13 @@ public class FieldSetupManager
     /// </summary>
     public FieldSetupManager(
         ICurrentUserAccessor currentUser,
-        IProjectRepository project,
+        IProjectMetadataRepository projectMetadataRepository,
         ICurrentProjectAccessor currentProject,
         IFieldSetupService service
         )
     {
         CurrentUser = currentUser;
-        ProjectRepository = project;
+        ProjectMetadataRepository = projectMetadataRepository;
         CurrentProject = currentProject;
         Service = service;
     }
@@ -50,32 +48,20 @@ public class FieldSetupManager
     /// </summary>
     public async Task<GameFieldCreateViewModel?> CreatePageAsync()
     {
-        var project = await ProjectRepository.GetProjectWithFieldsAsync(CurrentProject.ProjectId);
-        if (project == null)
-        {
-            return null;
-        }
-        return FillFromProject(project, new GameFieldCreateViewModel());
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
+        return FillFromProject(projectInfo, new GameFieldCreateViewModel());
     }
 
     public async Task<T?> FillFailedModel<T>(T model) where T : class, IFieldNavigationAware
     {
-        var project = await ProjectRepository.GetProjectWithFieldsAsync(CurrentProject.ProjectId);
-        if (project == null)
-        {
-            return null;
-        }
-        return FillFromProject(project, model);
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
+        return FillFromProject(projectInfo, model);
     }
 
     public async Task<FieldSettingsViewModel?> FillFailedSettingsModel(FieldSettingsViewModel model)
     {
-        var project = await ProjectRepository.GetProjectWithFieldsAsync(CurrentProject.ProjectId);
-        if (project == null)
-        {
-            return null;
-        }
-        return FillSettingsModel(project, model);
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
+        return FillSettingsModel(projectInfo, model);
     }
 
     /// <summary>
@@ -83,14 +69,15 @@ public class FieldSetupManager
     /// </summary>
     public async Task<GameFieldEditViewModel?> EditPageAsync(int projectFieldId)
     {
-        var field = await ProjectRepository.GetProjectField(CurrentProject.ProjectId, projectFieldId);
-        if (field == null)
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
+        var field = projectInfo.UnsortedFields.SingleOrDefault(f => f.Id.ProjectFieldId == projectFieldId);
+        if (field is null)
         {
             return null;
         }
 
-        var model = new GameFieldEditViewModel(field, CurrentUser.UserId);
-        return FillFromProject(field.Project, model);
+        var model = new GameFieldEditViewModel(field, projectInfo, CurrentUser.UserIdentification);
+        return FillFromProject(projectInfo, model);
     }
 
     /// <summary>
@@ -98,36 +85,32 @@ public class FieldSetupManager
     /// </summary>
     public async Task<FieldSettingsViewModel?> SettingsPagesAsync()
     {
-        var project = await ProjectRepository.GetProjectWithFieldsAsync(CurrentProject.ProjectId);
-        if (project == null)
-        {
-            return null;
-        }
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
 
         var viewModel = new FieldSettingsViewModel
         {
-            NameField = project.Details.CharacterNameField?.ProjectFieldId ?? -1,
-            DescriptionField = project.Details.CharacterDescription?.ProjectFieldId ?? -1,
+            NameField = projectInfo.CharacterNameField?.Id.ProjectFieldId ?? -1,
+            DescriptionField = projectInfo.CharacterDescriptionField?.Id.ProjectFieldId ?? -1,
         };
-        return FillSettingsModel(project, viewModel);
+        return FillSettingsModel(projectInfo, viewModel);
     }
 
-    private FieldSettingsViewModel FillSettingsModel(Project project, FieldSettingsViewModel viewModel)
+    private FieldSettingsViewModel FillSettingsModel(ProjectInfo projectInfo, FieldSettingsViewModel viewModel)
     {
-        var fields = project.GetOrderedFields();
+        var fields = projectInfo.SortedFields;
         viewModel.PossibleDescriptionFields =
                 ToSelectListItems(
-                    fields.Where(f => f.FieldType == ProjectFieldType.Text && f.FieldBoundTo == FieldBoundTo.Character),
+                    fields.Where(f => f.Type == ProjectFieldType.Text && f.BoundTo == FieldBoundTo.Character),
                     "Нет поля с описанием персонажа"
-                    ).SetSelected(project.Details.CharacterDescription?.ProjectFieldId);
+                    ).SetSelected(projectInfo.CharacterDescriptionField?.Id.ProjectFieldId);
         viewModel.PossibleNameFields =
                 ToSelectListItems(
-                    fields.Where(f => f.FieldType == ProjectFieldType.String && f.FieldBoundTo == FieldBoundTo.Character),
+                    fields.Where(f => f.Type == ProjectFieldType.String && f.BoundTo == FieldBoundTo.Character),
                     "Имя персонажа берется из имени игрока"
-                    ).SetSelected(project.Details.CharacterNameField?.ProjectFieldId);
+                    ).SetSelected(projectInfo.CharacterNameField?.Id.ProjectFieldId);
 
         // cast needed to call correct method
-        var _ = FillFromProject(project, viewModel);
+        var _ = FillFromProject(projectInfo, viewModel);
         return viewModel;
     }
 
@@ -145,14 +128,14 @@ public class FieldSetupManager
     }
 
     private List<JoinSelectListItem> ToSelectListItems(
-        IEnumerable<ProjectField> enumerable,
+        IEnumerable<ProjectFieldInfo> enumerable,
         string? notSelectedName = null
         )
     {
         var list = enumerable.Select(field => new JoinSelectListItem()
         {
-            Value = field.ProjectFieldId,
-            Text = field.FieldName,
+            Value = field.Id.ProjectFieldId,
+            Text = field.Name,
 
         }).ToList();
 
@@ -171,35 +154,31 @@ public class FieldSetupManager
 
     private async Task<GameFieldListViewModel?> GetFieldsImpl(
         FieldNavigationPage page,
-        Func<ProjectField, bool> predicate)
+        Func<ProjectFieldInfo, bool> predicate)
     {
-        var project = await ProjectRepository.GetProjectWithFieldsAsync(CurrentProject.ProjectId);
-        if (project == null)
-        {
-            return null;
-        }
-        var fields = project.GetOrderedFields().Where(predicate).ToViewModels(CurrentUser.UserId);
-        FieldNavigationModel navigation = GetNavigation(page, project);
+        var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(CurrentProject.ProjectId);
+        var fields = projectInfo.SortedFields.Where(predicate).ToViewModels(projectInfo, CurrentUser.UserIdentification);
+        FieldNavigationModel navigation = GetNavigation(page, projectInfo);
         return new GameFieldListViewModel(navigation, fields);
     }
 
-    private FieldNavigationModel GetNavigation(FieldNavigationPage page, Project project)
+    private FieldNavigationModel GetNavigation(FieldNavigationPage page, ProjectInfo projectInfo)
     {
         return new FieldNavigationModel
         {
             Page = page,
-            ProjectId = project.ProjectId,
-            CanEditFields = project.HasMasterAccess(CurrentUser, Permission.CanChangeFields)
-                && project.Active,
+            ProjectId = projectInfo.ProjectId,
+            CanEditFields = projectInfo.HasMasterAccess(CurrentUser.UserIdentification, Permission.CanChangeFields)
+                && projectInfo.IsActive,
         };
     }
 
     private T FillFromProject<T>(
-        Project project,
+        ProjectInfo projectInfo,
         T viewModel) where T : IFieldNavigationAware
     {
-        viewModel.SetNavigation(GetNavigation(FieldNavigationPage.Unknown, project));
-        viewModel.ProjectId = project.ProjectId;
+        viewModel.SetNavigation(GetNavigation(FieldNavigationPage.Unknown, projectInfo));
+        viewModel.ProjectId = projectInfo.ProjectId;
         return viewModel;
     }
 }

--- a/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldDropdownValueListItemViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldDropdownValueListItemViewModel.cs
@@ -1,4 +1,3 @@
-using JoinRpg.DataModel;
 using JoinRpg.Markdown;
 
 namespace JoinRpg.Web.Models.FieldSetup;
@@ -27,17 +26,17 @@ public class GameFieldDropdownValueListItemViewModel : IMovableListItem
 
     public int ValueId { get; }
 
-    public GameFieldDropdownValueListItemViewModel(ProjectFieldDropdownValue value)
+    public GameFieldDropdownValueListItemViewModel(ProjectFieldVariant variant, bool canPlayerEdit)
     {
-        Label = value.Label;
-        Description = ((MarkdownString?)value.Description).ToPlainTextWithoutHtmlEscape();
-        IsActive = value.IsActive;
-        Price = value.Price;
-        ProjectId = value.ProjectId;
-        ProjectFieldId = value.ProjectFieldId;
-        ValueId = value.ProjectFieldDropdownValueId;
-        CharacterGroupId = value.CharacterGroupId;
-        MasterRestricted = !value.PlayerSelectable && value.ProjectField.CanPlayerEdit;
+        Label = variant.Label;
+        Description = variant.Description.ToPlainTextWithoutHtmlEscape();
+        IsActive = variant.IsActive;
+        Price = variant.Price;
+        ProjectId = variant.Id.FieldId.ProjectId;
+        ProjectFieldId = variant.Id.FieldId.ProjectFieldId;
+        ValueId = variant.Id.ProjectFieldVariantId;
+        CharacterGroupId = variant.CharacterGroupId?.CharacterGroupId;
+        MasterRestricted = !variant.IsPlayerSelectable && canPlayerEdit;
     }
 
     #region Implementation of IMovableListItem

--- a/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldDropdownValueViewModelBase.cs
+++ b/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldDropdownValueViewModelBase.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel;
-using JoinRpg.DataModel;
-using JoinRpg.Domain;
 
 namespace JoinRpg.Web.Models.FieldSetup;
 
@@ -58,9 +56,9 @@ public abstract class GameFieldDropdownValueViewModelBase
 
     public GameFieldDropdownValueViewModelBase() { }
 
-    public TimeSlotOptions? GetTimeSlotRequest(ProjectField field, string? value)
+    public TimeSlotOptions? GetTimeSlotRequest(bool isTimeSlot, string? value)
     {
-        return value is not null && field.IsTimeSlot()
+        return value is not null && isTimeSlot
             ? new TimeSlotOptions
             {
                 StartTime = DateTimeOffset.ParseExact(

--- a/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldEditViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldEditViewModel.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel;
-using JoinRpg.DataModel;
-using JoinRpg.Domain;
 using JoinRpg.Markdown;
 using JoinRpg.Web.ProjectCommon.Fields;
 
@@ -31,49 +29,43 @@ public class GameFieldEditViewModel : GameFieldViewModelBase, IMovableListItem
 
     public string[] GroupNames { get; set; }
 
-    public GameFieldEditViewModel(ProjectField field, int currentUserId)
+    public GameFieldEditViewModel(ProjectFieldInfo field, ProjectInfo projectInfo, UserIdentification userId)
     {
         CanPlayerView = field.CanPlayerView;
         CanPlayerEdit = field.CanPlayerEdit;
-        DescriptionEditable = field.Description?.Contents ?? "";
-        MasterDescriptionEditable = field.MasterDescription?.Contents ?? "";
-        DescriptionDisplay = ((MarkdownString?)field.Description).ToHtmlString();
-        MasterDescriptionDisplay = ((MarkdownString?)field.MasterDescription).ToHtmlString();
-        ProjectFieldId = field.ProjectFieldId;
+        DescriptionEditable = field.Description?.Value ?? "";
+        MasterDescriptionEditable = field.MasterDescription?.Value ?? "";
+        DescriptionDisplay = field.Description.ToHtmlString();
+        MasterDescriptionDisplay = field.MasterDescription.ToHtmlString();
+        ProjectFieldId = field.Id.ProjectFieldId;
         IsPublic = field.IsPublic;
-        Name = field.FieldName;
-        ProjectId = field.ProjectId;
+        Name = field.Name;
+        ProjectId = field.Id.ProjectId;
         MandatoryStatus = (MandatoryStatusViewType)field.MandatoryStatus;
-        ShowForGroups = field
-            .GroupsAvailableFor
-            .Select(c => c.GetId())
-            .ToArray();
-        GroupNames = field.GroupsAvailableFor.Select(c => c.CharacterGroupName).ToArray();
+        ShowForGroups = [.. field.GroupsAvailableForIds];
+        GroupNames = [.. projectInfo.GetGroupsById(field.GroupsAvailableForIds).Select(g => g.Name)];
         IncludeInPrint = field.IncludeInPrint;
         ValidForNpc = field.ValidForNpc;
         ShowForUnApprovedClaim = field.ShowOnUnApprovedClaims;
         Price = field.Price;
         ProgrammaticValue = field.ProgrammaticValue ?? "";
-
-        FillNotEditable(field, currentUserId);
+        FillNotEditable(field, projectInfo, userId);
     }
 
-    public void FillNotEditable(ProjectField field, int currentUserId)
+    public void FillNotEditable(ProjectFieldInfo field, ProjectInfo projectInfo, UserIdentification userId)
     {
-        DropdownValues = field.GetOrderedValues()
-            .Select(fv => new GameFieldDropdownValueListItemViewModel(fv))
+        DropdownValues = field.SortedVariants
+            .Select(v => new GameFieldDropdownValueListItemViewModel(v, field.CanPlayerEdit))
             .MarkFirstAndLast();
-        FieldViewType = (ProjectFieldViewType)field.FieldType;
-        FieldBoundTo = (FieldBoundToViewModel)field.FieldBoundTo;
+        FieldViewType = (ProjectFieldViewType)field.Type;
+        FieldBoundTo = (FieldBoundToViewModel)field.BoundTo;
         IsActive = field.IsActive;
-        HasValueList = field.HasValueList();
+        HasValueList = field.HasValueList;
         WasEverUsed = field.WasEverUsed;
-        CanEditFields = field.HasMasterAccess(new UserIdentification(currentUserId), Permission.CanChangeFields);
-        CanDeleteField = CanEditFields && !field.IsName() && !field.IsRoomSlot() && !field.IsTimeSlot();
-        SupportsMassAdding = field.SupportsMassAdding();
-
+        CanEditFields = projectInfo.HasMasterAccess(userId, Permission.CanChangeFields);
+        CanDeleteField = CanEditFields && !field.IsName && !field.IsRoomSlot && !field.IsTimeSlot;
+        SupportsMassAdding = field.SupportsMassAdding;
     }
-
     public GameFieldEditViewModel()
     { }
 

--- a/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldViewModelsExtensions.cs
+++ b/src/JoinRpg.WebPortal.Models/FieldSetup/GameFieldViewModelsExtensions.cs
@@ -1,8 +1,10 @@
-using JoinRpg.DataModel;
-
 namespace JoinRpg.Web.Models.FieldSetup;
 
 public static class GameFieldViewModelsExtensions
 {
-    public static IEnumerable<GameFieldEditViewModel> ToViewModels(this IEnumerable<ProjectField> gameFields, int currentUserId) => gameFields.Select(pf => new GameFieldEditViewModel(pf, currentUserId)).MarkFirstAndLast();
+    public static IEnumerable<GameFieldEditViewModel> ToViewModels(
+        this IEnumerable<ProjectFieldInfo> fields,
+        ProjectInfo projectInfo,
+        UserIdentification userId)
+        => fields.Select(f => new GameFieldEditViewModel(f, projectInfo, userId)).MarkFirstAndLast();
 }


### PR DESCRIPTION
- Добавить WasEverUsed в ProjectFieldVariant, ProjectFieldInfo, TimeSlotFieldVariant
- Заполнять WasEverUsed из БД в ProjectMetadataRepository
- Добавить конструкторы view-моделей из доменных типов: GameFieldDropdownValueListItemViewModel(ProjectFieldVariant, bool), GameFieldEditViewModel(ProjectFieldInfo, ProjectInfo, UserIdentification), FillNotEditable(ProjectFieldInfo, ProjectInfo, UserIdentification), ToViewModels(IEnumerable<ProjectFieldInfo>, ProjectInfo, UserIdentification)
- GetTimeSlotRequest(bool isTimeSlot, string?) вместо перегрузки с ProjectField
- FieldSetupManager полностью переведён на IProjectMetadataRepository (убран IProjectRepository)
- GameFieldController: все null-проверки полей и вариантов через метаданные; Edit POST переведён на метаданные вместо GetProjectAsync