### PR TITLE
fix: возвращать сообщение в очередь при общей ошибке отправки в SenderJobService

### DIFF
--- a/src/JoinRpg.Services.Notifications.Tests/SenderJobServiceCommonFailureTest.cs
+++ b/src/JoinRpg.Services.Notifications.Tests/SenderJobServiceCommonFailureTest.cs
@@ -1,0 +1,107 @@
+using JoinRpg.Data.Write.Interfaces.Notifications;
+using JoinRpg.DomainTypes.Notifications;
+using JoinRpg.Interfaces;
+using JoinRpg.Services.Notifications.Senders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace JoinRpg.Services.Notifications.Tests;
+
+public class SenderJobServiceCommonFailureTest
+{
+    [Fact]
+    public async Task CommonFailure_ReturnsMessageToQueue_WithoutConsumingAttempt()
+    {
+        var repository = new FakeNotificationRepository();
+        var messageId = new NotificationId(42);
+        var message = new TargetedNotificationMessageForRecipient(
+            new NotificationMessageForRecipient(new MarkdownString("body"), new UserIdentification(1), "header", new UserIdentification(2), null, DateTimeOffset.UtcNow),
+            NotificationAddress.Ui(),
+            Attempts: 3,
+            messageId);
+        repository.Enqueue(message);
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSingleton<INotificationRepository>(repository);
+        builder.Services.Configure<NotificationWorkerOptions>(o =>
+        {
+            // Один сбой сразу переводит джобу в кулдаун, а нулевой MaxCooldownPause сразу его останавливает —
+            // так итерация обработки одного сообщения завершается предсказуемо, без реальных задержек.
+            o.MaxSubsequentFailures = 1;
+            o.MaxCooldownPause = TimeSpan.Zero;
+            o.EmptyPause = TimeSpan.FromMilliseconds(10);
+        });
+        builder.Services.AddSenderJob<CommonFailureSenderJob>();
+
+        using var host = builder.Build();
+        await host.StartAsync();
+        await Task.WhenAny(repository.ProcessedSignal.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await host.StopAsync();
+
+        repository.ProcessedSignal.Task.IsCompletedSuccessfully.ShouldBeTrue();
+        repository.MarkSendingFailedCalls.ShouldBeEmpty();
+        repository.MarkSendingSucceededCalls.ShouldBeEmpty();
+        var call = repository.MarkEnqueuedCalls.ShouldHaveSingleItem();
+        call.Id.ShouldBe(messageId);
+        call.Channel.ShouldBe(NotificationChannel.ShowInUi);
+        call.Attempts.ShouldBe(3); // общая ошибка не должна тратить попытку сообщения
+    }
+
+    private sealed class CommonFailureSenderJob : ISenderJob
+    {
+        public static NotificationChannel Channel => NotificationChannel.ShowInUi;
+
+        public NotificationChannel InstanceChannel => Channel;
+
+        public bool Enabled => true;
+
+        public Task<SendingResult> SendAsync(TargetedNotificationMessageForRecipient message, CancellationToken stoppingToken)
+            => Task.FromResult(SendingResult.CommonFailure());
+    }
+
+    private sealed class FakeNotificationRepository : INotificationRepository
+    {
+        private readonly Queue<TargetedNotificationMessageForRecipient> queue = new();
+
+        public List<(NotificationId Id, NotificationChannel Channel, DateTimeOffset SendAfter, int? Attempts)> MarkEnqueuedCalls { get; } = [];
+
+        public List<(NotificationId Id, NotificationChannel Channel)> MarkSendingFailedCalls { get; } = [];
+
+        public List<(NotificationId Id, NotificationChannel Channel)> MarkSendingSucceededCalls { get; } = [];
+
+        public TaskCompletionSource ProcessedSignal { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Enqueue(TargetedNotificationMessageForRecipient message) => queue.Enqueue(message);
+
+        public Task<TargetedNotificationMessageForRecipient?> SelectNextNotificationForSending(NotificationChannel channel)
+            => Task.FromResult(queue.Count > 0 ? queue.Dequeue() : null);
+
+        public Task MarkSendingSucceeded(NotificationId id, NotificationChannel channel)
+        {
+            MarkSendingSucceededCalls.Add((id, channel));
+            _ = ProcessedSignal.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task MarkSendingFailed(NotificationId id, NotificationChannel channel)
+        {
+            MarkSendingFailedCalls.Add((id, channel));
+            _ = ProcessedSignal.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task MarkEnqueued(NotificationId id, NotificationChannel channel, DateTimeOffset sendAfter, int? attempts = null)
+        {
+            MarkEnqueuedCalls.Add((id, channel, sendAfter, attempts));
+            _ = ProcessedSignal.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task InsertNotifications(NotificationMessageCreateDto[] notifications) => throw new NotSupportedException();
+
+        public Task<IReadOnlyCollection<NotificationHistoryDto>> GetLastNotificationsForUser(UserIdentification userId, NotificationChannel notificationChannel, KeySetPagination pagination)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyDictionary<NotificationChannel, int>> GetQueueLengths() => throw new NotSupportedException();
+    }
+}

--- a/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/SenderJobService.cs
@@ -188,8 +188,10 @@ internal class SenderJobService<TSender>(IServiceProvider serviceProvider,
                 if (sendingResult.Common)
                 {
                     numberOfCommonFailuresCounter.Add(1);
-                    logger.LogWarning("Произошла общая ошибка отправки при отправке сообщения {messageId}", nextMessage.MessageId);
+                    logger.LogWarning("Произошла общая ошибка отправки при отправке сообщения {messageId}, возвращаем в очередь", nextMessage.MessageId);
                     FailureCounter = WorkerOptions.MaxSubsequentFailures; // Сразу выходим в кулдаун, не ждем пока накопятся ошибки.
+                    // Ошибка не связана с сообщением — не тратим его попытку, просто возвращаем в очередь.
+                    await notificationRepository.MarkEnqueued(nextMessage.MessageId, channel, DateTimeOffset.UtcNow, nextMessage.Attempts);
                 }
                 else if (nextMessage.Attempts <= WorkerOptions.MaxAttempts && sendingResult.Repeatable)
                 {


### PR DESCRIPTION
## Что сделано
- Исправлен баг в `SenderJobService<TSender>.RunIteration`: при общей (не связанной с конкретным сообщением) ошибке отправки джоба уходила в кулдаун, но не возвращала сообщение обратно в очередь. Поскольку `SelectNextNotificationForSending` уже переводил сообщение в статус `Sending` до попытки отправки, оно навсегда застревало в этом статусе — не `Failed`, но и больше никогда не выбиралось для повторной отправки.
- Теперь при `SendingResult.Common == true` сообщение возвращается в очередь через `MarkEnqueued` с исходным (не увеличенным) значением `Attempts` — общая ошибка сервиса не связана с самим сообщением и не должна тратить его попытку.
- Добавлен юнит-тест `SenderJobServiceCommonFailureTest`, воспроизводящий баг через реальный `Host` с фейковыми `INotificationRepository`/`ISenderJob` (тест падает на коде до фикса и проходит после).

## Test plan
- [x] `dotnet build`
- [x] `dotnet test src/JoinRpg.Services.Notifications.Tests` — все 17 тестов проходят
- [x] Новый тест проверен на падение против кода до фикса
- [x] `dotnet format --verify-no-changes --severity error` для изменённых файлов

Generated with [Claude Code](https://claude.ai/code)