### PR TITLE
fix: подавить false-positive FirstWithoutOrderByAndFilterWarning в NotificationsDataDbContext

### DIFF
--- a/src/JoinRpg.Dal.Notifications/GlobalUsings.cs
+++ b/src/JoinRpg.Dal.Notifications/GlobalUsings.cs
@@ -2,4 +2,5 @@ global using System.ComponentModel.DataAnnotations;
 global using JoinRpg.Data.Write.Interfaces.Notifications;
 global using JoinRpg.DomainTypes.Notifications;
 global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Diagnostics;
 global using Microsoft.Extensions.Logging;

--- a/src/JoinRpg.Dal.Notifications/NotificationsDataDbContext.cs
+++ b/src/JoinRpg.Dal.Notifications/NotificationsDataDbContext.cs
@@ -10,6 +10,13 @@ public class NotificationsDataDbContext(DbContextOptions<NotificationsDataDbCont
             npgSqlOptions.MapEnum<NotificationChannel>();
             npgSqlOptions.MapEnum<NotificationMessageStatus>();
         });
+
+        // InternalSelectNextNotificationAsync (NotificationsRepository) делает FirstOrDefaultAsync() без OrderBy
+        // поверх FromSqlRaw с "LIMIT 1 FOR UPDATE SKIP LOCKED" — это намеренная выборка произвольной свободной
+        // задачи из очереди, порядок строки не важен. EF Core не разбирает сырой SQL и всегда предупреждает
+        // об отсутствии OrderBy в LINQ-части, а точечного подавления для одного запроса в EF Core нет
+        // (см. https://github.com/dotnet/efcore/issues/30411).
+        optionsBuilder.ConfigureWarnings(b => b.Ignore(CoreEventId.FirstWithoutOrderByAndFilterWarning));
     }
 
     internal DbSet<NotificationMessage> Notifications { get; set; } = null!;


### PR DESCRIPTION
## Что сделано
- В логах джобы `TelegramSenderJobService` появлялось предупреждение EF Core `FirstWithoutOrderByAndFilterWarning`.
- Источник — `NotificationsRepository.InternalSelectNextNotificationAsync`: `FirstOrDefaultAsync()` без `OrderBy` поверх `FromSqlRaw` с `LIMIT 1 FOR UPDATE SKIP LOCKED`. Это намеренная выборка произвольной свободной задачи из очереди нотификаций — порядок строки не важен. EF Core не разбирает сырой SQL и всегда предупреждает об отсутствии `OrderBy` в LINQ-части.
- Точечного (per-query) подавления предупреждений в EF Core нет — обсуждалось и закрыто как дубликат в [dotnet/efcore#30411](https://github.com/dotnet/efcore/issues/30411).
- Подавил предупреждение через `ConfigureWarnings` в `NotificationsDataDbContext.OnConfiguring`, а не глобально в общем `DbContextRegisterHelper`, чтобы не терять диагностику этого класса проблем для других DbContext-ов проекта.

## Test plan
- [x] `dotnet build` для `JoinRpg.Dal.Notifications` — без ошибок.
- [x] `dotnet format --verify-no-changes` для изменённых файлов — без изменений.

Generated with [Claude Code](https://claude.ai/code)