### PR TITLE
chore: group OpenTelemetry.* packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
       autofac:
         patterns:
           - "Autofac.*"
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry.*"
 
   - package-ecosystem: "github-actions"
     directory: "/" 


### PR DESCRIPTION
## Что сделано
- Добавлена группа `opentelemetry` в `.github/dependabot.yml`, объединяющая все пакеты `OpenTelemetry.*` в один Dependabot PR.

Closes #4505

Generated with [Claude Code](https://claude.ai/code)