### PR TITLE
feat: метрики зависания SenderJob и длины очереди уведомлений

### DIFF
--- a/src/JoinRpg.Data.Write.Interfaces/Notifications/NotificationWorkerOptions.cs
+++ b/src/JoinRpg.Data.Write.Interfaces/Notifications/NotificationWorkerOptions.cs
@@ -53,4 +53,9 @@ public class NotificationWorkerOptions
     /// How many subsequent successes should happen to stop counting cooldowns.
     /// </summary>
     public int MinSubsequentSuccessesToStopCooldownCounting { get; set; } = 20;
+
+    /// <summary>
+    /// How often to poll notification queue lengths for metrics.
+    /// </summary>
+    public TimeSpan QueueMetricsPollInterval { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/JoinRpg.Services.Notifications/NotificationQueueMetricsPublisher.cs
+++ b/src/JoinRpg.Services.Notifications/NotificationQueueMetricsPublisher.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using JoinRpg.Common.WebInfrastructure;
+using JoinRpg.Data.Write.Interfaces.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace JoinRpg.Services.Notifications;
+
+/// <summary>
+/// Периодически опрашивает длину очереди уведомлений по каналам и публикует её как метрику.
+/// </summary>
+internal class NotificationQueueMetricsPublisher(
+    IServiceProvider serviceProvider,
+    ILogger<NotificationQueueMetricsPublisher> logger,
+    IOptions<NotificationWorkerOptions> workerOptions,
+    IHostApplicationLifetime hostApplicationLifetime
+    ) : BackgroundService
+{
+    private readonly NotificationWorkerOptions WorkerOptions = workerOptions.Value;
+
+    private static readonly Meter meter = new("JoinRpg");
+    private static readonly ConcurrentDictionary<NotificationChannel, int> queueLengths = new();
+
+    // Возврат CreateObservableGauge не сохраняем: инструмент живёт, пока жив meter, регистрация не требует хранения ссылки.
+    static NotificationQueueMetricsPublisher()
+        => _ = meter.CreateObservableGauge(
+            "joinrpg.notifications.queue_length",
+            () => queueLengths.Select(kv => new Measurement<int>(kv.Value, new KeyValuePair<string, object?>("channel", kv.Key.ToString()))),
+            description: "Number of notification messages currently queued for sending, per channel.");
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await hostApplicationLifetime.WaitForAppStartup(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = serviceProvider.CreateScope();
+                var notificationRepository = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+                var lengths = await notificationRepository.GetQueueLengths();
+
+                foreach (var channel in Enum.GetValues<NotificationChannel>())
+                {
+                    queueLengths[channel] = lengths.GetValueOrDefault(channel);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Ошибка при получении длины очереди уведомлений для метрик");
+            }
+
+            await Task.Delay(WorkerOptions.QueueMetricsPollInterval, stoppingToken);
+        }
+    }
+}

--- a/src/JoinRpg.Services.Notifications/NotificationRegistration.cs
+++ b/src/JoinRpg.Services.Notifications/NotificationRegistration.cs
@@ -24,6 +24,7 @@ public static class NotificationRegistration
             .AddSenderJob<UiSenderJobService>()
             .AddSenderJob<PostboxSenderJobService>()
             .AddSenderJob<TelegramSenderJobService>()
+            .AddHostedService<NotificationQueueMetricsPublisher>()
             ;
     }
 

--- a/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
@@ -26,6 +26,21 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
     private static readonly Counter<int> numberOfSuccessCounter = meter.CreateCounter<int>(JobName.ToLowerInvariant() + "." + "success");
 
     /// <summary>
+    /// Момент завершения последней итерации (успешной или с ошибкой). Если джоба зависла внутри итерации
+    /// (например, застряла в бесконечном ожидании), это значение перестаёт обновляться,
+    /// и метрика ниже начинает бесконечно расти.
+    /// </summary>
+    private static DateTimeOffset lastIterationFinishedAt = DateTimeOffset.UtcNow;
+
+    // Возврат CreateObservableGauge не сохраняем: инструмент живёт, пока жив meter, регистрация не требует хранения ссылки.
+    static SenderJobService()
+        => _ = meter.CreateObservableGauge(
+            JobName.ToLowerInvariant() + "." + "seconds_since_last_iteration",
+            () => (DateTimeOffset.UtcNow - lastIterationFinishedAt).TotalSeconds,
+            unit: "s",
+            description: "Seconds since the sender job last finished an iteration. Growing indefinitely indicates the job is stuck.");
+
+    /// <summary>
     /// Counts the subsequent cooldowns.
     /// </summary>
     private int CooldownCounter { get; set; }
@@ -94,6 +109,10 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
                 logger.LogError(ex, "Ошибка при запуске итерации SenderJobService<{senderJobName}>", JobName);
                 SuccessCounter = 0;
                 FailureCounter++;
+            }
+            finally
+            {
+                lastIterationFinishedAt = DateTimeOffset.UtcNow;
             }
         }
     }


### PR DESCRIPTION
## Что сделано

Добавлены две новые метрики (`System.Diagnostics.Metrics` + существующий `Meter("JoinRpg")`, слушается общим OpenTelemetry `MeterProvider` и отдаётся через уже подключённый Prometheus scraping endpoint — дополнительная регистрация не требовалась).

### 1. Детект зависания `SenderJob` (`SenderJobService<TSender>`)

- `ObservableGauge<double>` **`<полное_имя_джобы>.seconds_since_last_iteration`** (unit: `s`).
- Значение = секунды с момента завершения последней итерации цикла отправки (успешной или с ошибкой).
- Обновляется в `finally` после каждого прохода `RunIteration` — то есть если джоба зависнет *внутри* итерации (например, застрянет на ожидании внешнего сервиса), таймстамп перестанет обновляться, и метрика начнёт бесконечно расти.
- Своя метрика для каждого закрытого generic-типа `SenderJobService<TSender>`, то есть отдельно для email (`PostboxSenderJobService`), Telegram (`TelegramSenderJobService`) и in-app (`UiSenderJobService`).
- Метрика per-pod: в проде Portal развёрнут в 2 репликах, поэтому значение считается независимо в каждом поде (общего состояния между подами нет), а разделение по инстансам делает Prometheus на скрейпинге.

### 2. Длина очереди уведомлений

- Новый `NotificationQueueMetricsPublisher` — `BackgroundService` в `JoinRpg.Services.Notifications`, опрашивает уже существующий `INotificationRepository.GetQueueLengths()` (используется веб-дашбордом уведомлений) раз в `NotificationWorkerOptions.QueueMetricsPollInterval` (по умолчанию 30 сек) и кэширует результат.
- `ObservableGauge<int>` **`joinrpg.notifications.queue_length`** с тегом `channel` (`ShowInUi` / `Email` / `Telegram`) — число сообщений в статусе `Queued` по каждому каналу.
- Зарегистрирован как hosted service в `AddJoinNotificationJobs()`, подключается автоматически через уже существующий вызов в `Startup.cs`.

### Прочее

- `NotificationWorkerOptions.QueueMetricsPollInterval` — новая настройка интервала опроса очереди (по умолчанию 30 сек).
- `ObservableGauge` не хранится в приватном поле — инструмент остаётся зарегистрированным, пока жив сам `Meter` (он `static readonly`), поэтому хранить ссылку не нужно (иначе анализатор ругается на `IDE0052`, "неиспользуемое поле").

## Test plan

- [x] `dotnet build src/JoinRpg.Services.Notifications` — 0 ошибок, 0 предупреждений.
- [x] `dotnet format --verify-no-changes --severity error` — чисто.
- [ ] Вручную проверить `/metrics` endpoint после деплоя — убедиться, что новые gauge-метрики появляются и растут/убывают ожидаемо.

Generated with [Claude Code](https://claude.ai/code)