### PR TITLE
fix: устранить N+1 lazy load PlotTags в списках сюжетов

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/PlotRepositoryImpl.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/PlotRepositoryImpl.cs
@@ -36,6 +36,7 @@ internal class PlotRepositoryImpl(MyDbContext ctx) : GameRepositoryImplBase(ctx)
           .Include(pf => pf.Elements.Select(e => e.TargetCharacters))
           .Include(pf => pf.Elements.Select(e => e.TargetGroups))
           .Include(pf => pf.Elements.Select(e => e.Texts.Select(t => t.AuthorUser)))
+          .Include(pf => pf.PlotTags)
           .Where(pf => pf.IsActive)
           .Where(pf => pf.ProjectId == projectid)
           .ToListAsync();
@@ -44,6 +45,7 @@ internal class PlotRepositoryImpl(MyDbContext ctx) : GameRepositoryImplBase(ctx)
     {
         var project = await Ctx.Set<Project>()
           .Include(p => p.PlotFolders.Select(pf => pf.Elements))
+          .Include(p => p.PlotFolders.Select(pf => pf.PlotTags))
           .Include(p => p.Details)
           .SingleAsync(pf => pf.ProjectId == projectId.Value);
 
@@ -55,6 +57,7 @@ internal class PlotRepositoryImpl(MyDbContext ctx) : GameRepositoryImplBase(ctx)
         return Ctx.Set<PlotFolder>()
           .Include(pf => pf.Elements.Select(e => e.TargetCharacters))
           .Include(pf => pf.Elements.Select(e => e.TargetGroups))
+          .Include(pf => pf.PlotTags)
           .Where(pf => pf.ProjectId == projectId)
           .Where(
               pf =>
@@ -66,9 +69,9 @@ internal class PlotRepositoryImpl(MyDbContext ctx) : GameRepositoryImplBase(ctx)
 
     public async Task<IReadOnlyCollection<PlotFolder>> GetPlotsByTag(int projectid, string tagname)
     {
-        await LoadProjectGroups(projectid); //TODO[GroupsLoad] it's unclear why we need this
         return await Ctx.Set<PlotFolder>()
           .Include(pf => pf.Elements)
+          .Include(pf => pf.PlotTags)
           .Where(pf => pf.ProjectId == projectid && pf.PlotTags.Any(tag => tag.TagName == tagname))
           .ToListAsync();
     }


### PR DESCRIPTION
## Что сделано
- По продакшн-логам (`SQL: Probably lazy load ...`) самый частый случай lazy load за неделю — 650+ предупреждений на `PlotListController.FlatList`/`Index`: `PlotFolderListViewModelBuilder` читает `folder.PlotTags` для каждой папки сюжета, а репозиторий не подгружал коллекцию eager'но, из-за чего EF6 делал отдельный SQL-запрос на каждую папку (N+1).
- Добавлен `Include(pf => pf.PlotTags)` в `GetPlotsWithTargetAndText`, `GetPlots`, `GetPlotsForTargets`, `GetPlotsByTag` (`PlotRepositoryImpl`).
- Заодно убран `LoadProjectGroups` в `GetPlotsByTag` — мёртвый вызов с комментарием `TODO[GroupsLoad] it's unclear why we need this`, висевшим с 2017 года; ни `folder.Elements`, ни `folder.PlotTags` не используют `CharacterGroups`. Аналогичный вызов уже безболезненно убрали из `GetPlots` при рефакторинге в 2025 (93dfc17dcc) без регрессий.

## Test plan
- [x] `dotnet build src/JoinRpg.Dal.Impl/JoinRpg.Dal.Impl.csproj`
- [ ] После деплоя проверить в логах прода, что `Probably lazy load ... PlotFolderProjectItemTags` для `PlotListController.*` пропало

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaWEgKAKQ2JFQY3tU5DunG