### PR TITLE
chore: запретить dependabot поднимать minor/major версии Microsoft.CodeAnalysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     ignore:
     # https://github.com/aws/aws-sdk-net/issues/3610
       - dependency-name: "AWSSDK.S3"
+    # Версия зафиксирована в JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj намеренно низкой
+    # (см. комментарий там) — анализатор не должен требовать более новый Roslyn, чем у потребителя.
+    # Разрешаем только патч-версии, чтобы dependabot не поднимал minor/major.
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "Microsoft.CodeAnalysis.Analyzers"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
       net: #I like to merge this groups, but it will cause dependabot to timeout
         patterns:


### PR DESCRIPTION
## Что сделано
- В `.github/dependabot.yml` добавлены `ignore`-правила для `Microsoft.CodeAnalysis.CSharp` и `Microsoft.CodeAnalysis.Analyzers`, запрещающие minor/major обновления (разрешены только патчи).

## Почему
Версия этих пакетов в `JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj` зафиксирована намеренно низкой (4.3.1 / 3.3.4) — анализатор грузится в компилятор потребителя как есть, и если версия Roslyn в анализаторе новее, чем у хоста, загрузка тихо отказывает (CS9057), а сгенерированный код исчезает. Dependabot уже поднимал эту версию до 5.9.0 в рамках группы `codeanalysis` (см. неслитый коммит `a1a17c95e`), что ломало генератор. Ограничение на патч-версии позволяет dependabot по-прежнему получать мелкие обновления безопасности, не трогая major/minor.

Generated with [Claude Code](https://claude.ai/code)