### PR TITLE
fix: restore claim by master sets invited status without contact access

### DIFF
--- a/src/JoinRpg.Domain/ClaimExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimExtensions.cs
@@ -58,7 +58,7 @@ public static class ClaimExtensions
                   .Contains(fromStatus);
             case ClaimStatus.AddedByMaster:
                 return new[]
-                    { ClaimStatus.DeclinedByUser, ClaimStatus.DeclinedByMaster, ClaimStatus.OnHold }
+                    {ClaimStatus.DeclinedByUser, ClaimStatus.DeclinedByMaster, ClaimStatus.OnHold}
                   .Contains(fromStatus);
             case ClaimStatus.DeclinedByUser:
             case ClaimStatus.DeclinedByMaster:

--- a/src/JoinRpg.Domain/ClaimExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimExtensions.cs
@@ -57,7 +57,9 @@ public static class ClaimExtensions
                     {ClaimStatus.DeclinedByUser, ClaimStatus.DeclinedByMaster, ClaimStatus.OnHold}
                   .Contains(fromStatus);
             case ClaimStatus.AddedByMaster:
-                return false;
+                return new[]
+                    { ClaimStatus.DeclinedByUser, ClaimStatus.DeclinedByMaster, ClaimStatus.OnHold }
+                  .Contains(fromStatus);
             case ClaimStatus.DeclinedByUser:
             case ClaimStatus.DeclinedByMaster:
                 return

--- a/src/JoinRpg.IntegrationTests/Scenarios/RestoreClaimByMasterScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/RestoreClaimByMasterScenario.cs
@@ -1,6 +1,7 @@
 using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.Data.Interfaces.Claims;
+using JoinRpg.DataModel;
 using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;

--- a/src/JoinRpg.IntegrationTests/Scenarios/RestoreClaimByMasterScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/RestoreClaimByMasterScenario.cs
@@ -1,0 +1,88 @@
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Claims;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.IntegrationTest.Scenarios;
+
+public class RestoreClaimByMasterScenario(JoinApplicationFactory factory) : IClassFixture<JoinApplicationFactory>
+{
+    [Fact]
+    public async Task MasterRestoresDeclinedClaim_ClaimBecomesInvitedWithoutContactsAccess()
+    {
+        // 1. Создаём мастера, проект и игрока
+        UserIdentification masterId;
+        ProjectIdentification projectId;
+        UserIdentification playerId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            masterId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+            projectId = await TestUserProjectHelpers.CreateProjectAsync(scope.ServiceProvider, masterId);
+            playerId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+        }
+
+        // 2. Мастер включает приём заявок (без автопринятия), создаёт персонажа
+        var characterId = await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var projectService = sp.GetRequiredService<IProjectService>();
+            var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+            var projectInfo = await metadataRepository.GetProjectMetadata(projectId);
+            await projectService.SetClaimSettings(
+                projectId,
+                projectInfo.ClaimSettings with { AutoAcceptClaims = false, IsAcceptingClaims = true });
+
+            var characterService = sp.GetRequiredService<ICharacterService>();
+            return await characterService.AddCharacter(new AddCharacterRequest(
+                projectId,
+                ParentCharacterGroupIds: [],
+                new CharacterTypeInfo(CharacterType.Player, IsHot: false, SlotLimit: null, SlotName: null, CharacterVisibility.Public),
+                FieldValues: new Dictionary<int, string?>()));
+        });
+
+        // 3. Игрок подаёт заявку, мастер принимает и затем отклоняет её
+        var claimId = await factory.Services.RunAsAsync(playerId, async sp =>
+        {
+            var claimService = sp.GetRequiredService<IClaimService>();
+            return await claimService.AddClaimFromUser(characterId, "Хочу эту роль", new Dictionary<int, string?>(), sensitiveDataAllowed: false);
+        });
+
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var claimService = sp.GetRequiredService<IClaimService>();
+            await claimService.ApproveByMaster(claimId, "Принято");
+        });
+
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var claimService = sp.GetRequiredService<IClaimService>();
+            await claimService.DeclineByMaster(claimId, ClaimDenialReason.Removed, "Отклонено", deleteCharacter: false);
+        });
+
+        // 4. Мастер восстанавливает заявку
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var claimService = sp.GetRequiredService<IClaimService>();
+            await claimService.RestoreByMaster(claimId, "Восстановлено", characterId);
+        });
+
+        // 5. Заявка должна быть в статусе «Предложена» (приглашение) без доступа к контактам
+        var restoredClaim = await GetClaim(claimId);
+        restoredClaim.ClaimStatus.ShouldBe(ClaimStatus.AddedByMaster);
+        restoredClaim.PlayerAllowedSenstiveData.ShouldBeFalse();
+    }
+
+    private async Task<Claim> GetClaim(ClaimIdentification claimId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var claimsRepository = scope.ServiceProvider.GetRequiredService<IClaimsRepository>();
+        return await claimsRepository.GetClaim(claimId)
+            ?? throw new InvalidOperationException("Claim not found");
+    }
+}

--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -652,9 +652,10 @@ internal class ClaimServiceImpl(
         var oldCharacterId = claim.GetCharacterId(); // Сохраняем на случай если он изменится
         var character = await CharactersRepository.GetCharacterAsync(characterId);
 
-        claim.EnsureCanChangeStatus(ClaimStatus.AddedByUser);
-        claim.ClaimStatus = ClaimStatus.AddedByUser; //TODO: Actually should be "AddedByMaster" but we don't support it yet.
+        claim.EnsureCanChangeStatus(ClaimStatus.AddedByMaster);
+        claim.ClaimStatus = ClaimStatus.AddedByMaster;
         claim.ClaimDenialStatus = null;
+        claim.PlayerAllowedSenstiveData = false; // Мастер не может дать разрешение на чувствительные данные от имени игрока
         SetDiscussed(claim, true);
 
         if (character.ApprovedClaim is not null)


### PR DESCRIPTION
## Changes
- RestoreByMaster now sets ClaimStatus.AddedByMaster
- Reset PlayerAllowedSenstiveData to false on restore
- Allow transition to AddedByMaster from DeclinedByUser, DeclinedByMaster, OnHold
- Add integration test

Closes #3623

Generated with [Claude Code](https://claude.ai/code)