### PR TITLE
feat: спрашивать про КогдаИгру при создании проекта

### DIFF
--- a/src/JoinRpg.Blazor.Client/ApiClients/ProjectClient.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/ProjectClient.cs
@@ -25,6 +25,9 @@ public class ProjectCreateClient(HttpClient httpClient) : IProjectCreateClient
         var response = await httpClient.PostAsJsonAsync("/webapi/project-create/create", model);
         return await response.EnsureSuccessStatusCode().Content.ReadFromJsonAsync<ProjectCreateResultViewModel>() ?? throw new Exception("Couldn't get result from server");
     }
+
+    public async Task<bool> IsProductionEnvironment()
+        => await httpClient.GetFromJsonAsync<bool>("/webapi/project-create/IsProductionEnvironment");
 }
 
 public class ProjectSettingsClient(HttpClient httpClient) : IProjectSettingsClient

--- a/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraRepository.cs
@@ -47,7 +47,7 @@ internal class KogdaIgraRepository(MyDbContext Ctx) : IKogdaIgraRepository
         var result = await GetSet()
             .AsNoTracking()
             .Where(ki => ki.Active)
-            .Where(ki => ki.Begin != null && ki.Begin.Value.Date >= DateTime.Today)
+            .Where(ki => ki.Begin != null && ki.Begin.Value >= DateTime.Today)
             .Where(ki => ki.Name.Length > 0)
             .Select(ki => new { ki.KogdaIgraGameId, ki.Name, ki.Begin })
             .ToListAsync();

--- a/src/JoinRpg.IntegrationTests/Scenarios/CloneProjectScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/CloneProjectScenario.cs
@@ -109,7 +109,10 @@ public class CloneProjectScenario(JoinApplicationFactory factory) : IClassFixtur
                 new CloneProjectRequest(
                     new ProjectName("Клон проекта"),
                     originalProjectId,
-                    ProjectCopySettingsDto.SettingsFieldsGroupsAndTemplates));
+                    ProjectCopySettingsDto.SettingsFieldsGroupsAndTemplates,
+                    KogdaIgraLinkChoiceDto.ShouldNotBeOnKogdaIgra,
+                    null,
+                    null));
 
             return result switch
             {

--- a/src/JoinRpg.IntegrationTests/TestInfrastructure/TestUserProjectHelpers.cs
+++ b/src/JoinRpg.IntegrationTests/TestInfrastructure/TestUserProjectHelpers.cs
@@ -74,7 +74,10 @@ public static class TestUserProjectHelpers
                         new ProjectName(projectName),
                         projectType,
                         null,
-                        default));
+                        default,
+                        KogdaIgraLinkChoiceDto.ShouldNotBeOnKogdaIgra,
+                        null,
+                        null));
 
                 return result switch
                 {

--- a/src/JoinRpg.IntegrationTests/TestInfrastructure/XApiMasterFixture.cs
+++ b/src/JoinRpg.IntegrationTests/TestInfrastructure/XApiMasterFixture.cs
@@ -70,7 +70,10 @@ public class XApiMasterFixture : IAsyncLifetime
                         new ProjectName("Тестовая Игра"),
                         projectType,
                         null,
-                        default));
+                        default,
+                        KogdaIgraLinkChoiceDto.ShouldNotBeOnKogdaIgra,
+                        null,
+                        null));
 
                 return result switch
                 {

--- a/src/JoinRpg.Portal.Test/ProjectCreateDiTests.cs
+++ b/src/JoinRpg.Portal.Test/ProjectCreateDiTests.cs
@@ -1,0 +1,21 @@
+using JoinRpg.Web.Games.Projects;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JoinRpg.Portal.Test;
+
+public class ProjectCreateDiTests(IntegrationTestPortalFactory factory)
+    : IClassFixture<IntegrationTestPortalFactory>
+{
+    [Fact]
+    public void IProjectCreateClient_Resolves_From_DI()
+    {
+        // CreateProjectPanel рендерится в режиме WebAssemblyPrerendered — на сервере он резолвит
+        // IProjectCreateClient из этого же контейнера ещё до того, как загрузится WASM-клиент.
+        // Если сервис зарегистрирован только в Blazor.Client (для HTTP после гидратации), но не
+        // здесь, страница падает с ComponentNotRegisteredException при первом же обращении к сервису
+        // из OnInitialized/OnInitializedAsync.
+        using var scope = factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetService<IProjectCreateClient>();
+        service.ShouldNotBeNull("IProjectCreateClient should resolve from DI container (needed for server-side prerendering of CreateProjectPanel)");
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/WebApi/ProjectCreateController.cs
+++ b/src/JoinRpg.Portal/Controllers/WebApi/ProjectCreateController.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Services.Interfaces.Projects;
 using JoinRpg.Web.Games.Projects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,37 +7,19 @@ namespace JoinRpg.Portal.Controllers.WebApi;
 [Route("/webapi/project-create/[action]")]
 [Authorize]
 [IgnoreAntiforgeryToken]
-public class ProjectCreateController(ILogger<ProjectCreateController> logger) : ControllerBase
+public class ProjectCreateController(IProjectCreateClient client) : ControllerBase
 {
+    [HttpGet]
+    public Task<bool> IsProductionEnvironment() => client.IsProductionEnvironment();
+
     [HttpPost]
-    public async Task<IActionResult> Create([FromBody] ProjectCreateViewModel model, [FromServices] ICreateProjectService createProjectService)
+    public async Task<IActionResult> Create([FromBody] ProjectCreateViewModel model)
     {
         if (!ModelState.IsValid)
         {
             return BadRequest();
         }
 
-        try
-        {
-            var request = CreateProjectRequest.Create(new ProjectName(model.ProjectName),
-                (ProjectTypeDto)model.ProjectType,
-                model.CopyFromProjectId,
-                (ProjectCopySettingsDto)model.CopySettings
-                );
-            var result = await createProjectService.CreateProject(request);
-
-            return result switch
-            {
-                FaildToCreateProjectResult failed => Problem(title: "Произошла ошибка при обработке запроса", detail: failed.Message, statusCode: 500),
-                PartiallySuccessCreateProjectResult partially => Ok(new ProjectCreateResultViewModel(partially.ProjectId, $"Ошибка: {partially.Message}\n RequestId: {HttpContext.TraceIdentifier}")),
-                SuccessCreateProjectResult successCreateProjectResult => Ok(new ProjectCreateResultViewModel(successCreateProjectResult.ProjectId, Error: null)),
-                _ => Ok(result)
-            };
-        }
-        catch (Exception exception)
-        {
-            logger.LogError(exception, "Error creating project");
-            return Problem(title: "Произошла ошибка при обработке запроса", detail: exception.Message, statusCode: 500);
-        }
+        return Ok(await client.CreateProject(model));
     }
 }

--- a/src/JoinRpg.Services.Impl/AdminNotificationServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/AdminNotificationServiceImpl.cs
@@ -1,12 +1,16 @@
+using JoinRpg.Data.Interfaces.AdminTools;
 using JoinRpg.DomainTypes.Notifications;
 using JoinRpg.Interfaces.Notifications;
 using JoinRpg.Services.Interfaces.Notification;
+using JoinRpg.Services.Interfaces.Projects;
 
 namespace JoinRpg.Services.Impl;
 
 internal class AdminNotificationServiceImpl(
     INotificationService notificationService,
-    ICurrentUserAccessor currentUserAccessor
+    ICurrentUserAccessor currentUserAccessor,
+    IUserRepository userRepository,
+    IKogdaIgraRepository kogdaIgraRepository
     )
     : IAdminNotificationService
 {
@@ -16,5 +20,39 @@ internal class AdminNotificationServiceImpl(
             [NotificationRecepient.Admin(currentUserAccessor.ToUserInfoHeader())], currentUserAccessor.UserIdentification);
 
         await notificationService.QueueNotification(notificationEvent);
+    }
+
+    public async Task NotifyAboutNewProjectKogdaIgraStatus(
+        ProjectIdentification projectId, ProjectName projectName, KogdaIgraLinkChoiceDto choice,
+        KogdaIgraIdentification? gameId, string? message)
+    {
+        var body = choice switch
+        {
+            KogdaIgraLinkChoiceDto.Linked => await DescribeLinkedGame(gameId),
+            KogdaIgraLinkChoiceDto.NotOnKogdaIgra => $"Мастер сообщает, что игры нет на КогдаИгре.\n\nСообщение редакторам: {message}",
+            _ => throw new ArgumentOutOfRangeException(nameof(choice)),
+        };
+
+        var admins = await userRepository.GetAdminUserInfoHeaders();
+        var notificationEvent = new NotificationEvent(
+            NotificationClass.AdminMessage,
+            EntityReference: projectId,
+            Header: $"Новый проект «{projectName}» — статус КогдаИгры",
+            TemplateText: new NotificationEventTemplate($"Добрый день, %recepient.name%!\n\nСоздан новый проект «{projectName}».\n\n{body}"),
+            Recepients: [.. admins.Select(a => NotificationRecepient.Admin(a))],
+            Initiator: currentUserAccessor.UserIdentification);
+
+        await notificationService.QueueNotification(notificationEvent);
+    }
+
+    private async Task<string> DescribeLinkedGame(KogdaIgraIdentification? gameId)
+    {
+        if (gameId is not KogdaIgraIdentification id)
+        {
+            return "Мастер указал, что игра есть на КогдаИгре.";
+        }
+        var games = await kogdaIgraRepository.GetDataByIds([id]);
+        var gameName = games.SingleOrDefault()?.Name ?? $"#{id.Value}";
+        return $"Мастер указал, что игра есть на КогдаИгре: «{gameName}».";
     }
 }

--- a/src/JoinRpg.Services.Impl/Projects/Create/CreateProjectService.KogdaIgra.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Create/CreateProjectService.KogdaIgra.cs
@@ -1,0 +1,32 @@
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.Services.Impl.Projects;
+
+internal partial class CreateProjectService
+{
+    //TODO[Localize]
+    private async Task HandleKogdaIgraChoice(CreateProjectRequest request, ProjectIdentification projectId)
+    {
+        switch (request.KogdaIgraChoice)
+        {
+            case KogdaIgraLinkChoiceDto.Linked:
+                // Автопривязки нет: только уведомляем админов с указанием выбранной игры;
+                // саму привязку они подтверждают вручную через ProjectAdminControlPanel /
+                // IKogdaIgraBindService.UpdateKogdaIgraBindings (единственная точка привязки).
+                await adminNotificationService.NotifyAboutNewProjectKogdaIgraStatus(
+                    projectId, request.ProjectName, request.KogdaIgraChoice, request.KogdaIgraGameId, message: null);
+                break;
+            case KogdaIgraLinkChoiceDto.NotOnKogdaIgra:
+                await adminNotificationService.NotifyAboutNewProjectKogdaIgraStatus(
+                    projectId, request.ProjectName, request.KogdaIgraChoice, gameId: null, request.MessageForKogdaIgraEditors);
+                break;
+            case KogdaIgraLinkChoiceDto.ShouldNotBeOnKogdaIgra:
+            case KogdaIgraLinkChoiceDto.Trial:
+                await projectPropsService.ChangeProjectProperties(
+                    projectId, Permission.CanChangeProjectProperties, ProjectActiveRequirement.MustBeActive,
+                    arguments: request.KogdaIgraChoice,
+                    action: ctx => ctx.Project.Details.DisableKogdaIgraMapping = true);
+                break;
+        }
+    }
+}

--- a/src/JoinRpg.Services.Impl/Projects/Create/CreateProjectService.Main.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Create/CreateProjectService.Main.cs
@@ -1,5 +1,6 @@
 using JoinRpg.Services.Impl.Projects.Create;
 using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.Notification;
 using JoinRpg.Services.Interfaces.ProjectMetadata;
 using JoinRpg.Services.Interfaces.Projects;
 
@@ -14,7 +15,9 @@ internal partial class CreateProjectService
     IProjectRepository projectRepository,
     IProjectRolesListService projectRolesListService,
     ILogger<CreateProjectService> logger,
-    CloneProjectHelperFactory cloneProjectHelperFactory
+    CloneProjectHelperFactory cloneProjectHelperFactory,
+    IProjectPropsService projectPropsService,
+    IAdminNotificationService adminNotificationService
     ) : ICreateProjectService
 {
 
@@ -37,6 +40,15 @@ internal partial class CreateProjectService
         }
 
         var projectId = new ProjectIdentification(project.ProjectId);
+
+        try
+        {
+            await HandleKogdaIgraChoice(request, projectId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Ошибка при обработке статуса КогдаИгры");
+        }
 
         if (request is CloneProjectRequest cloneRequest)
         {

--- a/src/JoinRpg.Services.Interfaces/Notification/IAdminNotificationService.cs
+++ b/src/JoinRpg.Services.Interfaces/Notification/IAdminNotificationService.cs
@@ -1,6 +1,18 @@
+using JoinRpg.Services.Interfaces.Projects;
+
 namespace JoinRpg.Services.Interfaces.Notification;
 
 public interface IAdminNotificationService
 {
     Task SendTestMessage();
+
+    /// <summary>
+    /// Уведомляет всех сайт-админов о статусе нового проекта относительно КогдаИгры,
+    /// выбранном мастером при создании проекта.
+    /// </summary>
+    /// <param name="gameId">Игра на КогдаИгре, если выбран <see cref="KogdaIgraLinkChoiceDto.Linked"/>.</param>
+    /// <param name="message">Сообщение мастера редакторам КогдаИгры, если выбран <see cref="KogdaIgraLinkChoiceDto.NotOnKogdaIgra"/>.</param>
+    Task NotifyAboutNewProjectKogdaIgraStatus(
+        ProjectIdentification projectId, ProjectName projectName, KogdaIgraLinkChoiceDto choice,
+        KogdaIgraIdentification? gameId, string? message);
 }

--- a/src/JoinRpg.Services.Interfaces/Projects/CreateProjectRequest.cs
+++ b/src/JoinRpg.Services.Interfaces/Projects/CreateProjectRequest.cs
@@ -2,27 +2,43 @@ namespace JoinRpg.Services.Interfaces.Projects;
 
 public record CreateProjectRequest
 {
-    internal CreateProjectRequest(ProjectName ProjectName, ProjectTypeDto ProjectType)
+    internal CreateProjectRequest(ProjectName ProjectName, ProjectTypeDto ProjectType,
+        KogdaIgraLinkChoiceDto KogdaIgraChoice, KogdaIgraIdentification? KogdaIgraGameId, string? MessageForKogdaIgraEditors)
     {
         this.ProjectName = ProjectName;
         this.ProjectType = ProjectType;
+        this.KogdaIgraChoice = KogdaIgraChoice;
+        this.KogdaIgraGameId = KogdaIgraGameId;
+        this.MessageForKogdaIgraEditors = MessageForKogdaIgraEditors;
     }
 
     public ProjectName ProjectName { get; }
     public ProjectTypeDto ProjectType { get; }
+    public KogdaIgraLinkChoiceDto KogdaIgraChoice { get; }
+    public KogdaIgraIdentification? KogdaIgraGameId { get; }
+    public string? MessageForKogdaIgraEditors { get; }
 
-    public static CreateProjectRequest Create(ProjectName ProjectName, ProjectTypeDto ProjectType, ProjectIdentification? CopyFromId, ProjectCopySettingsDto CopySettings)
+    public static CreateProjectRequest Create(ProjectName ProjectName, ProjectTypeDto ProjectType, ProjectIdentification? CopyFromId, ProjectCopySettingsDto CopySettings,
+        KogdaIgraLinkChoiceDto KogdaIgraChoice, KogdaIgraIdentification? KogdaIgraGameId, string? MessageForKogdaIgraEditors)
     {
         if (CopyFromId is not null && ProjectType == ProjectTypeDto.CopyFromAnother)
         {
-            return new CloneProjectRequest(ProjectName, CopyFromId, CopySettings);
+            return new CloneProjectRequest(ProjectName, CopyFromId, CopySettings, KogdaIgraChoice, KogdaIgraGameId, MessageForKogdaIgraEditors);
         }
         if (ProjectType != ProjectTypeDto.CopyFromAnother)
         {
-            return new CreateProjectRequest(ProjectName, ProjectType);
+            return new CreateProjectRequest(ProjectName, ProjectType, KogdaIgraChoice, KogdaIgraGameId, MessageForKogdaIgraEditors);
         }
         throw new ArgumentException("Incorrect combination of parameters");
     }
+}
+
+public enum KogdaIgraLinkChoiceDto
+{
+    Linked,
+    NotOnKogdaIgra,
+    ShouldNotBeOnKogdaIgra,
+    Trial,
 }
 
 public abstract record CreateProjectResultBase
@@ -45,7 +61,9 @@ public record FaildToCreateProjectResult(string Message) : CreateProjectResultBa
 
 }
 
-public record CloneProjectRequest(ProjectName ProjectName, ProjectIdentification CopyFromId, ProjectCopySettingsDto CopySettings) : CreateProjectRequest(ProjectName, ProjectTypeDto.CopyFromAnother)
+public record CloneProjectRequest(ProjectName ProjectName, ProjectIdentification CopyFromId, ProjectCopySettingsDto CopySettings,
+    KogdaIgraLinkChoiceDto KogdaIgraChoice, KogdaIgraIdentification? KogdaIgraGameId, string? MessageForKogdaIgraEditors)
+    : CreateProjectRequest(ProjectName, ProjectTypeDto.CopyFromAnother, KogdaIgraChoice, KogdaIgraGameId, MessageForKogdaIgraEditors)
 {
 
 }

--- a/src/JoinRpg.Web.Games/Projects/CreateProjectPanel.razor
+++ b/src/JoinRpg.Web.Games/Projects/CreateProjectPanel.razor
@@ -1,3 +1,4 @@
+@using JoinRpg.Web.ProjectCommon.KogdaIgra
 @inject ILogger<CreateProjectPanel> logger
 @inject NavigationManager NavigationManager
 @inject IServiceProvider Services
@@ -53,6 +54,24 @@
                 <FormRowFor For="@(() => Model.CopySettings)" hidden="@(Model.ProjectType != ProjectTypeViewModel.CopyFromAnother)">
                     <EnumRadioButtonGroup @bind-SelectedValue="Model.CopySettings" />
                 </FormRowFor>
+                <FormRowFor For="@(() => Model.KogdaIgraChoice)">
+                    <EnumRadioButtonGroup @bind-SelectedValue="Model.KogdaIgraChoice" />
+                    <JoinAlert Variation="VariationStyleEnum.Info"><a href="https://kogda-igra.ru/" target="_blank" rel="noopener">kogda-igra.ru</a> — календарь ролевых игр от нашей команды.</JoinAlert>
+                </FormRowFor>
+                <FormRowFor For="@(() => Model.KogdaIgraGameId)" hidden="@(Model.KogdaIgraChoice != KogdaIgraLinkChoiceViewModel.Linked)">
+                    <KogdaIgraGameSelector Multiple="false" FutureOnly="true"
+                        KogdaIgraIds="@(Model.KogdaIgraGameId is { } kiId ? [kiId] : [])"
+                        KogdaIgraIdsChanged="@(ids => Model.KogdaIgraGameId = ids.FirstOrDefault())" />
+                </FormRowFor>
+                <FormRowFor For="@(() => Model.MessageForKogdaIgraEditors)" hidden="@(Model.KogdaIgraChoice != KogdaIgraLinkChoiceViewModel.NotOnKogdaIgra)">
+                    <JoinTextArea @bind-Value="Model.MessageForKogdaIgraEditors" Rows="4" />
+                </FormRowFor>
+                @if (Model.KogdaIgraChoice == KogdaIgraLinkChoiceViewModel.Trial && isProduction)
+                {
+                    <JoinAlert Variation="VariationStyleEnum.Danger">
+                        Пробные проекты нельзя создавать на боевом сайте. Попробуйте на dev-версии сайта.
+                    </JoinAlert>
+                }
                 <FormRow>
                     <JoinButton Preset="ButtonPreset.Create" Submit="true" Disabled="@formInvalid" />
                 </FormRow>
@@ -67,6 +86,7 @@
     private EditContext? editContext;
     private bool formInvalid = true;
     private bool creating = false;
+    private bool isProduction;
     private ValidationMessageStore? messageStore;
     private ProjectIdentification? created;
     private string? createErrorResult;
@@ -85,6 +105,11 @@
         messageStore = new(editContext);
 
         logger.LogInformation("Setup everything");
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        isProduction = await Services.GetRequiredService<IProjectCreateClient>().IsProductionEnvironment();
     }
 
     private void HandleFieldChanged(object? sender, FieldChangedEventArgs e)
@@ -107,6 +132,16 @@
             {
                 messageStore?.Add(() => Model.CopyFromProjectId!, "Необходимо выбрать проект, откуда копировать");
             }
+        }
+
+        if (Model.KogdaIgraChoice == KogdaIgraLinkChoiceViewModel.Linked && Model.KogdaIgraGameId is null)
+        {
+            messageStore?.Add(() => Model.KogdaIgraGameId!, "Необходимо выбрать игру на КогдаИгре");
+        }
+
+        if (Model.KogdaIgraChoice == KogdaIgraLinkChoiceViewModel.Trial && isProduction)
+        {
+            messageStore?.Add(() => Model.KogdaIgraChoice, "Пробные проекты нельзя создавать на боевом сайте");
         }
     }
 

--- a/src/JoinRpg.Web.Games/Projects/IProjectCreateClient.cs
+++ b/src/JoinRpg.Web.Games/Projects/IProjectCreateClient.cs
@@ -3,6 +3,8 @@ namespace JoinRpg.Web.Games.Projects;
 public interface IProjectCreateClient
 {
     Task<ProjectCreateResultViewModel> CreateProject(ProjectCreateViewModel model);
+
+    Task<bool> IsProductionEnvironment();
 }
 
 public record ProjectCreateResultViewModel(ProjectIdentification? ProjectId, string? Error);

--- a/src/JoinRpg.Web.Games/Projects/ProjectCreateViewModel.cs
+++ b/src/JoinRpg.Web.Games/Projects/ProjectCreateViewModel.cs
@@ -24,6 +24,32 @@ public class ProjectCreateViewModel
 
     [Display(Name = "Глубина копирования")]
     public ProjectCopySettingsViewModel CopySettings { get; set; } = default;
+
+    [Required]
+    [Display(Name = "Есть ли это мероприятие на КогдаИгре?")]
+    public KogdaIgraLinkChoiceViewModel KogdaIgraChoice { get; set; }
+
+    [Display(Name = "Игра на КогдаИгре")]
+    public KogdaIgraIdentification? KogdaIgraGameId { get; set; }
+
+    [Display(Name = "Сообщение для редакторов КогдаИгры")]
+    [StringLength(1000)]
+    public string MessageForKogdaIgraEditors { get; set; } = "";
+}
+
+public enum KogdaIgraLinkChoiceViewModel
+{
+    [Display(Name = "Есть на КогдаИгре", Description = "Выберите игру из списка будущих игр КогдаИгры")]
+    Linked,
+
+    [Display(Name = "Игры нет на КогдаИгре", Description = "Опишите игру, чтобы редакторы КогдаИгры могли её завести")]
+    NotOnKogdaIgra,
+
+    [Display(Name = "Не должно быть на КогдаИгре", Description = "Игра идёт в рамках другого мероприятия или по другим причинам не должна попадать на КогдаИгру")]
+    ShouldNotBeOnKogdaIgra,
+
+    [Display(Name = "Пробный проект", Description = "Я завожу проект, чтобы попробовать")]
+    Trial,
 }
 
 public enum ProjectCopySettingsViewModel

--- a/src/JoinRpg.WebPortal.Managers/Projects/ProjectCreateViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Projects/ProjectCreateViewService.cs
@@ -1,0 +1,48 @@
+using JoinRpg.Services.Interfaces.Projects;
+using JoinRpg.Web.Games.Projects;
+using Microsoft.Extensions.Hosting;
+
+namespace JoinRpg.WebPortal.Managers.Projects;
+
+internal class ProjectCreateViewService(
+    ICreateProjectService createProjectService,
+    IHostEnvironment hostEnvironment,
+    ILogger<ProjectCreateViewService> logger
+    ) : IProjectCreateClient
+{
+    public Task<bool> IsProductionEnvironment() => Task.FromResult(hostEnvironment.IsProduction());
+
+    public async Task<ProjectCreateResultViewModel> CreateProject(ProjectCreateViewModel model)
+    {
+        if (model.KogdaIgraChoice == KogdaIgraLinkChoiceViewModel.Trial && hostEnvironment.IsProduction())
+        {
+            return new ProjectCreateResultViewModel(null, "Пробные проекты нельзя создавать на боевом сайте");
+        }
+
+        try
+        {
+            var request = CreateProjectRequest.Create(new ProjectName(model.ProjectName),
+                (ProjectTypeDto)model.ProjectType,
+                model.CopyFromProjectId,
+                (ProjectCopySettingsDto)model.CopySettings,
+                (KogdaIgraLinkChoiceDto)model.KogdaIgraChoice,
+                model.KogdaIgraGameId,
+                model.MessageForKogdaIgraEditors
+                );
+            var result = await createProjectService.CreateProject(request);
+
+            return result switch
+            {
+                FaildToCreateProjectResult failed => new ProjectCreateResultViewModel(null, failed.Message),
+                PartiallySuccessCreateProjectResult partially => new ProjectCreateResultViewModel(partially.ProjectId, $"Ошибка: {partially.Message}"),
+                SuccessCreateProjectResult success => new ProjectCreateResultViewModel(success.ProjectId, Error: null),
+                _ => new ProjectCreateResultViewModel(null, "Неизвестный результат создания проекта"),
+            };
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Error creating project");
+            return new ProjectCreateResultViewModel(null, exception.Message);
+        }
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/Registration.cs
+++ b/src/JoinRpg.WebPortal.Managers/Registration.cs
@@ -52,6 +52,7 @@ public static class Registration
         .AddScoped<IMasterClient, ProjectMasterViewService>()
         .AddTransient<IProjectListClient, ProjectListViewService>()
         .AddTransient<IProjectListForAdminClient, ProjectListViewService>()
+        .AddScoped<IProjectCreateClient, ProjectCreateViewService>()
         .AddScoped<IPlotClient, Plots.PlotViewService>()
         .AddScoped<IKogdaIgraSyncClient, AdminTools.KogdaIgraSyncManager>()
         .AddScoped<IKogdaIgraBindClient, AdminTools.KogdaIgraSyncManager>()


### PR DESCRIPTION
Новый шаг формы создания проекта: «Есть ли это мероприятие на КогдаИгре?»
1. Есть на КогдаИгре — выбор игры из списка будущих игр; проект создаётся без автопривязки, сайт-админам уходит уведомление с указанием выбранной игры — привязку они подтверждают вручную через существующую админ-панель.
2. Игры нет на КогдаИгре — с сообщением для редакторов КИ; уведомление уходит тем же путём.
3. Игра не должна быть на КогдаИгре (входит в состав другого мероприятия и т.п.) — ставится существующий флаг ProjectDetails.DisableKogdaIgraMapping, без уведомления.
4. Пробный проект — на боевом сайте создание запрещено (проверка и на клиенте, и на сервере через IHostEnvironment.IsProduction()), на деве создаётся с тем же DisableKogdaIgraMapping = true.

Мутация DisableKogdaIgraMapping идёт через существующий IProjectPropsService (права/кэш/аудит), а не напрямую через IUnitOfWork. Уведомление всем сайт-админам собрано в новом IAdminNotificationService.NotifyAboutNewProjectKogdaIgraStatus на основе IUserRepository.GetAdminUserInfoHeaders().


Claude-Session: https://claude.ai/code/session_01TCyadgCvP8ayb1pBQn5G1B