### PR TITLE
fix: подавить ложный варнинг NU5128 в SourceGenerator-пакете

### DIFF
--- a/src/JoinRpg.Common.PrimitiveTypes.SourceGenerator/JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj
+++ b/src/JoinRpg.Common.PrimitiveTypes.SourceGenerator/JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj
@@ -17,6 +17,8 @@
     <Description>Source generator for typed entity IDs</Description>
     <PackageProjectUrl>https://github.com/joinrpg/joinrpg-net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/joinrpg/joinrpg-net</RepositoryUrl>
+    <!-- Аналайзер-пакет намеренно не кладёт сборку в lib/ref (IncludeBuildOutput=false), NU5128 — ложное срабатывание -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Что сделано
- В `JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj` добавлен `<NoWarn>$(NoWarn);NU5128</NoWarn>`

## Почему
NU5128 (`Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches`) — известный false-positive для analyzer-only пакетов: проект собирается с `IncludeBuildOutput=false` и `IsRoslynComponent=true`, сборка намеренно кладётся только в `analyzers/dotnet/cs`, а не в `lib/`/`ref/`. NuGet сравнивает TFM из зависимостей с содержимым `lib/ref` и не находит совпадения, хотя это ожидаемое поведение аналайзер-пакета.

См. https://github.com/joinrpg/joinrpg-net/actions/runs/32658960395/job/97242081819

Generated with [Claude Code](https://claude.ai/code)