### PR TITLE
chore: обозначить GetProjectAsync как Obsolete, мигрировать простые вызовы

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectMetadataRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectMetadataRepository.cs
@@ -33,7 +33,9 @@ internal class ProjectMetadataRepository(MyDbContext ctx) : IProjectMetadataRepo
                         pt.TypeKind,
                         pt.IsActive,
                         new UserInfoHeader(new UserIdentification(pt.User.UserId), pt.User.ExtractDisplayName()),
-                        new PaymentTypeIdentification(pt.ProjectId, pt.PaymentTypeId)
+                        new PaymentTypeIdentification(pt.ProjectId, pt.PaymentTypeId),
+                        pt.Name,
+                        pt.IsDefault
                         )
                     )]);
 

--- a/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
@@ -4,6 +4,7 @@ namespace JoinRpg.Data.Interfaces;
 
 public interface IProjectRepository : IDisposable
 {
+    [Obsolete("Используйте IProjectMetadataRepository.GetProjectMetadata")]
     Task<Project> GetProjectAsync(int project);
     Task<Project?> GetProjectWithFieldsAsync(int project);
 

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/Payments/PaymentTypeInfo.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/Payments/PaymentTypeInfo.cs
@@ -2,7 +2,7 @@ using JoinRpg.Common.PrimitiveTypes.Users;
 
 namespace JoinRpg.DomainTypes.ProjectMetadata.Payments;
 
-public record PaymentTypeInfo(PaymentTypeKind TypeKind, bool Enabled, UserInfoHeader User, PaymentTypeIdentification PaymentTypeId)
+public record PaymentTypeInfo(PaymentTypeKind TypeKind, bool Enabled, UserInfoHeader User, PaymentTypeIdentification PaymentTypeId, string Name, bool IsDefault)
 {
     public void EnsureActive()
     {

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/Payments/ProjectFinanceSettings.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/Payments/ProjectFinanceSettings.cs
@@ -5,6 +5,7 @@ public record ProjectFinanceSettings(bool PreferentialFeeEnabled, IReadOnlyColle
     public PaymentTypeInfo? GetCashPaymentType(UserIdentification userId)
         => PaymentTypes.SingleOrDefault(pt => pt.User.UserId == userId && pt.TypeKind == PaymentTypeKind.Cash);
     public PaymentTypeInfo GetRequiredPayment(PaymentTypeIdentification paymentTypeId) => PaymentTypes.Single(pt => pt.PaymentTypeId == paymentTypeId);
+    public PaymentTypeInfo? GetPaymentByIdOrDefault(PaymentTypeIdentification paymentTypeId) => PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == paymentTypeId);
 
     public bool CanAcceptCash(UserIdentification userId) => GetCashPaymentType(userId)?.Enabled ?? false;
 }

--- a/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
+++ b/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
@@ -10,7 +10,6 @@ namespace JoinRpg.Portal.Controllers;
 [MasterAuthorize()]
 [Route("{projectId}/rooms/[action]")]
 public class AccommodationTypeController(
-    IProjectRepository projectRepository,
     IAccommodationService accommodationService,
     IAccommodationRepository accommodationRepository,
     IProjectMetadataRepository projectMetadataRepository,
@@ -47,8 +46,7 @@ public class AccommodationTypeController(
     public async Task<ActionResult> AddRoomType(int projectId)
     {
         var pi = await projectMetadataRepository.GetProjectMetadata(new(projectId));
-        return View(new RoomTypeViewModel(
-            await projectRepository.GetProjectAsync(projectId), currentUserAccessor.UserIdentification, pi));
+        return View(new RoomTypeViewModel(currentUserAccessor.UserIdentification, pi));
     }
 
     /// <summary>

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -159,8 +159,9 @@ public class FinancesController(
     [MasterAuthorize(Permission.CanManageMoney)]
     public async Task<ActionResult> EditPaymentType(int projectid, int paymenttypeid)
     {
-        var project = await projectRepository.GetProjectAsync(projectid);
-        var paymentType = project.PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == paymenttypeid);
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(projectid));
+        var paymentType = projectInfo.ProjectFinanceSettings.PaymentTypes
+            .SingleOrDefault(pt => pt.PaymentTypeId == new PaymentTypeIdentification(projectid, paymenttypeid));
         if (paymentType == null)
         {
             return NotFound();
@@ -178,8 +179,9 @@ public class FinancesController(
     [MasterAuthorize(Permission.CanManageMoney)]
     public async Task<ActionResult> EditPaymentType(EditPaymentTypeViewModel viewModel)
     {
-        var project = await projectRepository.GetProjectAsync(viewModel.ProjectId);
-        var paymentType = project.PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == viewModel.PaymentTypeId);
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(viewModel.ProjectId));
+        var paymentType = projectInfo.ProjectFinanceSettings.PaymentTypes
+            .SingleOrDefault(pt => pt.PaymentTypeId == new PaymentTypeIdentification(viewModel.ProjectId, viewModel.PaymentTypeId));
         if (paymentType == null)
         {
             return NotFound();
@@ -201,12 +203,6 @@ public class FinancesController(
     [HttpPost]
     public async Task<ActionResult> CreateFeeSetting(CreateProjectFeeSettingViewModel viewModel)
     {
-        var project = await projectRepository.GetProjectAsync(viewModel.ProjectId);
-        if (project == null)
-        {
-            return NotFound();
-        }
-
         try
         {
             await financeService.CreateFeeSetting(new CreateFeeSettingRequest()
@@ -230,12 +226,6 @@ public class FinancesController(
     [MasterAuthorize(Permission.CanManageMoney)]
     public async Task<ActionResult> DeleteFeeSetting(int projectid, int projectFeeSettingId)
     {
-        var project = await projectRepository.GetProjectAsync(projectid);
-        if (project == null)
-        {
-            return NotFound();
-        }
-
         try
         {
             await financeService.DeleteFeeSetting(projectid, projectFeeSettingId);
@@ -280,12 +270,6 @@ public class FinancesController(
     [HttpPost]
     public async Task<ActionResult> ChangeSettings(FinanceGlobalSettingsViewModel viewModel)
     {
-        var project = await projectRepository.GetProjectAsync(viewModel.ProjectId);
-        if (project == null)
-        {
-            return NotFound();
-        }
-
         try
         {
             await financeService.SaveGlobalSettings(new SetFinanceSettingsRequest

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -160,8 +160,7 @@ public class FinancesController(
     public async Task<ActionResult> EditPaymentType(int projectid, int paymenttypeid)
     {
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(projectid));
-        var paymentType = projectInfo.ProjectFinanceSettings.PaymentTypes
-            .SingleOrDefault(pt => pt.PaymentTypeId == new PaymentTypeIdentification(projectid, paymenttypeid));
+        var paymentType = projectInfo.ProjectFinanceSettings.GetPaymentByIdOrDefault(new PaymentTypeIdentification(projectid, paymenttypeid));
         if (paymentType == null)
         {
             return NotFound();
@@ -180,8 +179,7 @@ public class FinancesController(
     public async Task<ActionResult> EditPaymentType(EditPaymentTypeViewModel viewModel)
     {
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(viewModel.ProjectId));
-        var paymentType = projectInfo.ProjectFinanceSettings.PaymentTypes
-            .SingleOrDefault(pt => pt.PaymentTypeId == new PaymentTypeIdentification(viewModel.ProjectId, viewModel.PaymentTypeId));
+        var paymentType = projectInfo.ProjectFinanceSettings.GetPaymentByIdOrDefault(new PaymentTypeIdentification(viewModel.ProjectId, viewModel.PaymentTypeId));
         if (paymentType == null)
         {
             return NotFound();

--- a/src/JoinRpg.Portal/Controllers/PlotController.cs
+++ b/src/JoinRpg.Portal/Controllers/PlotController.cs
@@ -17,7 +17,6 @@ namespace JoinRpg.Portal.Controllers;
 
 [Route("{projectId}/plots/[action]")]
 public class PlotController(
-    IProjectRepository projectRepository,
     IPlotService plotService,
     IPlotRepository plotRepository,
     IUriService uriService,
@@ -30,11 +29,11 @@ public class PlotController(
     [HttpGet]
     public async Task<ActionResult> Create(int projectId)
     {
-        var project1 = await projectRepository.GetProjectAsync(projectId);
+        var project1 = await projectMetadataRepository.GetProjectMetadata(new(projectId));
         return View(new AddPlotFolderViewModel
         {
-            ProjectId = project1.ProjectId,
-            ProjectName = project1.ProjectName,
+            ProjectId = project1.ProjectId.Value,
+            ProjectName = project1.ProjectName.Value,
         });
     }
 

--- a/src/JoinRpg.Portal/Views/AccommodationType/AddRoomType.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/AddRoomType.cshtml
@@ -1,7 +1,7 @@
 ﻿@using JoinRpg.Web.Models.Accommodation
 @model RoomTypeViewModel
 @{
-    ViewBag.Title = Model.Project.ProjectName + ": новый тип размещения";
+    ViewBag.Title = Model.ProjectName + ": новый тип размещения";
     ViewBag.ActionName = "Добавить";
     ViewBag.IsNew = true;
 }

--- a/src/JoinRpg.Portal/Views/AccommodationType/EditRoomType.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/EditRoomType.cshtml
@@ -1,7 +1,7 @@
 ﻿@using JoinRpg.Web.Models.Accommodation
 @model RoomTypeViewModel
 @{
-    ViewBag.Title = Model.Project.ProjectName + ": тип поселения «" + Model.Name + "»";
+    ViewBag.Title = Model.ProjectName + ": тип поселения «" + Model.Name + "»";
     ViewBag.ActionName = "Сохранить";
     ViewBag.IsNew = false;
 }

--- a/src/JoinRpg.Portal/Views/AccommodationType/EditRoomTypeRooms.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/EditRoomTypeRooms.cshtml
@@ -2,7 +2,7 @@
 @using Newtonsoft.Json
 @model RoomTypeViewModel
 @{
-  ViewBag.Title = Model.Project.ProjectName + ": тип поселения «" + Model.Name + "»";
+  ViewBag.Title = Model.ProjectName + ": тип поселения «" + Model.Name + "»";
 }
 
 @section Scripts {

--- a/src/JoinRpg.WebPortal.Models/Accommodation/RoomTypeViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Accommodation/RoomTypeViewModel.cs
@@ -48,7 +48,7 @@ public class RoomTypeViewModel : RoomTypeViewModelBase
     [DisplayName("Описание"), UIHint("MarkdownString")]
     public string DescriptionEditable { get; set; }
 
-    public Project Project { get; set; }
+    public string ProjectName { get; set; }
 
 
     /// <summary>
@@ -70,7 +70,7 @@ public class RoomTypeViewModel : RoomTypeViewModelBase
     public IReadOnlyList<AccRequestViewModel> UnassignedRequests { get; set; }
 
     public RoomTypeViewModel(ProjectAccommodationType entity, UserIdentification userId, ProjectInfo projectInfo)
-        : this(entity.Project, userId, projectInfo)
+        : this(userId, projectInfo)
     {
         if (entity.ProjectId == 0 || entity.Id == 0)
         {
@@ -136,10 +136,10 @@ public class RoomTypeViewModel : RoomTypeViewModelBase
         Rooms = rl;
     }
 
-    public RoomTypeViewModel(Project project, UserIdentification userId, ProjectInfo projectInfo)
+    public RoomTypeViewModel(UserIdentification userId, ProjectInfo projectInfo)
     {
-        Project = project;
-        ProjectId = project.ProjectId;
+        ProjectName = projectInfo.ProjectName.Value;
+        ProjectId = projectInfo.ProjectId.Value;
         CanManageRooms = projectInfo.HasMasterAccess(userId, Permission.CanManageAccommodation);
         CanAssignRooms = projectInfo.HasMasterAccess(userId, Permission.CanSetPlayersAccommodations);
     }


### PR DESCRIPTION
## Что сделано
- `IProjectRepository.GetProjectAsync` помечен `[Obsolete]` в пользу `IProjectMetadataRepository.GetProjectMetadata`
- Мигрированы места, где реально нужны были только метаданные проекта (не EF-сущность):
  - `PlotController.Create`
  - `RoomTypeViewModel`/`AccommodationTypeController.AddRoomType` — вьюмодель больше не хранит `Project`, только `ProjectName`
  - `FinancesController.EditPaymentType` (GET/POST) — `PaymentTypeInfo` дополнен полями `Name`/`IsDefault`, добавлен `ProjectFinanceSettings.GetPaymentByIdOrDefault`
  - `FinancesController.CreateFeeSetting`/`DeleteFeeSetting`/`ChangeSettings` — убраны избыточные null-проверки проекта, т.к. `[MasterAuthorize]` уже гарантирует его существование до входа в action

## Что не тронуто (и почему)
Оставшиеся вызовы `GetProjectAsync`:
- `GameController.Edit` — читает `.Details.ClaimApplyRules`/`.ProjectAnnounce`, которых нет в `ProjectInfo`
- `CharacterController` — берёт `.RootGroup` (сущность `CharacterGroup`, а не Id)
- `CreateProjectService.Clone` — передаёт сущность `Project` дальше в `CloneProjectHelperFactory`, клонирование работает с ней напрямую
- `KogdaIgraSyncService` — мутирует `project.KogdaIgraGames`/`project.Details` и сохраняет через `unitOfWork.SaveChangesAsync()`
- `ClaimController.Add`/`Invite` — используют `project` только для null-проверки существования; не трогал, т.к. `GetProjectMetadata` бросает исключение вместо `null`, а это меняет поведение (404 → exception) и требует отдельного решения

Все эти случаи требуют либо EF-сущности (мутации/навигация), либо более широкого рефакторинга (вьюмодели, обработка исключений) — оставлены за рамками этого PR.

## Test plan
- [x] `dotnet build Joinrpg.slnx` — 0 ошибок
- [x] `dotnet format` на изменённых файлах — чисто
- [x] `dotnet test src/JoinRpg.WebPortal.Models.Test` — 183/183 пройдено

Generated with [Claude Code](https://claude.ai/code)