### PR TITLE
fix: не валить привязку соцсети 500-й при сбое загрузки аватарки

### DIFF
--- a/src/JoinRpg.Services.Impl/UserServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/UserServiceImpl.cs
@@ -159,7 +159,16 @@ public class UserServiceImpl(
             }
         }
 
-        UserAvatar userAvatar = await UploadNewAvatar(avatarInfo.Uri, user, providerId);
+        UserAvatar userAvatar;
+        try
+        {
+            userAvatar = await UploadNewAvatar(avatarInfo.Uri, user, providerId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to upload avatar from {avatarUri} for provider {providerId}, skipping avatar update", avatarInfo.Uri, providerId);
+            return;
+        }
 
         user.SelectedAvatar ??= userAvatar;
 


### PR DESCRIPTION
## Что сделано
- `TryAddSocialAvatarImplAsync` в `UserServiceImpl` теперь оборачивает загрузку аватарки в try/catch: если скачивание аватарки с провайдера (например, таймаут HttpClient при обращении к `t.me`) падает, ошибка логируется как warning, а привязка соцсети (Telegram/VK) всё равно сохраняется.

## Почему
Разобран инцидент на проде: пользователь пытался привязать Telegram-аккаунт, получил 500-ю ошибку, но привязка на самом деле прошла успешно. По логам (Yandex Cloud Logging) видно: `AddCustomLoginAsync` сохраняет привязку раньше, чем сервис пытается скачать аватарку пользователя с Telegram; скачивание подвисло на 100 секунд и упало по `HttpClient.Timeout`, что и превращалось в 500 уже после того, как основная операция была выполнена.

Generated with [Claude Code](https://claude.ai/code)