### PR TITLE
Добавить публикацию JoinRpg.Common.WebComponents в NuGet

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -21,6 +21,7 @@ jobs:
           - JoinRpg.Common.PrimitiveTypes
           - JoinRpg.Common.PrimitiveTypes.SourceGenerator
           - JoinRpg.Common.KogdaIgraClient
+          - JoinRpg.Common.WebComponents
           # Добавить новые проекты сюда:
           # - SomeOtherProject.csproj
 

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents/JoinRpg.Common.WebComponents.csproj
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents/JoinRpg.Common.WebComponents.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <PackageId>JoinRpg.Common.WebComponents</PackageId>
+    <Description>Библиотека переиспользуемых Blazor-компонентов Joinrpg.ru (кнопки, диалоги, поля ввода, иконки).</Description>
+    <PackageProjectUrl>https://github.com/joinrpg/joinrpg-net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/joinrpg/joinrpg-net</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />


### PR DESCRIPTION
## Что сделано
- `JoinRpg.Common.WebComponents.csproj`: добавлены `IsPackable`, `PackageId`, `Description`, `PackageProjectUrl`, `RepositoryUrl` — по образцу уже упакованных проектов (`JoinRpg.Common.PrimitiveTypes`, `JoinRpg.Common.WebInfrastructure`).
- `nuget-publish.yml`: проект добавлен в матрицу публикации.

Локально проверено `dotnet pack`: пакет собирается корректно, содержит staticwebassets (razor.css бандл, JS/CSS, иконки) и правильную зависимость на `JoinRpg.Common.PrimitiveTypes` в nuspec.

## Test plan
- [ ] `dotnet pack src/Common/WebComponents/JoinRpg.Common.WebComponents/JoinRpg.Common.WebComponents.csproj -c Release` — пакет собирается без ошибок
- [ ] Ручной запуск workflow `Publish NuGet packages` подтверждает публикацию пакета `JoinRpg.Common.WebComponents`

Generated with [Claude Code](https://claude.ai/code)