### PR TITLE
fix: фильтровать логи джобы по json_payload.jobName

### DIFF
--- a/src/JoinRpg.Web.AdminTools/Jobs/JobLogsLink.razor
+++ b/src/JoinRpg.Web.AdminTools/Jobs/JobLogsLink.razor
@@ -5,5 +5,5 @@
     public required string JobName { get; set; }
 
     private static string BuildLink(string jobName)
-        => $"https://console.yandex.cloud/folders/b1g1a4nj5oq5sv996tcv/logging/group/e2371utkp5mj3oltko4r/logs?from=now-1d&to=now&size=100&linesInRow=1&query=jobName%3A+%22{Uri.EscapeDataString(jobName)}%22";
+        => $"https://console.yandex.cloud/folders/b1g1a4nj5oq5sv996tcv/logging/group/e2371utkp5mj3oltko4r/logs?from=now-1d&to=now&size=100&linesInRow=1&query=json_payload.jobName%3A+%22{Uri.EscapeDataString(jobName)}%22";
 }


### PR DESCRIPTION
## Что сделано
- Ссылка на логи джобы на странице /admin/jobs теперь фильтрует по `json_payload.jobName`, а не по `jobName` — поле в Yandex Cloud Logging вложено в json_payload.

Generated with [Claude Code](https://claude.ai/code)