### PR TITLE
fix: определять основной конструктор TypedEntityId по синтаксису, а не по [JsonConstructor]

### DIFF
--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/Common/JoinRpg.Common.BastiliaRatingClient/JoinRpg.Common.BastiliaRatingClient.csproj" Id="6a466ef2-b96b-473f-95df-04c08b04cae8" />
     <Project Path="src/Common/JoinRpg.Common.KogdaIgraClient/JoinRpg.Common.KogdaIgraClient.csproj" Id="881e9784-9199-4f85-b173-9e91a15403e2" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj" />
+    <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test.csproj" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.Test/JoinRpg.Common.PrimitiveTypes.Test.csproj" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes/JoinRpg.Common.PrimitiveTypes.csproj" />
     <Project Path="src/Common/JoinRpg.Common.Telegram/JoinRpg.Common.Telegram.csproj" />

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -88,6 +88,6 @@
 ### Tests
 - `JoinRpg.TestHelpers` — общие тестовые утилиты
 - `JoinRpg.DataModel.Mocks` — моки DataModel
-- Тестовые проекты для каждого слоя: Domain, Services.Impl, Portal, IdPortal, Managers, Models, PrimitiveTypes, Markdown, Helpers, Notifications, KogdaIgra, CommonUI.Models
+- Тестовые проекты для каждого слоя: Domain, Services.Impl, Portal, IdPortal, Managers, Models, PrimitiveTypes, PrimitiveTypes.SourceGenerator, Markdown, Helpers, Notifications, KogdaIgra, CommonUI.Models
 
 Не используем Moq/NSubstitute. Предпочитаем классические юнит-тесты мокистким.

--- a/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/GeneratorTestHelper.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/GeneratorTestHelper.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test;
+
+/// <summary>
+/// Прогоняет <see cref="TypedEntityIdGenerator"/> над куском исходного кода и компилирует результат,
+/// чтобы можно было не только проверить диагностику, но и вызвать сгенерированный код через рефлексию.
+/// </summary>
+internal static class GeneratorTestHelper
+{
+    public static GeneratorRunResult RunGenerator(string source)
+    {
+        var references = GetMetadataReferences();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "GeneratorTestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new TypedEntityIdGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+
+        var compileDiagnostics = outputCompilation.GetDiagnostics();
+
+        return new GeneratorRunResult(outputCompilation, generatorDiagnostics, compileDiagnostics);
+    }
+
+    /// <summary>Компилирует результат генерации в assembly и загружает его для рефлексии.</summary>
+    public static Assembly EmitAndLoad(Compilation compilation)
+    {
+        using var stream = new MemoryStream();
+        EmitResult result = compilation.Emit(stream);
+        if (!result.Success)
+        {
+            var errors = string.Join(
+                Environment.NewLine,
+                result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Компиляция не удалась:{Environment.NewLine}{errors}");
+        }
+
+        stream.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(stream.ToArray());
+    }
+
+    private static List<MetadataReference> GetMetadataReferences()
+    {
+        var trustedPlatformAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
+        var references = trustedPlatformAssemblies
+            .Split(Path.PathSeparator)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToList();
+
+        references.Add(MetadataReference.CreateFromFile(typeof(TypedEntityIdAttribute).Assembly.Location));
+
+        return references;
+    }
+}
+
+internal sealed record GeneratorRunResult(
+    Compilation OutputCompilation,
+    IReadOnlyList<Diagnostic> GeneratorDiagnostics,
+    IReadOnlyList<Diagnostic> CompileDiagnostics)
+{
+    public IEnumerable<Diagnostic> Errors =>
+        GeneratorDiagnostics.Concat(CompileDiagnostics).Where(d => d.Severity == DiagnosticSeverity.Error);
+}

--- a/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test.csproj
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JoinRpg.Common.PrimitiveTypes.SourceGenerator\JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj" />
+    <ProjectReference Include="..\JoinRpg.Common.PrimitiveTypes\JoinRpg.Common.PrimitiveTypes.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/NestedTypedEntityIdTests.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test/NestedTypedEntityIdTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using Xunit;
+
+namespace JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test;
+
+/// <summary>
+/// Регрессия: генератор раньше находил основной конструктор вложенного TypedEntityId по атрибуту
+/// [JsonConstructor], который легко забыть на вложенном типе — тогда генерация вложенных Id молча
+/// не срабатывала (тип переставал реализовывать интерфейс). Теперь основной конструктор находится
+/// по синтаксису record-декларации, атрибут для этого не нужен.
+/// </summary>
+public class NestedTypedEntityIdTests
+{
+    private const string CommonDeclarations = """
+        using JoinRpg.Common.PrimitiveTypes;
+
+        namespace TestNs;
+
+        public interface IProjectEntityId
+        {
+            ProjectIdentification ProjectId { get; }
+            int Id { get; }
+        }
+
+        [TypedEntityId(ShortName = "Project")]
+        public partial record ProjectIdentification(int Value) : IProjectEntityId
+        {
+            ProjectIdentification IProjectEntityId.ProjectId => this;
+            int IProjectEntityId.Id => Value;
+        }
+        """;
+
+    [Fact]
+    public void Two_level_nesting_without_JsonConstructor_generates_ProjectId()
+    {
+        var source = CommonDeclarations + """
+
+            [TypedEntityId]
+            public partial record FolderIdentification(ProjectIdentification ProjectId, int FolderId) : IProjectEntityId;
+
+            [TypedEntityId]
+            public partial record ElementIdentification(FolderIdentification FolderId, int ElementId) : IProjectEntityId;
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        result.Errors.ShouldBeEmpty();
+
+        var assembly = GeneratorTestHelper.EmitAndLoad(result.OutputCompilation);
+        var elementType = assembly.GetType("TestNs.ElementIdentification")!;
+        var folderType = assembly.GetType("TestNs.FolderIdentification")!;
+        var projectType = assembly.GetType("TestNs.ProjectIdentification")!;
+
+        var project = Activator.CreateInstance(projectType, 1)!;
+        var folder = Activator.CreateInstance(folderType, project, 2)!;
+        var element = Activator.CreateInstance(elementType, folder, 3)!;
+
+        var projectId = elementType.GetProperty("ProjectId")!.GetValue(element)!;
+        projectType.GetProperty("Value")!.GetValue(projectId).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Three_level_nesting_without_JsonConstructor_generates_ProjectId()
+    {
+        var source = CommonDeclarations + """
+
+            [TypedEntityId]
+            public partial record FolderIdentification(ProjectIdentification ProjectId, int FolderId) : IProjectEntityId;
+
+            [TypedEntityId]
+            public partial record ElementIdentification(FolderIdentification FolderId, int ElementId) : IProjectEntityId;
+
+            [TypedEntityId]
+            public partial record VersionIdentification(ElementIdentification ElementId, int Version) : IProjectEntityId;
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        result.Errors.ShouldBeEmpty();
+
+        var assembly = GeneratorTestHelper.EmitAndLoad(result.OutputCompilation);
+        var versionType = assembly.GetType("TestNs.VersionIdentification")!;
+        var elementType = assembly.GetType("TestNs.ElementIdentification")!;
+        var folderType = assembly.GetType("TestNs.FolderIdentification")!;
+        var projectType = assembly.GetType("TestNs.ProjectIdentification")!;
+
+        var project = Activator.CreateInstance(projectType, 1)!;
+        var folder = Activator.CreateInstance(folderType, project, 2)!;
+        var element = Activator.CreateInstance(elementType, folder, 3)!;
+        var version = Activator.CreateInstance(versionType, element, 4)!;
+
+        var projectId = versionType.GetProperty("ProjectId")!.GetValue(version)!;
+        projectType.GetProperty("Value")!.GetValue(projectId).ShouldBe(1);
+
+        version.ToString().ShouldBe("VersionId(1-2-3-4)");
+    }
+
+    [Fact]
+    public void JsonConstructor_attribute_is_not_required_for_flat_constructor_disambiguation()
+    {
+        // FolderIdentification имеет 2 листа (Value, FolderId) -> генератор сам добавляет ему
+        // плоский конструктор FolderIdentification(int, int). ElementIdentification вложен в него
+        // без [JsonConstructor] — раньше это ломало поиск основного конструктора.
+        var source = CommonDeclarations + """
+
+            [TypedEntityId]
+            public partial record FolderIdentification(ProjectIdentification ProjectId, int FolderId) : IProjectEntityId;
+
+            [TypedEntityId]
+            public partial record ElementIdentification(FolderIdentification FolderId, int ElementId) : IProjectEntityId;
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        result.Errors.ShouldBeEmpty();
+
+        var generatedSource = result.OutputCompilation.SyntaxTrees
+            .Select(t => t.ToString())
+            .FirstOrDefault(t => t.StartsWith("// <auto-generated/>") && t.Contains("record ElementIdentification"));
+
+        generatedSource.ShouldNotBeNull();
+        generatedSource.ShouldContain("public ProjectIdentification ProjectId => FolderId.ProjectId;");
+    }
+}

--- a/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
@@ -333,12 +333,30 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         return result;
     }
 
+    /// <summary>
+    /// Находит основной (позиционный) конструктор record-типа — тот, что объявлен в списке параметров
+    /// record-декларации (record Foo(T1 P1, T2 P2)). Определяется по синтаксису, а не по атрибуту:
+    /// список имён параметров основного конструктора всегда совпадает с именами параметров record-декларации
+    /// (PascalCase, т.к. это имена генерируемых свойств), тогда как доп. конструктор с плоскими int-параметрами,
+    /// который генерирует сам этот генератор, использует lowerCamelCase-имена — совпадения не будет.
+    /// </summary>
     private static IMethodSymbol? FindPrimaryConstructor(INamedTypeSymbol type)
     {
-        // Для record-типов: ищем конструктор с атрибутом [JsonConstructor]
-        return type.InstanceConstructors
-            .FirstOrDefault(c => c.GetAttributes()
-                .Any(a => a.AttributeClass?.Name == "JsonConstructorAttribute"));
+        var recordDecl = type.DeclaringSyntaxReferences
+            .Select(r => r.GetSyntax())
+            .OfType<RecordDeclarationSyntax>()
+            .FirstOrDefault(r => r.ParameterList != null);
+
+        if (recordDecl?.ParameterList == null)
+        {
+            return null;
+        }
+
+        var paramNames = recordDecl.ParameterList.Parameters.Select(p => p.Identifier.Text).ToArray();
+
+        return type.InstanceConstructors.FirstOrDefault(c =>
+            c.Parameters.Length == paramNames.Length &&
+            c.Parameters.Select(p => p.Name).SequenceEqual(paramNames));
     }
 
     /// <summary>Проверяет, есть ли в типе hand-written реализация CompareTo (включая explicit interface implementations).</summary>


### PR DESCRIPTION
## Что сделано

- Генератор `TypedEntityIdGenerator` раньше искал основной (позиционный) конструктор вложенного `TypedEntityId` по атрибуту `[method: JsonConstructor]` — его легко забыть повесить на вложенный тип, и тогда генерация вложенных Id (например `ProjectId`) молча не срабатывала, что дальше валилось непонятными `CS0535` в другом месте.
- `[JsonConstructor]` в этом коде и не нужен для реальной сериализации: `TypedEntityIdJsonConverter<T>` сериализует через `ToString()`/`TryParse`, а не через стандартный STJ-контракт с конструктором. Атрибут использовался только внутренним механизмом генератора.
- Теперь основной конструктор находится по синтаксису record-декларации: его параметры всегда PascalCase (это имена генерируемых свойств), а сгенерированный самим генератором плоский int-конструктор — lowerCamelCase, коллизий не бывает.
- Добавлен новый тестовый проект `JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test`, который прогоняет генератор напрямую через `CSharpGeneratorDriver`, компилирует результат в memory-assembly и проверяет поведение через рефлексию. Тесты воспроизводят баг (2- и 3-уровневая вложенность без `[JsonConstructor]`) и падали на старой версии генератора с теми же `CS0535`, что ловил обычный `dotnet build`.

## Важно

Генератор подключается потребителями как NuGet-пакет с зафиксированной версией (`Directory.Packages.props`), а не как `ProjectReference`. Поэтому:
- Существующие `[method: JsonConstructor]` на TypedEntityId-типах в решении **не убраны** — они пока обязательны, так как солюшен собирается со старой опубликованной версией пакета.
- Эффект этой правки появится только после публикации новой версии `JoinRpg.Common.PrimitiveTypes.SourceGenerator` (workflow `nuget-publish.yml`) и обновления версии в `Directory.Packages.props`. Уборку атрибутов из существующих типов имеет смысл сделать отдельным PR после этого.

## Test plan

- [x] `dotnet test src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator.Test` — 3/3 зелёных
- [x] Вручную подтверждено, что тесты падают на пред-фикс версии генератора с теми же ошибками, что ловил основной билд
- [x] `dotnet format --verify-no-changes --severity error` для изменённых проектов

Generated with [Claude Code](https://claude.ai/code)