### PR TITLE
refactor: перенести KogdaIgraGameSelector в JoinRpg.Web.ProjectCommon и добавить список будущих игр

### DIFF
--- a/src/JoinRpg.Blazor.Client/ApiClients/HttpClientRegistration.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/HttpClientRegistration.cs
@@ -1,7 +1,6 @@
 using JoinRpg.Common.WebComponents;
 using JoinRpg.Web.Accommodation;
 using JoinRpg.Web.AdminTools;
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.CharacterGroups.GroupReport;
 using JoinRpg.Web.CharacterGroups.ProjectRoleGrid;
 using JoinRpg.Web.CheckIn;
@@ -12,6 +11,7 @@ using JoinRpg.Web.Plots;
 using JoinRpg.Web.ProjectCommon;
 using JoinRpg.Web.ProjectCommon.Claims;
 using JoinRpg.Web.ProjectCommon.Fields;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;
 using JoinRpg.Web.ProjectMasterTools.CaptainRules;
 using JoinRpg.Web.ProjectMasterTools.Fields;

--- a/src/JoinRpg.Blazor.Client/ApiClients/KogdaIgraClient.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/KogdaIgraClient.cs
@@ -1,5 +1,5 @@
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.Games.Projects;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.Blazor.Client.ApiClients;
 
@@ -9,6 +9,12 @@ public class KogdaIgraClient(HttpClient httpClient, ILogger<KogdaIgraClient> log
     public async Task<KogdaIgraShortViewModel[]> GetKogdaIgraCandidates()
     {
         return await httpClient.GetFromJsonAsync<KogdaIgraShortViewModel[]>("webapi/kogdaigra/GetKogdaIgraCandidates")
+            ?? throw new Exception("Couldn't get result from server");
+    }
+
+    public async Task<KogdaIgraShortViewModel[]> GetFutureKogdaIgraCandidates()
+    {
+        return await httpClient.GetFromJsonAsync<KogdaIgraShortViewModel[]>("webapi/kogdaigra/GetFutureKogdaIgraCandidates")
             ?? throw new Exception("Couldn't get result from server");
     }
     public async Task<KogdaIgraCardViewModel[]> GetKogdaIgraCards(IReadOnlyCollection<KogdaIgraIdentification> kogdaIgraIds)

--- a/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraRepository.cs
@@ -42,6 +42,18 @@ internal class KogdaIgraRepository(MyDbContext Ctx) : IKogdaIgraRepository
         return [.. result.Select(x => new KogdaIgraListItem(new KogdaIgraIdentification(x.KogdaIgraGameId), x.Name, x.Begin?.Year))];
     }
 
+    async Task<KogdaIgraListItem[]> IKogdaIgraRepository.GetActiveFuture()
+    {
+        var result = await GetSet()
+            .AsNoTracking()
+            .Where(ki => ki.Active)
+            .Where(ki => ki.Begin != null && ki.Begin.Value.Date >= DateTime.Today)
+            .Where(ki => ki.Name.Length > 0)
+            .Select(ki => new { ki.KogdaIgraGameId, ki.Name, ki.Begin })
+            .ToListAsync();
+        return [.. result.Select(x => new KogdaIgraListItem(new KogdaIgraIdentification(x.KogdaIgraGameId), x.Name, x.Begin?.Year))];
+    }
+
     public Task<int> GetNotUpdatedCount() => GetNotUpdatedQuery().CountAsync();
 
     async Task<ICollection<KogdaIgraGame>> IKogdaIgraRepository.GetByIds(IReadOnlyCollection<KogdaIgraIdentification> kogdaIgraIdentifications)

--- a/src/JoinRpg.Data.Interfaces/AdminTools/IKogdaIgraRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/AdminTools/IKogdaIgraRepository.cs
@@ -8,6 +8,7 @@ public record KogdaIgraListItem(KogdaIgraIdentification KogdaIgraId, string Name
 public interface IKogdaIgraRepository
 {
     Task<KogdaIgraListItem[]> GetActive();
+    Task<KogdaIgraListItem[]> GetActiveFuture();
     Task<ICollection<KogdaIgraGame>> GetByIds(IReadOnlyCollection<KogdaIgraIdentification> kogdaIgraIdentifications);
 
     Task<IReadOnlyCollection<KogdaIgraGameData>> GetDataByIds(IReadOnlyCollection<KogdaIgraIdentification> kogdaIgraIdentifications);

--- a/src/JoinRpg.Portal/Controllers/WebApi/KogdaIgraController.cs
+++ b/src/JoinRpg.Portal/Controllers/WebApi/KogdaIgraController.cs
@@ -1,0 +1,22 @@
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JoinRpg.Portal.Controllers.WebApi;
+
+/// <summary>
+/// В отличие от <see cref="KogdaIgraSyncController"/> (только для сайт-админов),
+/// эти методы доступны любому авторизованному пользователю — они нужны, например,
+/// форме создания проекта.
+/// </summary>
+[Route("/webapi/kogdaigra/[action]")]
+[Authorize]
+[IgnoreAntiforgeryToken]
+public class KogdaIgraController(IKogdaIgraSyncClient client) : ControllerBase
+{
+    [HttpGet]
+    public async Task<KogdaIgraShortViewModel[]> GetKogdaIgraCandidates() => await client.GetKogdaIgraCandidates();
+
+    [HttpGet]
+    public async Task<KogdaIgraShortViewModel[]> GetFutureKogdaIgraCandidates() => await client.GetFutureKogdaIgraCandidates();
+}

--- a/src/JoinRpg.Portal/Controllers/WebApi/KogdaIgraSyncController.cs
+++ b/src/JoinRpg.Portal/Controllers/WebApi/KogdaIgraSyncController.cs
@@ -1,5 +1,5 @@
 using JoinRpg.Portal.Infrastructure.Authorization;
-using JoinRpg.Web.AdminTools.KogdaIgra;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using Microsoft.AspNetCore.Mvc;
 
 namespace JoinRpg.Portal.Controllers.WebApi;
@@ -11,9 +11,6 @@ public class KogdaIgraSyncController(IKogdaIgraSyncClient client) : ControllerBa
 {
     [HttpGet]
     public async Task<SyncStatusViewModel> GetSyncStatus() => await client.GetSyncStatus();
-
-    [HttpGet]
-    public async Task<KogdaIgraShortViewModel[]> GetKogdaIgraCandidates() => await client.GetKogdaIgraCandidates();
 
     [HttpGet]
     public async Task<KogdaIgraShortViewModel[]> GetKogdaIgraNotUpdated() => await client.GetKogdaIgraNotUpdated();

--- a/src/JoinRpg.Portal/Pages/Admin/AdminHotRolesList.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/Admin/AdminHotRolesList.cshtml.cs
@@ -3,9 +3,9 @@ using JoinRpg.Data.Interfaces;
 using JoinRpg.Markdown;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using JoinRpg.Web.AdminTools;
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/JoinRpg.Portal/Pages/Admin/SyncWithKogdaIgra.cshtml
+++ b/src/JoinRpg.Portal/Pages/Admin/SyncWithKogdaIgra.cshtml
@@ -1,5 +1,6 @@
 ﻿@page "/admin/kogda-igra-sync"
 @using JoinRpg.Web.AdminTools.KogdaIgra
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @model JoinRpg.Portal.Pages.Admin.SyncWithKogdaIgraModel
 
 @{

--- a/src/JoinRpg.Portal/Pages/Admin/SyncWithKogdaIgra.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/Admin/SyncWithKogdaIgra.cshtml.cs
@@ -1,5 +1,5 @@
 using JoinRpg.Portal.Infrastructure.Authorization;
-using JoinRpg.Web.AdminTools.KogdaIgra;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace JoinRpg.Portal.Pages.Admin;

--- a/src/JoinRpg.Web.AdminTools/AdminHotRoleViewModel.cs
+++ b/src/JoinRpg.Web.AdminTools/AdminHotRoleViewModel.cs
@@ -1,5 +1,5 @@
-using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;
 using Microsoft.AspNetCore.Components;
 

--- a/src/JoinRpg.Web.AdminTools/AdminProjectGrid.razor
+++ b/src/JoinRpg.Web.AdminTools/AdminProjectGrid.razor
@@ -1,4 +1,4 @@
-@using JoinRpg.Web.AdminTools.KogdaIgra
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using JoinRpg.Web.ProjectCommon.Projects
 @using System.ComponentModel
 @using System.ComponentModel.DataAnnotations

--- a/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraForceGameSync.razor
+++ b/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraForceGameSync.razor
@@ -1,3 +1,4 @@
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @inject IKogdaIgraSyncClient Client
 
 <JoinPanel>

--- a/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraSyncList.razor
+++ b/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraSyncList.razor
@@ -1,3 +1,4 @@
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using JoinRpg.Web.ProjectCommon.Projects
 @using Microsoft.JSInterop
 @using System.ComponentModel.DataAnnotations

--- a/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraUpdater.razor
+++ b/src/JoinRpg.Web.AdminTools/KogdaIgra/KogdaIgraUpdater.razor
@@ -1,6 +1,7 @@
 @inject IKogdaIgraSyncClient Client
 @implements IDisposable
 @using JoinRpg.Web.AdminTools.Jobs
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using Timer = System.Timers.Timer
 
 @if (model is null)

--- a/src/JoinRpg.Web.AdminTools/ProjectAdminControlPanel.razor
+++ b/src/JoinRpg.Web.AdminTools/ProjectAdminControlPanel.razor
@@ -1,4 +1,4 @@
-@using JoinRpg.Web.AdminTools.KogdaIgra
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using JoinRpg.Web.ProjectCommon.Projects
 @using Microsoft.JSInterop
 @using System.ComponentModel.DataAnnotations

--- a/src/JoinRpg.Web.AdminTools/ProjectAdminListItemViewModel.cs
+++ b/src/JoinRpg.Web.AdminTools/ProjectAdminListItemViewModel.cs
@@ -1,4 +1,4 @@
-using JoinRpg.Web.Games.Projects;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;
 
 namespace JoinRpg.Web.AdminTools;

--- a/src/JoinRpg.Web.Games/Projects/KogdaIgraCard.razor
+++ b/src/JoinRpg.Web.Games/Projects/KogdaIgraCard.razor
@@ -1,3 +1,4 @@
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using JoinRpg.Web.ProjectCommon.Projects
 
 <JoinPanel>

--- a/src/JoinRpg.Web.Games/Projects/KogdaIgraDetails.razor
+++ b/src/JoinRpg.Web.Games/Projects/KogdaIgraDetails.razor
@@ -1,3 +1,4 @@
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @using JoinRpg.Web.ProjectCommon.Projects
 @using JoinRpg.Common.WebComponents
 

--- a/src/JoinRpg.Web.Games/Projects/ViewModels.cs
+++ b/src/JoinRpg.Web.Games/Projects/ViewModels.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Web.ProjectCommon;
 using JoinRpg.Web.ProjectCommon.Claims;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using Microsoft.AspNetCore.Components;
 
 namespace JoinRpg.Web.Games.Projects;
@@ -17,18 +18,6 @@ public record class ProjectInfoViewModel(
     KogdaIgraIdentification[] KogdaIgraLinkedIds)
 {
 }
-
-public record class KogdaIgraCardViewModel(
-    KogdaIgraIdentification KogdaIgraId,
-    Uri KogdaIgraUri,
-    string Name,
-    DateOnly Begin,
-    DateOnly End,
-    string RegionName,
-    string MasterGroupName, Uri? SiteUri,
-    VkId? Vk = null,
-    LiveJournalId? LiveJournal = null,
-    string? TelegramChannel = null);
 
 [method: JsonConstructor]
 public class ProjectDetailsViewModel(ProjectInfo project, MarkupString projectDescription, IReadOnlyCollection<ClaimLinkViewModel> claims,

--- a/src/JoinRpg.Web.ProjectCommon/KogdaIgra/Clients.cs
+++ b/src/JoinRpg.Web.ProjectCommon/KogdaIgra/Clients.cs
@@ -1,6 +1,4 @@
-using JoinRpg.Web.Games.Projects;
-
-namespace JoinRpg.Web.AdminTools.KogdaIgra;
+namespace JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 public interface IKogdaIgraSyncClient
 {
@@ -13,6 +11,8 @@ public interface IKogdaIgraSyncClient
     Task<SyncStatusViewModel> GetSyncStatus();
 
     Task<KogdaIgraShortViewModel[]> GetKogdaIgraCandidates();
+
+    Task<KogdaIgraShortViewModel[]> GetFutureKogdaIgraCandidates();
 
     Task<KogdaIgraShortViewModel[]> GetKogdaIgraNotUpdated();
 

--- a/src/JoinRpg.Web.ProjectCommon/KogdaIgra/KogdaIgraGameSelector.razor
+++ b/src/JoinRpg.Web.ProjectCommon/KogdaIgra/KogdaIgraGameSelector.razor
@@ -11,7 +11,7 @@
                SelectedValues="@KogdaIgraIds"
                SelectedValuesChanged="@KogdaIgraIdsChanged"
                SelectedItemsChanged="@KogdaIgrasChanged"
-               Multiple="true"
+               Multiple="@Multiple"
                />
 
 @code {
@@ -24,10 +24,18 @@
     [Parameter] public EventCallback<KogdaIgraShortViewModel[]> KogdaIgrasChanged { get; set; }
     [Parameter] public KogdaIgraShortViewModel[]? InitialList { get; set; }
 
+    /// <summary>Разрешить выбор нескольких игр (по умолчанию — как в админке).</summary>
+    [Parameter] public bool Multiple { get; set; } = true;
+
+    /// <summary>Загружать только будущие игры (используется формой создания проекта).</summary>
+    [Parameter] public bool FutureOnly { get; set; } = false;
+
     private KogdaIgraShortViewModel[]? itemModels;
 
     protected override async Task OnInitializedAsync()
     {
-        itemModels = InitialList ?? await client.GetKogdaIgraCandidates();
+        itemModels = InitialList ?? (FutureOnly
+            ? await client.GetFutureKogdaIgraCandidates()
+            : await client.GetKogdaIgraCandidates());
     }
 }

--- a/src/JoinRpg.Web.ProjectCommon/KogdaIgra/ViewModels.cs
+++ b/src/JoinRpg.Web.ProjectCommon/KogdaIgra/ViewModels.cs
@@ -1,6 +1,6 @@
 using JoinRpg.Common.WebComponents;
 
-namespace JoinRpg.Web.AdminTools.KogdaIgra;
+namespace JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 public record class JoinRpgSyncCandidateViewModel(
     ProjectIdentification ProjectId, string Name, UserLinkViewModel[] Masters, DateTimeOffset LastUpdatedAt, MarkdownString? Description);
@@ -11,6 +11,18 @@ public record class KogdaIgraBindViewModel(
     bool DisableKogdaIgraMapping);
 
 public record class KogdaIgraShortViewModel(KogdaIgraIdentification KogdaIgraId, string Name, Uri KogdaIgraLink, int? Year);
+
+public record class KogdaIgraCardViewModel(
+    KogdaIgraIdentification KogdaIgraId,
+    Uri KogdaIgraUri,
+    string Name,
+    DateOnly Begin,
+    DateOnly End,
+    string RegionName,
+    string MasterGroupName, Uri? SiteUri,
+    VkId? Vk = null,
+    LiveJournalId? LiveJournal = null,
+    string? TelegramChannel = null);
 
 public record class ResyncOperationResultsViewModel(bool OperationSuccessful, string OperationStatusMessage, SyncStatusViewModel SyncStatus);
 

--- a/src/JoinRpg.WebPortal.Managers/AdminTools/KogdaIgraSyncManager.cs
+++ b/src/JoinRpg.WebPortal.Managers/AdminTools/KogdaIgraSyncManager.cs
@@ -1,8 +1,8 @@
 using JoinRpg.Common.KogdaIgraClient;
 using JoinRpg.Data.Interfaces.AdminTools;
 using JoinRpg.Services.Interfaces.Integrations.KogdaIgra;
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.Games.Projects;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.WebPortal.Managers.AdminTools;
 
@@ -17,6 +17,12 @@ internal class KogdaIgraSyncManager(
     public async Task<KogdaIgraShortViewModel[]> GetKogdaIgraCandidates()
     {
         var items = await kogdaIgraRepository.GetActive();
+        return ToShortViewModels(items);
+    }
+
+    public async Task<KogdaIgraShortViewModel[]> GetFutureKogdaIgraCandidates()
+    {
+        var items = await kogdaIgraRepository.GetActiveFuture();
         return ToShortViewModels(items);
     }
 

--- a/src/JoinRpg.WebPortal.Managers/AdminTools/ViewModelBuilders.cs
+++ b/src/JoinRpg.WebPortal.Managers/AdminTools/ViewModelBuilders.cs
@@ -1,7 +1,7 @@
 using JoinRpg.Common.KogdaIgraClient;
 using JoinRpg.Services.Interfaces.Integrations.KogdaIgra;
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.Games.Projects;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.WebPortal.Managers.AdminTools;
 

--- a/src/JoinRpg.WebPortal.Managers/Registration.cs
+++ b/src/JoinRpg.WebPortal.Managers/Registration.cs
@@ -1,7 +1,6 @@
 using JoinRpg.Common.WebComponents;
 using JoinRpg.Web.Accommodation;
 using JoinRpg.Web.AdminTools;
-using JoinRpg.Web.AdminTools.KogdaIgra;
 using JoinRpg.Web.AdminTools.Notifications;
 using JoinRpg.Web.CharacterGroups.GroupReport;
 using JoinRpg.Web.CharacterGroups.ProjectRoleGrid;
@@ -13,6 +12,7 @@ using JoinRpg.Web.Plots;
 using JoinRpg.Web.ProjectCommon;
 using JoinRpg.Web.ProjectCommon.Claims;
 using JoinRpg.Web.ProjectCommon.Fields;
+using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;
 using JoinRpg.Web.ProjectMasterTools.CaptainRules;
 using JoinRpg.Web.ProjectMasterTools.Fields;


### PR DESCRIPTION
## Что сделано
- Клиентские интерфейсы/DTO КогдаИгры (`IKogdaIgraSyncClient`, `IKogdaIgraBindClient`, `KogdaIgraShortViewModel`, `KogdaIgraCardViewModel` и т.д.) переехали из `JoinRpg.Web.AdminTools` в `JoinRpg.Web.ProjectCommon`, чтобы `KogdaIgraGameSelector` стал доступен не только админке.
- Компонент `KogdaIgraGameSelector` получил параметры `Multiple` (одиночный/множественный выбор) и `FutureOnly` (загружать только будущие игры) — дефолты сохраняют текущее поведение админских экранов без изменений.
- Добавлены `IKogdaIgraRepository.GetActiveFuture()` и публичный (доступный не только админам) эндпоинт `GetFutureKogdaIgraCandidates` — понадобятся форме создания проекта в отдельной задаче.

Вторая часть подготовки к задаче про новый шаг «Есть ли это мероприятие на КогдаИгре?» в форме создания проекта — вынесена в отдельный PR, чтобы не смешивать рефакторинг с фичей. Не зависит от #4616 (первый PR про перенос флоу создания проекта) — можно смержить в любом порядке.

## Test plan
- [x] `dotnet build` — 0 ошибок
- [x] `dotnet format --verify-no-changes --severity error` — без изменений
- [ ] Ручная проверка админ-экранов КогдаИгры (`/admin/kogda-igra-sync`, привязка к проекту)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCyadgCvP8ayb1pBQn5G1B