### PR TITLE
chore: указать JoinRpg.Portal как startup project по умолчанию

### DIFF
--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -94,7 +94,7 @@
   <Project Path="src/JoinRpg.DataModel/JoinRpg.DataModel.csproj" />
   <Project Path="src/JoinRpg.Domain/JoinRpg.Domain.csproj" />
   <Project Path="src/JoinRpg.Interfaces/JoinRpg.Interfaces.csproj" />
-  <Project Path="src/JoinRpg.Portal/JoinRpg.Portal.csproj" />
+  <Project Path="src/JoinRpg.Portal/JoinRpg.Portal.csproj" DefaultStartup="true" />
   <Project Path="src/Joinrpg.Web.Identity/Joinrpg.Web.Identity.csproj" />
 </Solution>
 


### PR DESCRIPTION
## Что сделано
- В `Joinrpg.slnx` для `src/JoinRpg.Portal/JoinRpg.Portal.csproj` добавлен атрибут `DefaultStartup="true"`, чтобы при открытии решения в Visual Studio стартовым проектом сразу становился основной сайт (JoinRpg.Portal).

## Тест-план
- [ ] Открыть `Joinrpg.slnx` в Visual Studio и убедиться, что JoinRpg.Portal выбран как startup project

Generated with [Claude Code](https://claude.ai/code)