### PR TITLE
feat: поддержка long в генераторе TypedEntityId, добавить TelegramChatId

### DIFF
--- a/src/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
@@ -34,6 +34,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
             return null;
         }
 
+
         var attrData = ctx.Attributes.FirstOrDefault();
         if (attrData == null)
         {
@@ -43,6 +44,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         // Извлекаем свойства атрибута
         string? shortName = null;
         var additionalPrefixes = new List<string>();
+        bool allowNonPositive = false;
 
         foreach (var namedArg in attrData.NamedArguments)
         {
@@ -59,6 +61,10 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
                         additionalPrefixes.Add(s);
                     }
                 }
+            }
+            else if (namedArg.Key == "AllowNonPositive" && namedArg.Value.Value is bool anp)
+            {
+                allowNonPositive = anp;
             }
         }
 
@@ -134,17 +140,27 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
             ? null
             : typeSymbol.ContainingNamespace.ToDisplayString();
 
-        // Последний int-параметр (для IComparable и Id)
-        string? lastIntParamName = null;
+        // long поддерживается только для простого случая: единственный параметр без вложенности.
+        // Комбинации long с несколькими leaf-ами не поддерживаем — IdentificationParseHelper.SplitIdentifier
+        // делит и по '-', что для отрицательного long-листа среди нескольких частей даёт неверный результат.
+        if (parameters.Any(p => p.Kind == ParamKind.Long) && parameters.Count != 1)
+        {
+            return null;
+        }
+
+        // Последний числовой (int/long) параметр (для IComparable и Id)
+        string? lastNumericParamName = null;
+        string numericTypeKeyword = "int";
         for (int i = parameters.Count - 1; i >= 0; i--)
         {
-            if (parameters[i].Kind == ParamKind.Int)
+            if (parameters[i].Kind == ParamKind.Int || parameters[i].Kind == ParamKind.Long)
             {
-                lastIntParamName = parameters[i].Name;
+                lastNumericParamName = parameters[i].Name;
+                numericTypeKeyword = parameters[i].Kind == ParamKind.Long ? "long" : "int";
                 break;
             }
         }
-        if (lastIntParamName == null)
+        if (lastNumericParamName == null)
         {
             return null;
         }
@@ -163,7 +179,9 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
             AdditionalPrefixes: additionalPrefixes.ToArray(),
             SkipComparable: HasHandWrittenCompareTo(typeSymbol),
             FlatLeafExpressions: flatLeaves,
-            LastIntParamName: lastIntParamName,
+            LastIntParamName: lastNumericParamName,
+            NumericTypeKeyword: numericTypeKeyword,
+            AllowNonPositive: allowNonPositive,
             PrimaryParams: primaryParams,
             NestedProperties: nestedProperties
         );
@@ -268,6 +286,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         switch (kind)
         {
             case ParamKind.Int:
+            case ParamKind.Long:
                 return new List<string> { accessor };
             case ParamKind.NestedEntityId:
                 return ExpandNestedType(accessor, type, compilation);
@@ -340,6 +359,11 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
             return ParamKind.Int;
         }
 
+        if (type.SpecialType == SpecialType.System_Int64)
+        {
+            return ParamKind.Long;
+        }
+
         // Тип помечен [TypedEntityId] — это вложенный типизированный Id
         if (type.GetAttributes().Any(a => a.AttributeClass?.Name == "TypedEntityIdAttribute"))
         {
@@ -375,6 +399,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         return param.Kind switch
         {
             ParamKind.Int => leafParamNames[0],
+            ParamKind.Long => leafParamNames[0],
             // Для NestedEntityId: new NT(leaf1, leaf2, ...) — C# выбирает нужный конструктор по типу leaf1
             ParamKind.NestedEntityId => $"new {param.TypeName}({string.Join(", ", leafParamNames)})",
             _ => "/* Ошибка: неизвестный тип параметра */"
@@ -414,13 +439,13 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         sb.AppendLine("{");
 
         // Свойство Id — генерируется безусловно для всех TypedEntityId
-        sb.AppendLine($"    public int Id => {info.LastIntParamName};");
+        sb.AppendLine($"    public {info.NumericTypeKeyword} Id => {info.LastIntParamName};");
         sb.AppendLine();
 
-        // Неявное преобразование к int — только для не составных id (ровно одно свойство)
+        // Неявное преобразование к числовому типу — только для не составных id (ровно одно свойство)
         if (info.PrimaryParams.Count == 1)
         {
-            sb.AppendLine($"    public static implicit operator int({info.TypeName} self) => self.{info.LastIntParamName};");
+            sb.AppendLine($"    public static implicit operator {info.NumericTypeKeyword}({info.TypeName} self) => self.{info.LastIntParamName};");
             sb.AppendLine();
         }
 
@@ -440,7 +465,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         if (!info.SkipComparable)
         {
             sb.AppendLine($"    public int CompareTo({info.TypeName}? other)");
-            sb.AppendLine($"        => Comparer<int>.Default.Compare({info.LastIntParamName}, other?.{info.LastIntParamName} ?? -1);");
+            sb.AppendLine($"        => Comparer<{info.NumericTypeKeyword}>.Default.Compare({info.LastIntParamName}, other?.{info.LastIntParamName} ?? -1);");
             sb.AppendLine();
         }
 
@@ -523,6 +548,12 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
                 nullChecks.Add($"{paramNameLower} is not null");
                 ctorArgs.Add($"{paramNameLower}.Value");
             }
+            else if (param.Kind == ParamKind.Long)
+            {
+                optParams.Add($"long? {paramNameLower}");
+                nullChecks.Add($"{paramNameLower} is not null");
+                ctorArgs.Add($"{paramNameLower}.Value");
+            }
             else
             {
                 // NestedEntityId — reference type, nullable через ?
@@ -559,7 +590,12 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         string tryParseCall;
         string constructorArgs;
 
-        if (leafCount == 1)
+        if (leafCount == 1 && info.NumericTypeKeyword == "long")
+        {
+            tryParseCall = $"IdentificationParseHelper.TryParse1Long(value, provider, {(info.AllowNonPositive ? "true" : "false")}, [{prefixesStr}])";
+            constructorArgs = "parsed.Value";
+        }
+        else if (leafCount == 1)
         {
             tryParseCall = $"IdentificationParseHelper.TryParse1(value, provider, [{prefixesStr}])";
             constructorArgs = "parsed.Value";
@@ -608,7 +644,7 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         sb.AppendLine("    }");
     }
 
-    private enum ParamKind { Int, NestedEntityId, Unknown }
+    private enum ParamKind { Int, Long, NestedEntityId, Unknown }
 
     private sealed record ParameterInfo(string Name, INamedTypeSymbol TypeSymbol, ParamKind Kind);
 
@@ -634,6 +670,8 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         bool SkipComparable,
         List<string> FlatLeafExpressions,
         string LastIntParamName,
+        string NumericTypeKeyword,
+        bool AllowNonPositive,
         IReadOnlyList<PrimaryParamInfo> PrimaryParams,
         IReadOnlyList<NestedPropertyInfo> NestedProperties
     );

--- a/src/JoinRpg.Common.PrimitiveTypes/IdentificationParseHelper.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/IdentificationParseHelper.cs
@@ -47,6 +47,18 @@ public static class IdentificationParseHelper
         return null;
     }
 
+    public static long? TryParse1Long(ReadOnlySpan<char> value, IFormatProvider? provider, bool allowNonPositive, params ReadOnlySpan<string> prefixes)
+    {
+        ReadOnlySpan<char> val = RemovePrefixes(value, prefixes);
+
+        if (long.TryParse(val, provider, out var id) && (allowNonPositive || id > 0))
+        {
+            return id;
+        }
+
+        return null;
+    }
+
     public static ReadOnlySpan<char> RemovePrefixes(ReadOnlySpan<char> value, ReadOnlySpan<string> prefixes)
     {
         var val = value.Trim();

--- a/src/JoinRpg.Common.PrimitiveTypes/TelegramChatId.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/TelegramChatId.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace JoinRpg.Common.PrimitiveTypes;
+
+/// <summary>
+/// Числовой идентификатор адресата в Telegram Bot API (chat_id). Bot API не различает личные чаты,
+/// группы и каналы — везде один и тот же числовой id, который может быть отрицательным (супергруппы/каналы).
+/// </summary>
+[method: JsonConstructor]
+[TypedEntityId(AllowNonPositive = true, AdditionalPrefixes = ["Telegram", "TelegramId"])]
+public partial record TelegramChatId(long Value)
+{
+}

--- a/src/JoinRpg.Common.PrimitiveTypes/TypedEntityIdAttribute.cs
+++ b/src/JoinRpg.Common.PrimitiveTypes/TypedEntityIdAttribute.cs
@@ -9,4 +9,11 @@ public sealed class TypedEntityIdAttribute : Attribute
 
     /// <summary>Дополнительные префиксы для парсинга (например, старые форматы). По умолчанию ShortName без суффикса "Id" добавляется автоматически.</summary>
     public string[]? AdditionalPrefixes { get; set; }
+
+    /// <summary>
+    /// Разрешить значения id &lt;= 0. По умолчанию — false (обычные PK-шные id всегда положительны).
+    /// Нужно, например, для Telegram chat id, который может быть 0 или отрицательным (супергруппы/каналы).
+    /// Применимо только к типам с одним числовым (long) параметром без вложенности.
+    /// </summary>
+    public bool AllowNonPositive { get; set; }
 }


### PR DESCRIPTION
## Что сделано
- Генератор `TypedEntityIdGenerator` расширен на `long`-параметры (раньше умел только `int`).
- Добавлен флаг `[TypedEntityId(AllowNonPositive = true)]` для id, которые могут быть `<= 0`.
- Добавлен `IdentificationParseHelper.TryParse1Long`.
- Добавлен новый тип `TelegramChatId(long Value)` — единый числовой идентификатор адресата в Telegram Bot API (личный чат/группа/канал), нужен для последующего разделения текущего `TelegramId` на "адрес отправки" и "идентичность пользователя в профиле" (отдельная задача).
- Поддержаны только простые типы с одним `long`-параметром без вложенности — `IdentificationParseHelper.SplitIdentifier` делит и по `-`, что для составных id с отрицательным `long`-листом даёт неверный результат.

## Важно про релизный цикл
Генератор подключён как **опубликованный NuGet-пакет** (`JoinRpg.Common.PrimitiveTypes.SourceGenerator`, версия закреплена в `Directory.Packages.props`), а не `ProjectReference` — см. `docs/adr011-roles-grid-payload.md`. Эта правка **не имеет эффекта**, пока пакет не переопубликован через `nuget-publish.yml` (workflow_dispatch) и версия не забампана отдельным PR.

Логику генератора проверил локально: временно переключил `JoinRpg.Common.PrimitiveTypes.csproj`/`JoinRpg.DomainTypes.csproj` на `ProjectReference` и прогнал сборку/тесты (потом вернул обратно на `PackageReference` — этот коммит их не трогает), а также прогнал генератор в изолированном in-process Roslyn-харнессе, проверив сгенерированный код для `long`- и `int`-параметров.

## Test plan
- [x] `dotnet build src/JoinRpg.Common.PrimitiveTypes.SourceGenerator`
- [x] `dotnet build src/JoinRpg.Common.PrimitiveTypes` (с текущим опубликованным пакетом — новый тип просто не использует генерируемые члены, пока пакет не переопубликован)
- [x] `dotnet test src/JoinRpg.Common.PrimitiveTypes.Test` — 53/53
- [x] Генератор проверен локально через временный `ProjectReference` + in-process Roslyn-харнесс (сгенерированный код для `TelegramChatId`/`long` соответствует ожидаемому, регрессий для существующих `int`-типов нет)

Generated with [Claude Code](https://claude.ai/code)