### PR TITLE
feat: показывать RequestId на странице ошибки оплаты

### DIFF
--- a/src/JoinRpg.Portal/Controllers/Money/PaymentsController.cs
+++ b/src/JoinRpg.Portal/Controllers/Money/PaymentsController.cs
@@ -40,6 +40,7 @@ public class PaymentsController : Common.JoinMvcControllerBase
         model.Title = string.IsNullOrWhiteSpace(model.Title)
             ? "Ошибка онлайн-оплаты"
             : model.Title.Trim();
+        model.RequestId ??= HttpContext.TraceIdentifier;
         return View("Error", model);
     }
 
@@ -79,6 +80,7 @@ public class PaymentsController : Common.JoinMvcControllerBase
         }
         catch (Exception e)
         {
+            logger.LogError(e, "Error while creating recurrent payment subscription");
             return Error(
                 new ErrorViewModel
                 {
@@ -161,6 +163,7 @@ public class PaymentsController : Common.JoinMvcControllerBase
         }
         catch (Exception e)
         {
+            logger.LogError(e, "Error while creating payment");
             return Error(
                 new ErrorViewModel
                 {

--- a/src/JoinRpg.Portal/Views/Payments/Error.cshtml
+++ b/src/JoinRpg.Portal/Views/Payments/Error.cshtml
@@ -14,6 +14,11 @@
     </div>
 </div>
 
+@if (!string.IsNullOrWhiteSpace(Model.RequestId))
+{
+    <p><b>RequestId</b>: <code>@Model.RequestId</code></p>
+}
+
 @if (Model.Data is not null)
 {
     <pre style="width: 100%; height: 300px; overflow: scroll; display: @errorDetailsDisplay;">

--- a/src/JoinRpg.WebPortal.Models/ErrorViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/ErrorViewModel.cs
@@ -16,6 +16,8 @@ public class ErrorViewModel
 
     public object? Data { get; set; }
 
+    public string? RequestId { get; set; }
+
     public ErrorViewModel()
     {
 #if DEBUG


### PR DESCRIPTION
## Что сделано
- `ErrorViewModel` получил свойство `RequestId`, заполняемое в `PaymentsController.Error` из `HttpContext.TraceIdentifier`
- `Views/Payments/Error.cshtml` выводит RequestId, чтобы пользователь мог передать его в техподдержку
- `ClaimPayment` и `ClaimRecurrentPayment` больше не проглатывают исключения молча — ошибка теперь пишется в лог через `logger.LogError` перед показом страницы ошибки

## Test plan
- [x] `dotnet build` без ошибок
- [ ] Вручную вызвать ошибку оплаты (например, `ClaimPayment` с `AcceptContract = false`) и убедиться, что RequestId отображается на странице и совпадает с TraceIdentifier в логах

Generated with [Claude Code](https://claude.ai/code)