### PR TITLE
Копировать сетки ролей при клонировании проекта

### DIFF
--- a/src/JoinRpg.IntegrationTests/Scenarios/CloneProjectScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/CloneProjectScenario.cs
@@ -1,0 +1,169 @@
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.ProjectMetadata;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.IntegrationTest.Scenarios;
+
+public class CloneProjectScenario(JoinApplicationFactory factory) : IClassFixture<JoinApplicationFactory>
+{
+    [Fact]
+    public async Task CloneProject_WithRolesLists_CopiesThemToNewProject()
+    {
+        UserIdentification masterId;
+        ProjectIdentification originalProjectId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            masterId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+            originalProjectId = await TestUserProjectHelpers.CreateProjectAsync(
+                scope.ServiceProvider, masterId, "Исходный проект для клонирования");
+        }
+
+        string rolesListAName = "Публичная сетка";
+        string rolesListBName = "Сетка по группе";
+
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+            var fieldSetupService = sp.GetRequiredService<IFieldSetupService>();
+            var characterGroupService = sp.GetRequiredService<ICharacterGroupService>();
+            var characterService = sp.GetRequiredService<ICharacterService>();
+            var rolesListService = sp.GetRequiredService<IProjectRolesListService>();
+
+            var projectInfo = await metadataRepository.GetProjectMetadata(originalProjectId);
+            var rootGroupId = projectInfo.RootCharacterGroupId;
+            var nameFieldId = (projectInfo.CharacterNameField
+                ?? throw new InvalidOperationException("В проекте нет поля имени"))
+                .Id.ProjectFieldId;
+
+            // Строковое поле для колонки сетки
+            var extraFieldId = await fieldSetupService.AddField(new CreateFieldRequest(
+                originalProjectId,
+                ProjectFieldType.String,
+                "Цитата",
+                fieldHint: "",
+                canPlayerEdit: false,
+                canPlayerView: true,
+                isPublic: true,
+                fieldBoundTo: FieldBoundTo.Character,
+                MandatoryStatus.Optional,
+                showForGroups: [],
+                validForNpc: false,
+                includeInPrint: false,
+                showForUnapprovedClaims: false,
+                price: 0,
+                masterFieldHint: "",
+                programmaticValue: null));
+
+            // Группа персонажей
+            var groupId = await characterGroupService.AddCharacterGroup(
+                originalProjectId,
+                "Северяне",
+                isPublic: true,
+                parentCharacterGroupIds: [rootGroupId],
+                description: "");
+
+            // Шаблонный персонаж
+            await characterService.AddCharacter(new AddCharacterRequest(
+                originalProjectId,
+                ParentCharacterGroupIds: [rootGroupId],
+                new CharacterTypeInfo(CharacterType.Slot, IsHot: false, SlotLimit: 5, SlotName: "Северянин", CharacterVisibility.Public),
+                FieldValues: new Dictionary<int, string?> { [nameFieldId] = "Шаблон Северянина" }));
+
+            // Сетка A: от корня, со строковым полем
+            await rolesListService.CreateAsync(new ProjectRolesList(
+                new ProjectRolesListIdentification(originalProjectId, -1),
+                rolesListAName,
+                CharacterGroupId: null,
+                PublicMode: true,
+                Fields: [extraFieldId],
+                ContactsColumn: ProjectRolesListVisibilityMode.None,
+                GroupsColumn: ProjectRolesListVisibilityMode.PublicOnly,
+                ShowCharacterGroups: true,
+                ShowRolesFilter: ShowRolesFilter.All));
+
+            // Сетка B: от конкретной группы, без полей
+            await rolesListService.CreateAsync(new ProjectRolesList(
+                new ProjectRolesListIdentification(originalProjectId, -1),
+                rolesListBName,
+                CharacterGroupId: groupId,
+                PublicMode: false,
+                Fields: [],
+                ContactsColumn: ProjectRolesListVisibilityMode.None,
+                GroupsColumn: ProjectRolesListVisibilityMode.None,
+                ShowCharacterGroups: false,
+                ShowRolesFilter: ShowRolesFilter.VacantOnly));
+        });
+
+        // Клонирование проекта на уровне SettingsFieldsGroupsAndTemplates
+        var cloneProjectId = await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var createProjectService = sp.GetRequiredService<ICreateProjectService>();
+            var result = await createProjectService.CreateProject(
+                new CloneProjectRequest(
+                    new ProjectName("Клон проекта"),
+                    originalProjectId,
+                    ProjectCopySettingsDto.SettingsFieldsGroupsAndTemplates));
+
+            return result switch
+            {
+                SuccessCreateProjectResult r => r.ProjectId,
+                PartiallySuccessCreateProjectResult r => r.ProjectId,
+                _ => throw new InvalidOperationException($"Не удалось склонировать проект: {result}")
+            };
+        });
+
+        // Проверяем, что сетки ролей скопировались
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+            var cloneInfo = await metadataRepository.GetProjectMetadata(cloneProjectId);
+
+            cloneInfo.ProjectRolesLists.Count.ShouldBe(2);
+
+            foreach (var rolesList in cloneInfo.ProjectRolesLists)
+            {
+                // Все сетки принадлежат новому проекту
+                rolesList.ProjectRolesListId.ProjectId.ShouldBe(cloneProjectId);
+
+                // Поля ссылаются на новый проект
+                foreach (var field in rolesList.Fields)
+                {
+                    field.ProjectId.ShouldBe(cloneProjectId);
+                }
+
+                // CharacterGroupId, если задан, ссылается на новый проект
+                if (rolesList.CharacterGroupId is { } cgId)
+                {
+                    cgId.ProjectId.ShouldBe(cloneProjectId);
+                }
+            }
+
+            var names = cloneInfo.ProjectRolesLists.Select(r => r.Name).ToHashSet();
+            names.ShouldContain(rolesListAName);
+            names.ShouldContain(rolesListBName);
+
+            // Сетка A: без привязки к группе, с полем, публичная
+            var cloneA = cloneInfo.ProjectRolesLists.Single(r => r.Name == rolesListAName);
+            cloneA.CharacterGroupId.ShouldBeNull();
+            cloneA.Fields.Count.ShouldBe(1);
+            cloneA.PublicMode.ShouldBeTrue();
+            cloneA.GroupsColumn.ShouldBe(ProjectRolesListVisibilityMode.PublicOnly);
+            cloneA.ShowRolesFilter.ShouldBe(ShowRolesFilter.All);
+
+            // Сетка B: с привязкой к группе, без полей, приватная
+            var cloneB = cloneInfo.ProjectRolesLists.Single(r => r.Name == rolesListBName);
+            cloneB.CharacterGroupId.ShouldNotBeNull();
+            cloneB.Fields.Count.ShouldBe(0);
+            cloneB.PublicMode.ShouldBeFalse();
+            cloneB.ShowCharacterGroups.ShouldBeFalse();
+            cloneB.ShowRolesFilter.ShouldBe(ShowRolesFilter.VacantOnly);
+        });
+    }
+}

--- a/src/JoinRpg.Services.Impl/Projects/CloneProjectHelper.cs
+++ b/src/JoinRpg.Services.Impl/Projects/CloneProjectHelper.cs
@@ -6,6 +6,7 @@ using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Plots;
 using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.ProjectMetadata;
 using JoinRpg.Services.Interfaces.Projects;
 
 namespace JoinRpg.Services.Impl.Projects;
@@ -22,6 +23,7 @@ internal class CloneProjectHelper(
     IProjectMetadataRepository projectMetadataRepository,
     ICharacterService characterService,
     IPlotService plotService,
+    IProjectRolesListService projectRolesListService,
     ILogger logger)
 {
     private readonly Dictionary<CharacterIdentification, CharacterIdentification> CharacterMapping = [];
@@ -44,6 +46,7 @@ internal class CloneProjectHelper(
         if (cloneRequest.CopySettings >= ProjectCopySettingsDto.SettingsFieldsGroupsAndTemplates)
         {
             await CopyGroups();
+            await CopyRolesLists();
         }
 
         await FixupConditionalFields(); // Это надо делать даже если группы не копируются, чтобы поправить спецгруппы
@@ -332,6 +335,43 @@ internal class CloneProjectHelper(
         }
 
         return string.Join(",", values.Select(x => x.ProjectFieldVariantId.ToString()));
+    }
+
+    private async Task CopyRolesLists()
+    {
+        foreach (var originalList in original.ProjectRolesLists)
+        {
+            try
+            {
+                CharacterGroupIdentification? newCharacterGroupId = originalList.CharacterGroupId is { } cgId
+                    ? GroupMapping.GetValueOrDefault(cgId)
+                    : null;
+
+                var newFields = originalList.Fields
+                    .Select(f => FieldMapping.GetValueOrDefault(f))
+                    .WhereNotNull()
+                    .ToList();
+
+                var newModel = originalList with
+                {
+                    ProjectRolesListId = new ProjectRolesListIdentification(projectId, 0),
+                    CharacterGroupId = newCharacterGroupId,
+                    Fields = newFields,
+                };
+
+                await projectRolesListService.CreateAsync(newModel);
+            }
+            catch (DbEntityValidationException ex)
+            {
+                logger.LogWarning(ex, "Не удалось скопировать сетку ролей {Name} в проект {projectId}. Копирование проекта будет продолжено.", originalList.Name, projectId);
+                everythingFine = false;
+            }
+            catch (JoinRpgBaseException ex)
+            {
+                logger.LogWarning(ex, "Не удалось скопировать сетку ролей {Name} в проект {projectId}. Копирование проекта будет продолжено.", originalList.Name, projectId);
+                everythingFine = false;
+            }
+        }
     }
 
     private async Task CopyPlot()

--- a/src/JoinRpg.Services.Impl/Projects/CloneProjectHelperFactory.cs
+++ b/src/JoinRpg.Services.Impl/Projects/CloneProjectHelperFactory.cs
@@ -1,13 +1,14 @@
 using JoinRpg.DataModel;
 using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.ProjectMetadata;
 using JoinRpg.Services.Interfaces.Projects;
 
 namespace JoinRpg.Services.Impl.Projects;
 
-internal class CloneProjectHelperFactory(IProjectService projectService, ICharacterGroupService characterGroupService, IFieldSetupService fieldSetupService, IProjectMetadataRepository projectMetadataRepository, ICharacterService characterService, IPlotService plotService, ILogger<CloneProjectHelper> logger)
+internal class CloneProjectHelperFactory(IProjectService projectService, ICharacterGroupService characterGroupService, IFieldSetupService fieldSetupService, IProjectMetadataRepository projectMetadataRepository, ICharacterService characterService, IPlotService plotService, IProjectRolesListService projectRolesListService, ILogger<CloneProjectHelper> logger)
 {
     public CloneProjectHelper Create(CloneProjectRequest cloneRequest, Project project, ProjectIdentification projectId, ProjectInfo original, Project originalEntity)
     {
-        return new CloneProjectHelper(cloneRequest, project, projectId, original, originalEntity, projectService, characterGroupService, fieldSetupService, projectMetadataRepository, characterService, plotService, logger);
+        return new CloneProjectHelper(cloneRequest, project, projectId, original, originalEntity, projectService, characterGroupService, fieldSetupService, projectMetadataRepository, characterService, plotService, projectRolesListService, logger);
     }
 }


### PR DESCRIPTION
При клонировании на уровне SettingsFieldsGroupsAndTemplates и выше ProjectRolesList теперь копируются: маппинг полей и групп проводится через существующие словари CloneProjectHelper. Ошибка копирования отдельной сетки не прерывает общее клонирование.