### PR TITLE
feat: добавить поддержку proxy для Telegram-бота

### DIFF
--- a/src/JoinRpg.Common.Telegram.Test/TelegramHttpClientFactoryTest.cs
+++ b/src/JoinRpg.Common.Telegram.Test/TelegramHttpClientFactoryTest.cs
@@ -1,0 +1,45 @@
+namespace JoinRpg.Common.Telegram.Test;
+
+public class TelegramHttpClientFactoryTest
+{
+    [Fact]
+    public void Create_WithNullOptions_ReturnsNull()
+    {
+        var result = TelegramHttpClientFactory.Create(null);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_WithAddressOnly_ReturnsHttpClient()
+    {
+        var options = new TelegramProxyOptions { Address = "http://proxy.example.com:8080" };
+
+        var result = TelegramHttpClientFactory.Create(options);
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Create_WithSocks5AddressAndCredentials_ReturnsHttpClient()
+    {
+        var options = new TelegramProxyOptions
+        {
+            Address = "socks5://proxy.example.com:1080",
+            Username = "user",
+            Password = "pass",
+        };
+
+        var result = TelegramHttpClientFactory.Create(options);
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Create_WithInvalidAddress_ThrowsUriFormatException()
+    {
+        var options = new TelegramProxyOptions { Address = "not a uri" };
+
+        _ = Should.Throw<UriFormatException>(() => TelegramHttpClientFactory.Create(options));
+    }
+}

--- a/src/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
+++ b/src/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
@@ -3,6 +3,7 @@ using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Services.Interfaces.Notification;
 using Microsoft.Extensions.Logging.Abstractions;
 using Telegram.Bot;
+using Telegram.Bot.Exceptions;
 
 namespace JoinRpg.Common.Telegram.Test;
 

--- a/src/JoinRpg.Common.Telegram/README.md
+++ b/src/JoinRpg.Common.Telegram/README.md
@@ -1,0 +1,53 @@
+# JoinRpg.Common.Telegram
+
+Интеграция с Telegram Bot API: отправка уведомлений и валидация Telegram Login Widget.
+Используется библиотека [Telegram.Bot](https://github.com/TelegramBots/Telegram.Bot).
+
+## Настройки
+
+Настройки биндятся из секции `Telegram` в `appsettings.json` (класс `TelegramLoginOptions`),
+подключение — через `services.AddJoinTelegram()` (`Registration.cs`).
+
+```json
+"Telegram": {
+  "BotName": "",
+  "BotId": "",
+  "BotSecret": "",
+  "AllowedTimeOffset": "00:00:30",
+  "Proxy": {
+    "Address": "socks5://proxy.example.com:1080",
+    "Username": "",
+    "Password": ""
+  }
+}
+```
+
+| Параметр | Обязателен | Описание |
+|---|---|---|
+| `BotName` | нет | Имя бота (`@username` без `@`). Используется в Telegram Login Widget. Пока пусто — Telegram-интеграция считается выключенной (`Enabled == false`), уведомления шлёт заглушка `StubTelegramNotificationService`, а не реальный бот. |
+| `BotId` | да, если `BotName` задан | Numeric id бота, первая часть токена (`{BotId}:{BotSecret}`). |
+| `BotSecret` | да, если `BotName` задан | Секретная часть токена бота, выданная BotFather. |
+| `AllowedTimeOffset` | нет (по умолчанию 30 секунд) | Насколько старым может быть `auth_date` в ответе Login Widget, чтобы попытка входа считалась валидной. |
+| `Proxy` | нет | Настройки proxy для исходящих запросов к Telegram Bot API (см. ниже). Если не задано — используется прямое подключение. |
+
+### Proxy
+
+Если Telegram Bot API недоступен напрямую (например, из-за блокировок), можно направить весь трафик бота
+через HTTP или SOCKS5 proxy — секция `Telegram:Proxy` (класс `TelegramProxyOptions`).
+
+| Параметр | Обязателен | Описание |
+|---|---|---|
+| `Address` | да (если секция `Proxy` задана) | Адрес proxy в виде URI. Схема определяет тип proxy: `http://host:port` — HTTP-proxy, `socks5://host:port` (или `socks4://`) — SOCKS-proxy. |
+| `Username` | нет | Логин для аутентификации на proxy. |
+| `Password` | нет | Пароль для аутентификации на proxy (используется только если задан `Username`). |
+
+Реализация — `TelegramHttpClientFactory.Create(TelegramProxyOptions?)`: строит `HttpClient` с `WebProxy`,
+который передаётся в конструктор `TelegramBotClient`. Если `Proxy` не задан, `TelegramBotClient` создаётся
+с `HttpClient` по умолчанию (`httpClient: null`) — прямое подключение, как раньше.
+
+## Health check
+
+`HealthCheckTelegram` (регистрируется как `"Telegram client"`) вызывает `GetMyUserName` через
+`ITelegramNotificationService`: `Degraded`, если Telegram выключен (`BotName` пуст), `Healthy` — если бот
+отвечает. Проверка идёт через тот же `TelegramBotClient`, поэтому неверно настроенный `Proxy` тоже приведёт
+к ошибке в этом health check.

--- a/src/JoinRpg.Common.Telegram/Registration.cs
+++ b/src/JoinRpg.Common.Telegram/Registration.cs
@@ -24,8 +24,9 @@ public static class Registration
             })
             .AddSingleton(services =>
             {
-                var options = services.GetRequiredService<IOptions<TelegramLoginOptions>>();
-                return new TelegramBotClient($"{options.Value.BotId}:{options.Value.BotSecret}");
+                var options = services.GetRequiredService<IOptions<TelegramLoginOptions>>().Value;
+                var httpClient = TelegramHttpClientFactory.Create(options.Proxy);
+                return new TelegramBotClient($"{options.BotId}:{options.BotSecret}", httpClient);
             });
 
 

--- a/src/JoinRpg.Common.Telegram/TelegramHttpClientFactory.cs
+++ b/src/JoinRpg.Common.Telegram/TelegramHttpClientFactory.cs
@@ -1,0 +1,22 @@
+using System.Net;
+
+namespace JoinRpg.Common.Telegram;
+
+public static class TelegramHttpClientFactory
+{
+    public static HttpClient? Create(TelegramProxyOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        var webProxy = new WebProxy(new Uri(options.Address));
+        if (!string.IsNullOrEmpty(options.Username))
+        {
+            webProxy.Credentials = new NetworkCredential(options.Username, options.Password);
+        }
+
+        return new HttpClient(new HttpClientHandler { Proxy = webProxy, UseProxy = true });
+    }
+}

--- a/src/JoinRpg.Common.Telegram/TelegramLoginOptions.cs
+++ b/src/JoinRpg.Common.Telegram/TelegramLoginOptions.cs
@@ -11,5 +11,7 @@ public class TelegramLoginOptions
     /// </summary>
     public TimeSpan AllowedTimeOffset { get; set; } = TimeSpan.FromSeconds(30);
 
+    public TelegramProxyOptions? Proxy { get; set; }
+
     public bool Enabled => !string.IsNullOrWhiteSpace(BotName);
 }

--- a/src/JoinRpg.Common.Telegram/TelegramProxyOptions.cs
+++ b/src/JoinRpg.Common.Telegram/TelegramProxyOptions.cs
@@ -1,0 +1,11 @@
+namespace JoinRpg.Common.Telegram;
+
+public class TelegramProxyOptions
+{
+    /// <summary>
+    /// Адрес proxy в виде URI, например http://host:8080 или socks5://host:1080
+    /// </summary>
+    public required string Address { get; set; }
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+}


### PR DESCRIPTION
## Что сделано
- `TelegramProxyOptions` — новая секция конфигурации `Telegram:Proxy` (`Address`, `Username`, `Password`)
- `TelegramHttpClientFactory` — строит `HttpClient` с `WebProxy` (поддерживает схемы `http://` и `socks5://`/`socks4://`) для передачи в `TelegramBotClient`
- `TelegramLoginOptions.Proxy` — nullable-свойство, при отсутствии proxy поведение не меняется (прямое подключение)
- Добавлен `README.md` в `JoinRpg.Common.Telegram` с описанием всех настроек секции `Telegram`, включая `Proxy`
- Юнит-тесты для `TelegramHttpClientFactory`

## Test plan
- [x] `dotnet build`
- [x] `dotnet test src/JoinRpg.Common.Telegram.Test`
- [x] `dotnet format --verify-no-changes --severity error`

Generated with [Claude Code](https://claude.ai/code)