### PR TITLE
fix: TelegramId.TryParse не парсит отрицательные chat id

### DIFF
--- a/src/JoinRpg.Common.PrimitiveTypes.Test/TelegramIdParseTest.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes.Test/TelegramIdParseTest.cs
@@ -54,4 +54,22 @@ public class TelegramIdParseTest
         TelegramId.TryParse(val, provider: null, out var parseResult).ShouldBeTrue();
         parseResult.ShouldBe(version);
     }
+
+    [Theory]
+    [InlineData("Telegram(-1004315256401)")]
+    [InlineData("-1004315256401")]
+    public void TelegramIdShouldParseNegativeChannelId(string val)
+    {
+        TelegramId.TryParse(val, provider: null, out var parseResult).ShouldBeTrue();
+        parseResult.ShouldBe(new TelegramId(-1004315256401, null));
+    }
+
+    [Fact]
+    public void NegativeChannelIdShouldRoundTrip()
+    {
+        var version = new TelegramId(-1004315256401, null);
+        var val = version.ToString();
+        TelegramId.TryParse(val, provider: null, out var parseResult).ShouldBeTrue();
+        parseResult.ShouldBe(version);
+    }
 }

--- a/src/JoinRpg.Common.PrimitiveTypes/Users/TelegramId.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/Users/TelegramId.cs
@@ -11,23 +11,28 @@ public record TelegramId(long Id, PrefferedName? UserName) : ISpanParsable<Teleg
 
     public static bool TryParse([NotNullWhen(true)] ReadOnlySpan<char> value, IFormatProvider? provider, [MaybeNullWhen(false)] out TelegramId result)
     {
+        // Не используем общий IdentificationParseHelper.SplitIdentifier — он делит и по ',', и по
+        // '-', а chat id каналов/супергрупп в Telegram отрицательный, так что '-' здесь не
+        // разделитель, а часть числа. TelegramId делит только по ',' (перед именем пользователя).
         ReadOnlySpan<char> val = IdentificationParseHelper.RemovePrefixes(value, [nameof(TelegramId), "Telegram"]);
-        Span<Range> ranges = stackalloc Range[2];
-        var count = IdentificationParseHelper.SplitIdentifier(val, ranges);
-        if (count == 2
-           && long.TryParse(val[ranges[0]], provider, out var i1)
-           )
+
+        var commaIndex = val.IndexOf(',');
+        if (commaIndex < 0)
         {
-            var usernameSpan = val[ranges[1]].TrimStart('@');
-            result = new TelegramId(i1, string.IsNullOrWhiteSpace(usernameSpan.ToString()) ? null : new PrefferedName(usernameSpan.ToString()));
-            return true;
+            if (long.TryParse(val.Trim(), provider, out var i))
+            {
+                result = new TelegramId(i, null);
+                return true;
+            }
+
+            result = null!;
+            return false;
         }
 
-        if (count == 1
-          && long.TryParse(val[ranges[0]], provider, out var i)
-          )
+        if (long.TryParse(val[..commaIndex].Trim(), provider, out var i1))
         {
-            result = new TelegramId(i, null);
+            var usernameSpan = val[(commaIndex + 1)..].Trim().TrimStart('@');
+            result = new TelegramId(i1, string.IsNullOrWhiteSpace(usernameSpan.ToString()) ? null : new PrefferedName(usernameSpan.ToString()));
             return true;
         }
 


### PR DESCRIPTION
## Что сделано
- `TelegramId.TryParse` парсил chat id через общий `IdentificationParseHelper.SplitIdentifier`, который делит строку по `,` и по `-`. Из-за этого отрицательные chat id Telegram-каналов/супергрупп (например `-1004315256401`) не парсились вовсе — `-` воспринимался как разделитель полей, а не часть числа.
- Личные Telegram ID пользователей всегда положительные, поэтому баг был незаметен до сих пор — вскрылся при работе с рекламными Telegram-каналами (у них отрицательные chat id).
- `TelegramId.TryParse` теперь делит строку только по `,` (перед именем пользователя), не трогая общий `SplitIdentifier` — он используется другими составными идентификаторами (например `ClaimIdentification`), где `-` — легитимный разделитель полей.

## Тесты
- Регрессионные юнит-тесты на парсинг и round-trip отрицательных chat id (`TelegramIdParseTest`).

Generated with [Claude Code](https://claude.com/claude-code)