### PR TITLE
feat: точка расширения под отправку в Telegram от разных ботов

### DIFF
--- a/src/Common/JoinRpg.Common.Telegram.Test/DefaultOnlyTelegramNotificationServiceFactoryTest.cs
+++ b/src/Common/JoinRpg.Common.Telegram.Test/DefaultOnlyTelegramNotificationServiceFactoryTest.cs
@@ -1,0 +1,32 @@
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Services.Interfaces.Notification;
+
+namespace JoinRpg.Common.Telegram.Test;
+
+public class DefaultOnlyTelegramNotificationServiceFactoryTest
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetService_WithNoBotKey_ReturnsDefaultService(string? botKey)
+    {
+        var defaultService = new FakeTelegramNotificationService();
+        var factory = new DefaultOnlyTelegramNotificationServiceFactory(defaultService);
+
+        factory.GetService(botKey).ShouldBe(defaultService);
+    }
+
+    [Fact]
+    public void GetService_WithBotKey_Throws()
+    {
+        var factory = new DefaultOnlyTelegramNotificationServiceFactory(new FakeTelegramNotificationService());
+
+        Should.Throw<NotSupportedException>(() => factory.GetService("advBot"));
+    }
+
+    private sealed class FakeTelegramNotificationService : ITelegramNotificationService
+    {
+        public Task<SendingResult> SendTelegramNotification(TelegramId telegramId, TelegramHtmlString contents) => throw new NotSupportedException();
+        public Task<string?> GetMyUserName(CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+}

--- a/src/Common/JoinRpg.Common.Telegram/Registration.cs
+++ b/src/Common/JoinRpg.Common.Telegram/Registration.cs
@@ -22,6 +22,7 @@ public static class Registration
                 }
                 return services.GetRequiredService<TelegramNotificationServiceImpl>();
             })
+            .AddTransient<ITelegramNotificationServiceFactory, DefaultOnlyTelegramNotificationServiceFactory>()
             .AddSingleton(services =>
             {
                 var options = services.GetRequiredService<IOptions<TelegramLoginOptions>>().Value;

--- a/src/Common/JoinRpg.Common.Telegram/TelegramNotificationServiceImpl.cs
+++ b/src/Common/JoinRpg.Common.Telegram/TelegramNotificationServiceImpl.cs
@@ -89,3 +89,19 @@ internal class StubTelegramNotificationService(ILogger<StubTelegramNotificationS
         return Task.FromResult(SendingResult.Success());
     }
 }
+
+/// <summary>
+/// Пока поддерживает только дефолтного бота приложения — реальный мультибот (свои боты
+/// у рекламных каналов/мастеров) не реализован, см. ADR010 §5.
+/// </summary>
+internal class DefaultOnlyTelegramNotificationServiceFactory(ITelegramNotificationService defaultService) : ITelegramNotificationServiceFactory
+{
+    public ITelegramNotificationService GetService(string? botKey)
+    {
+        if (!string.IsNullOrEmpty(botKey))
+        {
+            throw new NotSupportedException($"Отправка от имени бота '{botKey}' пока не поддерживается (ADR010 §5).");
+        }
+        return defaultService;
+    }
+}

--- a/src/JoinRpg.Services.Interfaces/Notification/ITelegramNotificationServiceFactory.cs
+++ b/src/JoinRpg.Services.Interfaces/Notification/ITelegramNotificationServiceFactory.cs
@@ -1,0 +1,12 @@
+namespace JoinRpg.Services.Interfaces.Notification;
+
+/// <summary>
+/// Резолвит клиента отправки в Telegram по ключу бота.
+/// Точка расширения под будущий мультибот (ADR010 §5) — сегодня поддерживается только
+/// дефолтный бот приложения.
+/// </summary>
+public interface ITelegramNotificationServiceFactory
+{
+    /// <param name="botKey">null/пусто — дефолтный бот приложения.</param>
+    ITelegramNotificationService GetService(string? botKey);
+}


### PR DESCRIPTION
## Что сделано
- `ITelegramNotificationServiceFactory.GetService(string? botKey)` (`JoinRpg.Services.Interfaces`) — резолвит клиента отправки по ключу бота.
- `DefaultOnlyTelegramNotificationServiceFactory` (`JoinRpg.Common.Telegram`) — единственная реализация на сегодня: поддерживает только дефолтного бота приложения (`botKey` пуст/null), для любого другого ключа бросает `NotSupportedException`. Зарегистрирована в `Registration.cs`.
- Тесты на оба сценария (`DefaultOnlyTelegramNotificationServiceFactoryTest`).

Это только точка расширения (ADR010 §5) — ничего в проекте пока не потребляет фабрику, `ITelegramNotificationService` продолжает внедряться напрямую везде, где раньше. В частности, эта фабрика не завязана на очередь уведомлений и её формат адреса — предполагается, что если понадобится слать через разных ботов, это будет решаться на уровне конкретного отправителя (получает `ITelegramNotificationServiceFactory` и сам решает, какой `botKey` передать), а не через сериализацию бота в адрес уведомления.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test src/Common/JoinRpg.Common.Telegram.Test` (новые тесты зелёные; один существующий тест таймаута падает и на master, не связано с этим PR)
- [x] `dotnet format --verify-no-changes --severity error` (на изменённых файлах)

Generated with [Claude Code](https://claude.ai/code)