### PR TITLE
Перевести PlotFolderSelector на TypedSelector

### DIFF
--- a/src/JoinRpg.Portal/Controllers/PlotController.cs
+++ b/src/JoinRpg.Portal/Controllers/PlotController.cs
@@ -91,7 +91,7 @@ public class PlotController(
 
     #region Create elements
     [HttpGet, MasterAuthorize()]
-    public async Task<ActionResult> CreateElement(ProjectIdentification projectId, int? plotFolderId, PlotElementIdentification? copyFrom)
+    public async Task<ActionResult> CreateElement(ProjectIdentification projectId, PlotFolderIdentification? plotFolderId, PlotElementIdentification? copyFrom)
     {
         var folders = await plotRepository.GetPlots(projectId);
         if (folders.Count == 0)
@@ -110,7 +110,7 @@ public class PlotController(
         }
 
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
-        var selectedPlotFolderId = plotFolderId ?? copyFrom?.PlotFolderId?.PlotFolderId;
+        var selectedPlotFolderId = plotFolderId ?? copyFrom?.PlotFolderId;
 
         return View(new PlotElementCreateViewModel()
         {
@@ -126,28 +126,26 @@ public class PlotController(
     }
 
     [HttpPost, MasterAuthorize(), ValidateAntiForgeryToken]
-    public async Task<ActionResult> CreateElement(ProjectIdentification projectId, int plotFolderId, string content,
+    public async Task<ActionResult> CreateElement(ProjectIdentification projectId, PlotFolderIdentification plotFolderId, string content,
       string todoField, IReadOnlyCollection<CharacterIdentification>? targetCharacters, ICollection<int>? targetGroups, PlotElementTypeView elementType, bool publishNow, bool isMasterOnly)
     {
-        PlotFolderIdentification plotFolderId1 = new(projectId, plotFolderId);
-
         var targetGroupIds = CharacterGroupIdentification.FromList(targetGroups ?? [], projectId).ToList();
         var targetCharIds = (targetCharacters ?? []).EnsureProject(projectId);
         try
         {
             var versionId =
-                await plotService.CreatePlotElement(plotFolderId1, content, todoField, targetGroupIds, targetCharIds, (PlotElementType)elementType, isMasterOnly);
+                await plotService.CreatePlotElement(plotFolderId, content, todoField, targetGroupIds, targetCharIds, (PlotElementType)elementType, isMasterOnly);
 
             if (publishNow && string.IsNullOrWhiteSpace(todoField) && (isMasterOnly || targetGroupIds.Count != 0 || targetCharIds.Count != 0))
             {
                 await plotService.PublishElementVersion(versionId, sendNotification: false, commentText: null);
             }
-            return ReturnToPlot(plotFolderId1);
+            return ReturnToPlot(plotFolderId);
         }
         catch (Exception exception)
         {
             AddModelException(exception);
-            var folder = await plotRepository.GetPlotFolderAsync(plotFolderId1);
+            var folder = await plotRepository.GetPlotFolderAsync(plotFolderId);
             if (folder == null)
             {
                 return NotFound();
@@ -216,7 +214,7 @@ public class PlotController(
         var viewModel = new PlotElementEditViewModel()
         {
             ProjectId = element.PlotFolder.ProjectId,
-            PlotFolderId = element.PlotFolderId,
+            PlotFolderId = new PlotFolderIdentification(projectId, element.PlotFolderId),
             PlotElementId = element.PlotElementId,
             PlotFolderName = folder.MasterTitle,
             ElementType = (PlotElementTypeView)element.ElementType,

--- a/src/JoinRpg.Web.Plots/PlotElementEditModels.cs
+++ b/src/JoinRpg.Web.Plots/PlotElementEditModels.cs
@@ -13,7 +13,7 @@ public abstract class PlotElementViewModelBase
     public int ProjectId { get; set; }
 
     [Display(Name = "Сюжет", Description = "Сюжет выступает в роли папки для вводных")]
-    public int? PlotFolderId { get; set; }
+    public PlotFolderIdentification? PlotFolderId { get; set; }
 
     [Display(Name = "Текст"), Required]
     public string Content { get; set; } = "";

--- a/src/JoinRpg.Web.Plots/PlotElementEditPanel.razor
+++ b/src/JoinRpg.Web.Plots/PlotElementEditPanel.razor
@@ -26,7 +26,7 @@
         </FormRowFor>
 
         <FormRow Label="Сюжет">
-            <input type="hidden" name="PlotFolderId" value="@editModel.PlotFolderId" />
+            <input type="hidden" name="PlotFolderId" value="@editModel.PlotFolderId?.PlotFolderId" />
             <input type="hidden" name="plotelementid" value="@editModel.PlotElementId" />
             <span>@editModel.PlotFolderName</span>
         </FormRow>

--- a/src/JoinRpg.Web.Plots/PlotFolderSelector.razor
+++ b/src/JoinRpg.Web.Plots/PlotFolderSelector.razor
@@ -1,55 +1,36 @@
 @inject IPlotClient client
 
-@if (items is null)
-{
-    <JoinLoadingMessage />
-}
-else
-{
-    int[] initial = SelectedId is not null ? [SelectedId.Value] : [];
-    <IntSelector
-    Name="@Name"
-    SelectedValues="@initial"
-    SelectedValuesChanged="SelectedValuesChanged"
-    PossibleValues="items"
-    Multiple="@false"
-    />
-}
+<TypedSelector TKey="PlotFolderIdentification" TItem="PlotFolderDto"
+               Name="@Name"
+               Items="folders"
+               KeySelector="@(f => f.PlotFolderId)"
+               ToListItem="@(f => TypedSelectList.CreateItem(
+                   Value: f.PlotFolderId,
+                   Text: f.Name))"
+               SelectedValues="initial"
+               SelectedItemsChanged="HandleSelectedItemsChanged"
+               Multiple="false"
+               />
 
 @code {
 
     [Parameter] public string? Name { get; set; } = null;
     [Parameter][EditorRequired] public ProjectIdentification ProjectId { get; set; } = null!;
-    [Parameter] public int? SelectedId { get; set; } 
-    [Parameter] public EventCallback<int[]> SelectedIdsChanged { get; set; }
+    [Parameter] public PlotFolderIdentification? SelectedId { get; set; }
+    [Parameter] public EventCallback<PlotFolderIdentification[]> SelectedIdsChanged { get; set; }
     [Parameter] public EventCallback<PlotFolderDto[]> SelectedChanged { get; set; }
 
-    public string SelectedCharactersText{ get; private set; } = "";
+    private PlotFolderDto[]? folders;
+    private PlotFolderIdentification[] initial => SelectedId is not null ? [SelectedId] : [];
 
-    private IntSelectListItem[] items = null!;
-    private PlotFolderDto[] folders = null!;
-
-    private async Task SelectedValuesChanged(int[] values)
+    private async Task HandleSelectedItemsChanged(PlotFolderDto[] selectedItems)
     {
-        values = [..values.Where(v => v != -1)];
-
-        var selectedItems = folders.Where(item => values.Contains(item.PlotFolderId.PlotFolderId)).ToArray();
-        await SelectedIdsChanged.InvokeAsync(values);
+        await SelectedIdsChanged.InvokeAsync(selectedItems.Select(x => x.PlotFolderId).ToArray());
         await SelectedChanged.InvokeAsync(selectedItems);
     }
 
     protected override async Task OnInitializedAsync()
     {
         folders = await client.GetPlotFoldersList(ProjectId);
-        items = [.. folders.Select(ToSelectListItem)];
-    }
-
-    private static IntSelectListItem ToSelectListItem(PlotFolderDto item)
-    {
-        return new IntSelectListItem(
-          Value: item.PlotFolderId.PlotFolderId,
-          Text: item.Name,
-          Subtext: "",
-          ExtraSearch: "");
     }
 }


### PR DESCRIPTION
## Что сделано
- `PlotFolderSelector` переведён с `IntSelector` на `TypedSelector` с типизированным ключом `PlotFolderIdentification` вместо голого `int`
- `PlotElementViewModelBase.PlotFolderId` теперь `PlotFolderIdentification?`
- `PlotController.CreateElement` (GET/POST) принимает `PlotFolderIdentification` вместо `int`, биндинг идёт через существующий `ProjectEntityIdModelBinder`
- `PlotController.EditElement` (GET) собирает `PlotFolderIdentification` из данных сущности; POST и hidden-поле в форме редактирования остались без изменений (plain int), так как там folder не выбирается через селектор

## Test plan
- [x] `dotnet build` всего решения — без ошибок
- [x] `dotnet test src/JoinRpg.Web.Plots.Tests` — все тесты проходят
- [ ] Ручная проверка в браузере: создание вводной с выбором сюжета через селектор