### PR TITLE
feat: Handle Telegram bot blocked by user

### DIFF
--- a/src/JoinRpg.Common.PrimitiveTypes/SendingResult.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/SendingResult.cs
@@ -15,5 +15,6 @@ public record struct SendingResult(bool Succeeded, bool Repeatable, bool Common)
     public static SendingResult Success() => new(true, false, false);
 
     public static SendingResult RepeatableFailure() => new(false, true, false);
+    public static SendingResult UserRelatedFailure() => new(false, true, false);
     public static SendingResult CommonFailure() => new(false, true, true);
 }

--- a/src/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
+++ b/src/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
@@ -9,6 +9,19 @@ namespace JoinRpg.Common.Telegram.Test;
 public class TelegramNotificationServiceImplTimeoutTest
 {
     [Fact]
+    public async Task SendTelegramNotification_WithBotBlockedException_ReturnsUserRelatedFailure()
+    {
+        var handler = new ThrowingHttpMessageHandler(new ApiRequestException("Forbidden: bot was blocked by the user", 403));
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.telegram.org") };
+        var botClient = new TelegramBotClient("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11", httpClient);
+        var service = new TelegramNotificationServiceImpl(botClient, NullLogger<TelegramNotificationServiceImpl>.Instance);
+
+        var result = await service.SendTelegramNotification(new TelegramId(1, null), new TelegramHtmlString("test"));
+
+        result.ShouldBe(SendingResult.UserRelatedFailure());
+    }
+
+    [Fact]
     public async Task SendTelegramNotification_WithTimeoutException_ReturnsCommonFailure()
     {
         var handler = new ThrowingHttpMessageHandler(new TimeoutException("Request timed out"));

--- a/src/JoinRpg.Common.Telegram/TelegramNotificationServiceImpl.cs
+++ b/src/JoinRpg.Common.Telegram/TelegramNotificationServiceImpl.cs
@@ -32,6 +32,12 @@ internal class TelegramNotificationServiceImpl(TelegramBotClient client, ILogger
             logger.LogInformation("Отправлено сообщение пользователю в телеграм {telegramId}", telegramId);
             return SendingResult.Success();
         }
+        catch (ApiRequestException exception) when (exception.Message.Contains("bot was blocked by the user", StringComparison.OrdinalIgnoreCase))
+        {
+            CountError("blocked");
+            logger.LogWarning("Пользователь {telegramId} заблокировал бота", telegramId);
+            return SendingResult.UserRelatedFailure();
+        }
         catch (ApiRequestException exception)
         {
             CountError("api");


### PR DESCRIPTION
Closes #4431

- Added SendingResult.UserRelatedFailure()
- Handle ApiRequestException "bot was blocked by the user" in TelegramNotificationServiceImpl
- Log specialized message when user blocks the bot
- Count error_type=blocked metric
- Added unit test

Generated with [Claude Code](https://claude.ai/code)