### PR TITLE
fix: не прятать кнопку отвязки соцсети и не терять данные при неудачном RemoveLogin

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -39,9 +39,9 @@ public class ManageController(
         var user = await userManager.FindByIdAsync(userId.ToString());
         ManageMessageId? message;
         var result = await userManager.RemoveLoginAsync(user, loginProvider, providerKey);
-        await externalLoginProfileExtractor.CleanAfterLogin(user, loginProvider);
         if (result.Succeeded)
         {
+            await externalLoginProfileExtractor.CleanAfterLogin(user, loginProvider);
             if (user != null)
             {
                 await signInManager.SignInAsync(user, isPersistent: true);

--- a/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
+++ b/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
@@ -290,11 +290,18 @@
             }
             @if (social.AllowUnlink)
             {
-                <form asp-controller="Manage" asp-action="RemoveLogin" style="display:inline">
-                    <input type="hidden" value="@social.LoginProvider.ProviderId" name="loginProvider" />
-                    <input type="hidden" value="@social.ProviderKey" name="providerKey" />
-                    <button type="submit" class="btn btn-default">Отключить</button>
-                </form>
+                @if (social.IsOnlyLoginMethod)
+                {
+                    <button type="button" class="btn btn-default" disabled title="Невозможно отвязать единственный способ входа">Отключить</button>
+                }
+                else
+                {
+                    <form asp-controller="Manage" asp-action="RemoveLogin" style="display:inline">
+                        <input type="hidden" value="@social.LoginProvider.ProviderId" name="loginProvider" />
+                        <input type="hidden" value="@social.ProviderKey" name="providerKey" />
+                        <button type="submit" class="btn btn-default">Отключить</button>
+                    </form>
+                }
             }
         </div>
     </div>

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserLoginInfoViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserLoginInfoViewModel.cs
@@ -37,6 +37,11 @@ public record UserLoginInfoViewModel
     public required bool AllowLink { get; set; }
     public required bool AllowUnlink { get; set; }
     public required bool NeedToReLink { get; set; }
+
+    /// <summary>
+    /// True когда привязка есть, но отвязать её нельзя, т.к. это единственный способ входа в аккаунт.
+    /// </summary>
+    public required bool IsOnlyLoginMethod { get; set; }
 }
 
 public static class UserLoginInfoViewModelBuilder
@@ -55,10 +60,12 @@ public static class UserLoginInfoViewModelBuilder
         {
             if (TryGetExternalLoginByProviderId(user, provider.ProviderId) is UserExternalLogin login)
             {
+                var hasOtherLoginMethods = user.PasswordHash != null || user.ExternalLogins.Count > 1;
                 return new UserLoginInfoViewModel()
                 {
                     AllowLink = false,
-                    AllowUnlink = user.PasswordHash != null || user.ExternalLogins.Count > 1,
+                    AllowUnlink = true,
+                    IsOnlyLoginMethod = !hasOtherLoginMethods,
                     LoginProvider = provider,
                     ProviderKey = login.Key,
                     NeedToReLink = false,
@@ -71,6 +78,7 @@ public static class UserLoginInfoViewModelBuilder
                 {
                     AllowLink = idFromProfile is null,
                     AllowUnlink = false,
+                    IsOnlyLoginMethod = false,
                     LoginProvider = provider,
                     ProviderKey = null,
                     NeedToReLink = idFromProfile is not null,


### PR DESCRIPTION
## Что сделано

- Кнопка «Отключить» на `/manage/setupprofile` для соцсети (ВК/Телеграм), если она единственный способ входа, теперь рендерится задизейбленной с подсказкой «Невозможно отвязать единственный способ входа», а не пропадает совсем. Раньше в этом случае карточка не показывала вообще никаких кнопок, что выглядело как «привязки нет и её нельзя сделать».
- В `ManageController.RemoveLogin` вызов `CleanAfterLogin` (обнуляет `UserExtra.Vk`/`VkVerified`) перенесён внутрь `if (result.Succeeded)`. Раньше он вызывался безусловно, поэтому при неудачном `RemoveLoginAsync` реальная привязка (`UserExternalLogin`) оставалась в БД, а закэшированные в `UserExtra` данные всё равно обнулялись — из-за этого рассинхрона проверка обязательной привязки ВК при подаче заявки и отображение ВК в профиле переставали работать, хотя формальная OAuth-привязка была на месте.

## Test plan

- [x] `dotnet build src/JoinRpg.Portal/JoinRpg.Portal.csproj` — 0 ошибок
- [ ] Ручная проверка: пользователь с единственным способом входа видит задизейбленную кнопку «Отключить» с подсказкой на `/manage/setupprofile`
- [ ] Ручная проверка: при неуспешном `RemoveLoginAsync` (например, попытка отвязать единственный способ входа) `UserExtra.Vk`/`VkVerified` не сбрасываются

Generated with [Claude Code](https://claude.ai/code)