### PR TITLE
fix: восстанавливать нормальный размер шрифта кнопок в JoinButtonGroup

### DIFF
--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents/JoinButtonGroup.razor.css
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents/JoinButtonGroup.razor.css
@@ -12,5 +12,7 @@
  * получает вменяемую базу и не ломается.
  */
 .join-btn-group ::deep > * {
-    font-size: 1rem;
+    /* 1rem здесь — не браузерные 16px, а 10px (html { font-size: 10px } в Bootstrap 3),
+       поэтому используем 1.4rem, чтобы получить обычные 14px, как у body */
+    font-size: 1.4rem;
 }


### PR DESCRIPTION
## Что сделано
- Кнопки внутри `<JoinButtonGroup>` (например, на странице настроек проекта `/{projectId}/project/settings`) были мельче остальных кнопок на странице.
- Причина: `.join-btn-group ::deep > * { font-size: 1rem; }` — `1rem` считается от `<html>`, а в Bootstrap 3 (`html { font-size: 10px }`) это 10px, а не обычные 14px, которые `body` задаёт остальному тексту.
- Заменил `1rem` на `1.4rem`, чтобы получить те же 14px, что и у body/остальных кнопок сайта.

## Test plan
- [ ] Открыть `/{projectId}/project/settings`, сравнить размер шрифта кнопок «Настройки полей» / «Настройки регистрации» / «Закрыть проект» с кнопкой «Сохранить» — должны совпадать
- [ ] Проверить другие места использования `JoinButtonGroup` на отсутствие регрессий

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LR3gqUcorTPFJb9Xxis39L