### PR TITLE
fix: логировать неудачное авто-подтверждение email при входе через ВК

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -364,7 +364,12 @@ public class AccountController(
                     logger.LogInformation("Пользователь входит через {loginProvider} / {loginProviderKey}, но у него не подтвержден email {email}. Он соответствует тому, что отдает ВК, подтверждаем.",
                         loginInfo.LoginProvider, loginInfo.ProviderKey, email);
                     var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
-                    _ = await userManager.ConfirmEmailAsync(user, token);
+                    var confirmResult = await userManager.ConfirmEmailAsync(user, token);
+                    if (!confirmResult.Succeeded)
+                    {
+                        logger.LogError("Не удалось автоматически подтвердить email {email} пользователю {userId} при входе через {loginProvider} / {loginProviderKey}: {confirmResult}",
+                            email, user.Id, loginInfo.LoginProvider, loginInfo.ProviderKey, confirmResult);
+                    }
                 }
 
                 // Возможно не получается зайти, т.к. логин не привязан к этому аккаунту


### PR DESCRIPTION
## Что сделано

В `AccountController.ExternalLoginCallback` при входе через внешний провайдер (ВК) для аккаунта с неподтверждённым email код пытается автоматически подтвердить email:

```csharp
var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
_ = await userManager.ConfirmEmailAsync(user, token);
```

Результат `ConfirmEmailAsync` игнорировался. Если подтверждение по какой-то причине не проходило, код всё равно шёл на повторный `ExternalLoginSignInAsync`, тот закономерно падал (email так и не подтверждён), и пользователь получал экран `"Lockout"` — без единой записи в логах, что же на самом деле пошло не так.

Теперь результат `ConfirmEmailAsync` проверяется, и при неудаче пишется `LogError` с email, userId и провайдером — это отдельный PR из связки с #4635, только логирование этого конкретного шага.

## Test plan
- [x] `dotnet build src/JoinRpg.Portal/JoinRpg.Portal.csproj` — без ошибок

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DZRT7szLCzFmGXJ2zURzMM