### PR TITLE
fix: убрать лишнюю nullability в Email.CustomValidateAndCanonicalize

### DIFF
--- a/src/Common/JoinRpg.Common.PrimitiveTypes/Users/Email.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes/Users/Email.cs
@@ -3,7 +3,7 @@ namespace JoinRpg.Common.PrimitiveTypes;
 [TypedStringValue]
 public partial record Email(string Value)
 {
-    internal static string? CustomValidateAndCanonicalize(string value)
+    internal static string CustomValidateAndCanonicalize(string value)
     {
         if (!value.Contains('@'))
         {


### PR DESCRIPTION
## Что сделано
- Исправлен warning CS8600/CS8603 в сгенерированном коде для `JoinRpg.Common.PrimitiveTypes.Email`.
- Причина: `Email.CustomValidateAndCanonicalize` был объявлен как возвращающий `string?`, хотя фактически никогда не возвращает `null` (при ошибке бросает `ArgumentException`). Source-generator `TypedStringValueGenerator` присваивает и возвращает этот результат как non-nullable `string`, из-за чего возникали предупреждения nullable-анализа в сгенерированном файле.
- Убрана лишняя nullability в сигнатуре метода — это точечный фикс без изменения поведения и без правок в самом генераторе.

Generated with [Claude Code](https://claude.ai/code)