### PR TITLE
fix: добавлять jobName в лог о входе в кулдаун

### DIFF
--- a/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
@@ -51,6 +51,9 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            using var activity = SenderServiceActivityHolder.ActivitySource.StartActivity($"Iteration of {JobName}");
+            activity?.AddTag("jobName", JobName);
+
             logger.LogDebug("Запущена итерация обработки... ");
 
             if (FailureCounter >= WorkerOptions.MaxSubsequentFailures)
@@ -98,8 +101,6 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
     private async Task RunIteration(CancellationToken stoppingToken)
     {
         using var scope = serviceProvider.CreateScope();
-        using var activity = SenderServiceActivityHolder.ActivitySource.StartActivity($"Run of {JobName}");
-        activity?.AddTag("jobName", JobName);
 
         var notificationRepository = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
 


### PR DESCRIPTION
## Что сделано
- Предупреждение "Entering cooldown for ..." в `SenderJobService.ExecuteAsync` логировалось без `jobName` в `json_payload`, из-за чего его нельзя было отфильтровать по конкретной джобе.
- Причина: `Activity` с тегом `jobName` создавался только внутри `RunIteration`, а кулдаун-лог пишется в `ExecuteAsync` до вызова `RunIteration`.
- Перенёс создание `Activity` на уровень цикла в `ExecuteAsync`, чтобы тег `jobName` покрывал всю итерацию, включая лог о кулдауне. Убрал дублирующий `Activity` внутри `RunIteration`.

Generated with [Claude Code](https://claude.ai/code)