### PR TITLE
fix: убрать служебный префикс ProjectName из заголовков уведомлений

### DIFF
--- a/src/JoinRpg.Services.Impl/ForumNotificationService.cs
+++ b/src/JoinRpg.Services.Impl/ForumNotificationService.cs
@@ -19,7 +19,7 @@ internal class ForumNotificationService(
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(model.ForumCommentId.ProjectId);
         var forumThread = await forumRepository.GetThreadHeader(model.ForumCommentId.ThreadId);
 
-        var header = $"{projectInfo.ProjectName}: тема на форуме {forumThread.Header}";
+        var header = $"{projectInfo.ProjectName.Value}: тема на форуме {forumThread.Header}";
 
         var text1 =
 $@"Добрый день, %recepient.name%

--- a/src/JoinRpg.Services.Impl/MassProjectEmailService.cs
+++ b/src/JoinRpg.Services.Impl/MassProjectEmailService.cs
@@ -86,7 +86,7 @@ public partial class MassProjectEmailService(
 
         var notification = new NotificationEvent(NotificationClass.MassProjectEmails,
                                                  plotElementId,
-                                                 Header: $@"{project.ProjectName}: опубликована вводная",
+                                                 Header: $@"{project.ProjectName.Value}: опубликована вводная",
                                                  template,
                                                  recipients,
                                                  currentUserAccessor.UserIdentification);


### PR DESCRIPTION
## Что сделано

- `MassProjectEmailService.cs`: заменено `{project.ProjectName}` на `{project.ProjectName.Value}` в заголовке уведомления о вводной
- `ForumNotificationService.cs`: заменено `{projectInfo.ProjectName}` на `{projectInfo.ProjectName.Value}` в заголовке уведомления форума

Теперь вместо `ProjectName(ДЮНА 2026): опубликована вводная` отображается `ДЮНА 2026: опубликована вводная`.

Closes #4436

Generated with [Claude Code](https://claude.ai/code)