### PR TITLE
chore: группировать обновления Microsoft.CodeAnalysis в dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,9 @@ updates:
       opentelemetry:
         patterns:
           - "OpenTelemetry.*"
+      codeanalysis:
+        patterns:
+          - "Microsoft.CodeAnalysis*"
 
   - package-ecosystem: "github-actions"
     directory: "/" 


### PR DESCRIPTION
## Что сделано
- Добавлена группа `codeanalysis` в `.github/dependabot.yml`, объединяющая все пакеты `Microsoft.CodeAnalysis*` в единый PR при обновлении.

Generated with [Claude Code](https://claude.ai/code)