### PR TITLE
ComponentBook: страницы с Bootstrap и без него

### DIFF
--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Pages/Index.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Pages/Index.razor
@@ -1,11 +1,10 @@
-﻿@page "/"
+@page "/"
 
-<h1>Hello, world!</h1>
+<HeadContent>
+    <link href="/lib/twitter-bootstrap/css/bootstrap.css" rel="stylesheet" />
+    <link href="_content/JoinRpg.Common.WebComponents/lib/bootstrap-select/css/bootstrap-select.css" rel="stylesheet" />
+</HeadContent>
 
-Welcome to your new app.
+<h1>Компоненты с подключённым Bootstrap</h1>
 
-<IntSelectorDemo />
-<PriceElementDemo />
-<JoinUserLinkEditorDemo />
-<JoinIconDemo />
-<JoinRpgDatePickerDemo />
+<AllDemos />

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Pages/NoBootstrap.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Pages/NoBootstrap.razor
@@ -1,0 +1,5 @@
+@page "/no-bootstrap"
+
+<h1>Компоненты без подключённого Bootstrap</h1>
+
+<AllDemos />

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Program.cs
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 namespace JoinRpg.Common.WebComponentBook.Client;
@@ -8,6 +9,7 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.RootComponents.Add<App>("#app");
+        builder.RootComponents.Add<HeadOutlet>("head::after");
 
         builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Shared/AllDemos.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Shared/AllDemos.razor
@@ -1,0 +1,5 @@
+<IntSelectorDemo />
+<PriceElementDemo />
+<JoinUserLinkEditorDemo />
+<JoinIconDemo />
+<JoinRpgDatePickerDemo />

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Shared/NavMenu.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/Shared/NavMenu.razor
@@ -9,7 +9,12 @@
     <ul class="nav flex-column">
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="oi oi-home" aria-hidden="true"></span> Home
+                <span class="oi oi-home" aria-hidden="true"></span> С Bootstrap
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="no-bootstrap">
+                <span class="oi oi-ban" aria-hidden="true"></span> Без Bootstrap
             </NavLink>
         </li>
     </ul>

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/wwwroot/index.html
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/wwwroot/index.html
@@ -6,10 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>JoinRpg.Common.WebComponentBook</title>
     <base href="/" />
-    <link href="/lib/twitter-bootstrap/css/bootstrap.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="JoinRpg.Common.WebComponentBook.Client.styles.css" rel="stylesheet" />
-    <link href="_content/JoinRpg.Common.WebComponents/lib/bootstrap-select/css/bootstrap-select.css" rel="stylesheet" />
 </head>
 
 <body>


### PR DESCRIPTION
## Что сделано
- В `JoinRpg.Common.WebComponentBook.Client` разделены демо компонентов на две страницы: `/` (со стилями Bootstrap, подключаемыми через `HeadContent`) и `/no-bootstrap` (без Bootstrap).
- Глобальное подключение `bootstrap.css`/`bootstrap-select.css` убрано из `wwwroot/index.html`, добавлен `HeadOutlet` для поддержки `HeadContent`.
- Список демо-компонентов вынесен в общий `Shared/AllDemos.razor`, используется обеими страницами.
- В навигации добавлены ссылки на обе страницы.

## Test plan
- [x] `dotnet build` проекта ComponentBook.Client — успешно
- [x] Проверено, что `bootstrap.css` больше не грузится глобально в `index.html`
- [ ] Визуальная проверка в браузере (не удалось выполнить в этой сессии — недоступно расширение Chrome)