### PR TITLE
refactor: перенести флоу создания проекта в JoinRpg.Web.Games

### DIFF
--- a/src/JoinRpg.Portal/Controllers/GameController.cs
+++ b/src/JoinRpg.Portal/Controllers/GameController.cs
@@ -11,7 +11,6 @@ using JoinRpg.Services.Interfaces;
 using JoinRpg.Services.Interfaces.Projects;
 using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.Models;
-using JoinRpg.Web.ProjectCommon.Projects;
 using JoinRpg.WebPortal.Managers.AdminTools;
 using JoinRpg.WebPortal.Managers.Claims;
 using Microsoft.AspNetCore.Authorization;

--- a/src/JoinRpg.Portal/Controllers/WebApi/ProjectCreateController.cs
+++ b/src/JoinRpg.Portal/Controllers/WebApi/ProjectCreateController.cs
@@ -1,5 +1,5 @@
 using JoinRpg.Services.Interfaces.Projects;
-using JoinRpg.Web.ProjectCommon.Projects;
+using JoinRpg.Web.Games.Projects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/JoinRpg.Portal/Views/Game/Create.cshtml
+++ b/src/JoinRpg.Portal/Views/Game/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@using JoinRpg.Web.ProjectCommon.Projects
+﻿@using JoinRpg.Web.Games.Projects
 
 @model ProjectCreateViewModel
 
@@ -8,4 +8,4 @@
 
 <h2>@ViewBag.Title</h2>
 
-    <component type="typeof(JoinRpg.Web.ProjectCommon.Projects.CreateProjectPanel)" render-mode="WebAssemblyPrerendered" />
+    <component type="typeof(JoinRpg.Web.Games.Projects.CreateProjectPanel)" render-mode="WebAssemblyPrerendered" />

--- a/src/JoinRpg.Web.Games/Projects/CreateProjectPanel.razor
+++ b/src/JoinRpg.Web.Games/Projects/CreateProjectPanel.razor
@@ -22,7 +22,7 @@
     <JoinAlert Variation="VariationStyleEnum.Danger">
         Проект был создан, вы можете перейти на <a href="/@(created.Value)/home">страницу проекта</a>.
         При настройке проекта согласно вашим запросам произошла ошибка. Обратитесь в техподдержку и/или проверьте настройки проекта вручную.
-        <br> 
+        <br>
         @createErrorResult
     </JoinAlert>
     return;
@@ -36,7 +36,7 @@
         <EditForm FormName="CreateProject" EditContext="@editContext" OnValidSubmit="HandleValidSubmit">
             <FormHorizontal>
                 <ValidationSummary />
-                <DataAnnotationsValidator />    
+                <DataAnnotationsValidator />
                 <FormRowFor For="@(() => Model.ProjectName)">
                     <JoinTextInput @bind-Value="Model.ProjectName" />
                 </FormRowFor>

--- a/src/JoinRpg.Web.Games/Projects/IProjectCreateClient.cs
+++ b/src/JoinRpg.Web.Games/Projects/IProjectCreateClient.cs
@@ -1,4 +1,4 @@
-namespace JoinRpg.Web.ProjectCommon.Projects;
+namespace JoinRpg.Web.Games.Projects;
 
 public interface IProjectCreateClient
 {

--- a/src/JoinRpg.Web.Games/Projects/ProjectCreateViewModel.cs
+++ b/src/JoinRpg.Web.Games/Projects/ProjectCreateViewModel.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-namespace JoinRpg.Web.ProjectCommon.Projects;
+namespace JoinRpg.Web.Games.Projects;
 
 public class ProjectCreateViewModel
 {

--- a/src/JoinRpg.WebPortal.Models.Test/EnumTests.cs
+++ b/src/JoinRpg.WebPortal.Models.Test/EnumTests.cs
@@ -9,8 +9,8 @@ using JoinRpg.Services.Interfaces.Projects;
 using JoinRpg.Web.Claims;
 using JoinRpg.Web.Claims.Finance;
 using JoinRpg.Web.Claims.UnifiedGrid;
+using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon.Fields;
-using JoinRpg.Web.ProjectCommon.Projects;
 using JoinRpg.Web.ProjectMasterTools.Settings;
 using MoreLinq;
 


### PR DESCRIPTION
## Что сделано
- `CreateProjectPanel`, `ProjectCreateViewModel` и `IProjectCreateClient` переехали из общего `JoinRpg.Web.ProjectCommon` в `JoinRpg.Web.Games` — по docs/structure.md это более точное место (UI страниц проекта, а не общие для всех страниц типы).
- Чисто перенос (namespace + правки using), поведение не меняется.

Первая часть подготовки к задаче про новый шаг «Есть ли это мероприятие на КогдаИгре?» в форме создания проекта — вынесена в отдельный PR, чтобы не смешивать рефакторинг с фичей.

## Test plan
- [x] `dotnet build` — 0 ошибок
- [x] `dotnet format --verify-no-changes --severity error` — без изменений
- [ ] Ручной проход формы создания проекта на деве

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCyadgCvP8ayb1pBQn5G1B