### PR TITLE
chore: указать JoinRpg.Portal как startup project по умолчанию

### DIFF
--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -94,7 +94,7 @@
   <Project Path="src/JoinRpg.DataModel/JoinRpg.DataModel.csproj" />
   <Project Path="src/JoinRpg.Domain/JoinRpg.Domain.csproj" />
   <Project Path="src/JoinRpg.Interfaces/JoinRpg.Interfaces.csproj" />
-  <Project Path="src/JoinRpg.Portal/JoinRpg.Portal.csproj" />
+  <Project Path="src/JoinRpg.Portal/JoinRpg.Portal.csproj" DefaultStartup="true" />
   <Project Path="src/Joinrpg.Web.Identity/Joinrpg.Web.Identity.csproj" />
 </Solution>
 


### PR DESCRIPTION
Добавлен атрибут DefaultStartup="true" для JoinRpg.Portal.csproj в Joinrpg.slnx,
чтобы Visual Studio при открытии решения сразу выбирала основной сайт
как стартовый проект.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
