### PR TITLE
chore: удалить неиспользуемый IProjectRepository.LoadGroupWithChildsAsync

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
@@ -45,14 +45,6 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
         }
     }
 
-    public async Task<CharacterGroup> LoadGroupWithChildsAsync(int projectId, int characterGroupId)
-    {
-        await LoadProjectCharactersAndGroups(projectId);
-        return
-          await Ctx.Set<CharacterGroup>()
-            .SingleOrDefaultAsync(cg => cg.CharacterGroupId == characterGroupId && cg.ProjectId == projectId);
-    }
-
     public async Task<IList<CharacterGroup>> LoadGroups(IReadOnlyCollection<CharacterGroupIdentification> groupIds)
     {
         if (groupIds.Count == 0)

--- a/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
@@ -10,7 +10,6 @@ public interface IProjectRepository : IDisposable
     Task<CharacterGroup?> GetGroupAsync(CharacterGroupIdentification characterGroupId);
 
     Task<CharacterGroup?> LoadGroupWithTreeAsync(int projectId, int? characterGroupId = null);
-    Task<CharacterGroup> LoadGroupWithChildsAsync(int projectId, int characterGroupId);
 
     Task<IList<CharacterGroup>> LoadGroups(IReadOnlyCollection<CharacterGroupIdentification> groupIds);
 


### PR DESCRIPTION
## Что сделано
- Удалён неиспользуемый метод `LoadGroupWithChildsAsync` из `IProjectRepository` и его реализации в `ProjectRepository`
- Проверено grep-ом по всему решению: вызовов метода не было, только объявление и реализация

Generated with [Claude Code](https://claude.ai/code)