### PR TITLE
fix: логирование конфликта привязки ВК и lockout в ExternalLoginCallback

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -378,6 +378,14 @@ public class AccountController(
                     var addLoginResult = await userManager.AddLoginAsync(user, loginInfo);
                     if (!addLoginResult.Succeeded)
                     {
+                        if (addLoginResult.Errors.Any(e => e.Code == "LoginAlreadyAssociated"))
+                        {
+                            var existingOwner = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
+                            logger.LogWarning("Не удалось привязать {loginProvider} / {loginProviderKey} к аккаунту {userId} (email {email}), т.к. этот внешний логин уже привязан к аккаунту {existingOwnerId}",
+                                loginInfo.LoginProvider, loginInfo.ProviderKey, user.Id, email, existingOwner?.Id);
+                            return View("Lockout");
+                        }
+
                         logger.LogError("Неожиданная ошибка при привязке {loginProvider} / {loginProviderKey} к аккаунту {userId}: {loginResult}",
                             loginInfo.LoginProvider, loginInfo.ProviderKey, user.Id, addLoginResult);
                         return View("Lockout");
@@ -408,6 +416,9 @@ public class AccountController(
 
         if (result.IsLockedOut)
         {
+            var existingOwner = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
+            logger.LogWarning("Вход через {loginProvider} / {loginProviderKey} (email {email}) вернул IsLockedOut. Этот внешний логин привязан к аккаунту {existingOwnerId}",
+                loginInfo.LoginProvider, loginInfo.ProviderKey, email, existingOwner?.Id);
             return View("Lockout");
         }
 

--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -142,6 +142,9 @@ public class ManageController(
         {
             if (result.Errors.Any(i => i.Code == "LoginAlreadyAssociated"))
             {
+                var existingOwner = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
+                logger.LogInformation("Пользователь {userId} пытался привязать {loginProvider} / {loginProviderKey}, но этот внешний логин уже привязан к аккаунту {existingOwnerId}",
+                    userId, loginInfo.LoginProvider, loginInfo.ProviderKey, existingOwner?.Id);
                 return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked });
             }
             logger.LogError("Unexpected error during linking user to another account: {loginError}", result.Errors.First().Code);


### PR DESCRIPTION
## Что сделано

Пользователь не может подтвердить/привязать ВК к аккаунту, если этот ВК-логин уже привязан к другому аккаунту, а при попытке войти через ВК напрямую видит экран "Lockout" — без единой записи в логах, откуда понять причину.

Разобрался: в `AccountController.ExternalLoginCallback` и `ManageController.LinkLoginCallback` есть несколько веток, показывающих один и тот же экран `Lockout`/сообщение об ошибке, но по разным причинам — настоящий `SignInResult.IsLockedOut` и конфликт `LoginAlreadyAssociated` (внешний логин уже привязан к другому аккаунту) визуально неотличимы и почти не логировались.

- `ManageController.LinkLoginCallback`: при `LoginAlreadyAssociated` теперь логируется, к какому аккаунту (`existingOwnerId`) уже привязан внешний логин.
- `AccountController.ExternalLoginCallback`:
  - при неудачной попытке привязать ВК к аккаунту, найденному по email (`AddLoginAsync` fails), отдельно обрабатывается и логируется случай `LoginAlreadyAssociated` с указанием текущего владельца логина;
  - в ветке `result.IsLockedOut` (которая раньше не логировалась вообще) добавлено логирование с провайдером, providerKey, email и текущим владельцем этого внешнего логина.

Это не меняет поведение для пользователя (экран `Lockout` показывается как и раньше), только добавляет диагностику для дальнейшего расследования бага.

## Test plan
- [x] `dotnet build src/JoinRpg.Portal/JoinRpg.Portal.csproj` — без ошибок

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DZRT7szLCzFmGXJ2zURzMM