### PR TITLE
feat: IEntityId<TSelf,TValue> и generic EF Core ValueConverter для typed id

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -22,6 +22,7 @@ jobs:
           - JoinRpg.Common.PrimitiveTypes.SourceGenerator
           - JoinRpg.Common.KogdaIgraClient
           - JoinRpg.Common.WebComponents
+          - JoinRpg.Common.EntityFrameworkCore
           # Добавить новые проекты сюда:
           # - SomeOtherProject.csproj
 

--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Common/">
     <Project Path="src/Common/JoinRpg.Common.BastiliaRatingClient/JoinRpg.Common.BastiliaRatingClient.csproj" Id="6a466ef2-b96b-473f-95df-04c08b04cae8" />
+    <Project Path="src/Common/JoinRpg.Common.EntityFrameworkCore/JoinRpg.Common.EntityFrameworkCore.csproj" />
     <Project Path="src/Common/JoinRpg.Common.KogdaIgraClient/JoinRpg.Common.KogdaIgraClient.csproj" Id="881e9784-9199-4f85-b173-9e91a15403e2" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.Test/JoinRpg.Common.PrimitiveTypes.Test.csproj" />

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -28,6 +28,7 @@
 - `JoinRpg.Helpers` — утилиты без зависимостей от проекта
 - `JoinRpg.Markdown` — обработка Markdown (Markdig)
 - `JoinRpg.PrimitiveTypes` — доменные типы-значения: идентификаторы и Value Objects
+- `JoinRpg.Common.EntityFrameworkCore` — generic EF Core ValueConverter для `[TypedEntityId]`-типов, реализующих `IEntityId<TSelf,TValue>` (не составные id)
 - `JoinRpg.Common.WebInfrastructure` — веб-инфраструктура: логирование (Serilog), кеш, DataProtection, фоновые задачи
 - `JoinRpg.Common.Telegram` — интеграция с Telegram Bot
 - `JoinRpg.Common.BastiliaRatingClient` — HTTP-клиент к сайту клуба #Бастилия

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore/EntityIdConversionExtensions.cs
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore/EntityIdConversionExtensions.cs
@@ -1,0 +1,41 @@
+using JoinRpg.Common.PrimitiveTypes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace JoinRpg.Common.EntityFrameworkCore;
+
+public static class EntityIdConversionExtensions
+{
+    /// <summary>
+    /// Регистрирует <see cref="EntityIdValueConverter{TId, TValue}"/> для id-типа. Вызывается из
+    /// ConfigureConventions (обязательно ДО построения модели — иначе EF примет свойство этого типа
+    /// за навигацию к новой entity). TValue не выводится из TId одного generic-параметра, поэтому
+    /// указывается явно: .HaveEntityIdValueConversion&lt;BastiliaProjectId, int&gt;().
+    /// </summary>
+    public static void HaveEntityIdValueConversion<TId, TValue>(this PropertiesConfigurationBuilder<TId> builder)
+        where TId : class, IEntityId<TId, TValue>
+        where TValue : struct
+        => builder.HaveConversion<EntityIdValueConverter<TId, TValue>>();
+
+    /// <summary>
+    /// Помечает все однопроцессные PK-свойства, чей CLR-тип реализует <see cref="IEntityId{TSelf, TValue}"/>,
+    /// как identity (ValueGenerated.OnAdd). Вызывается из OnModelCreating, когда модель уже построена.
+    /// </summary>
+    public static void EntityIdsSetValueGeneratedOnAdd(this ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (entityType.FindPrimaryKey() is { Properties: [var keyProperty] }
+                && ImplementsEntityId(keyProperty.ClrType))
+            {
+                keyProperty.ValueGenerated = ValueGenerated.OnAdd;
+            }
+        }
+    }
+
+    // IEntityId<TSelf, TValue> — generic-интерфейс, поэтому "typeof(IEntityId<,>).IsAssignableFrom(clrType)"
+    // не работает напрямую; ищем среди реализованных интерфейсов совпадение по открытой generic-форме.
+    private static bool ImplementsEntityId(Type type) =>
+        type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEntityId<,>));
+}

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore/EntityIdValueConverter.cs
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore/EntityIdValueConverter.cs
@@ -1,0 +1,19 @@
+using JoinRpg.Common.PrimitiveTypes;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace JoinRpg.Common.EntityFrameworkCore;
+
+/// <summary>
+/// Общий конвертер для любого id-типа, сгенерированного через [TypedEntityId] и реализующего
+/// <see cref="IEntityId{TSelf, TValue}"/> — новый id-тип не требует отдельного класса-конвертера,
+/// достаточно объявить у него ": IEntityId&lt;TSelf, TValue&gt;" (генератор делает это сам для не составных id).
+/// </summary>
+internal sealed class EntityIdValueConverter<TId, TValue>()
+    : ValueConverter<TId, TValue>(id => id.Id, value => FromProvider(value))
+    where TId : class, IEntityId<TId, TValue>
+    where TValue : struct
+{
+    // Expression trees don't allow direct calls to static abstract interface members (CS8927),
+    // so the call is routed through this regular method instead.
+    private static TId FromProvider(TValue value) => TId.FromOptional(value);
+}

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore/JoinRpg.Common.EntityFrameworkCore.csproj
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore/JoinRpg.Common.EntityFrameworkCore.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <PackageId>JoinRpg.Common.EntityFrameworkCore</PackageId>
+    <Description>EF Core mapping helpers for JoinRpg.Common.PrimitiveTypes typed entity ids.</Description>
+    <PackageProjectUrl>https://github.com/joinrpg/joinrpg-net</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/joinrpg/joinrpg-net</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JoinRpg.Common.PrimitiveTypes\JoinRpg.Common.PrimitiveTypes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/TypedEntityIdGenerator.cs
@@ -433,6 +433,13 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         {
             interfaces.Add($"IComparable<{info.TypeName}>");
         }
+        // Не составные id (единственный числовой параметр) можно обобщённо смаппить на колонку БД —
+        // см. IEntityId<TSelf,TValue> в JoinRpg.Common.PrimitiveTypes и generic ValueConverter в
+        // JoinRpg.Common.EntityFrameworkCore.
+        if (info.PrimaryParams.Count == 1)
+        {
+            interfaces.Add($"IEntityId<{info.TypeName}, {info.NumericTypeKeyword}>");
+        }
 
         sb.AppendLine($"[global::System.Text.Json.Serialization.JsonConverter(typeof(global::JoinRpg.Common.PrimitiveTypes.TypedEntityIdJsonConverter<{info.TypeName}>))]");
         sb.AppendLine($"public partial record {info.TypeName} : {string.Join(", ", interfaces)}");
@@ -567,6 +574,14 @@ public class TypedEntityIdGenerator : IIncrementalGenerator
         var checksStr = string.Join(" && ", nullChecks);
         var argsStr = string.Join(", ", ctorArgs);
 
+        // Единственный параметр — это ровно сигнатура IEntityId<TSelf,TValue>.FromOptional(TValue?):
+        // null на входе даёт null на выходе, не-null даёт не-null. Для составных id (несколько параметров)
+        // атрибут не ставим — там nullability результата это AND нескольких параметров, одним именем не выразить.
+        if (info.PrimaryParams.Count == 1)
+        {
+            var soleParamName = char.ToLower(info.PrimaryParams[0].Name[0]) + info.PrimaryParams[0].Name.Substring(1);
+            sb.AppendLine($"    [return: NotNullIfNotNull(nameof({soleParamName}))]");
+        }
         sb.AppendLine($"    public static {info.TypeName}? FromOptional({paramsStr})");
         sb.AppendLine($"        => {checksStr} ? new {info.TypeName}({argsStr}) : null;");
         sb.AppendLine();

--- a/src/Common/JoinRpg.Common.PrimitiveTypes/IEntityId.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes/IEntityId.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace JoinRpg.Common.PrimitiveTypes;
+
+/// <summary>
+/// Реализуется типами, сгенерированными через <see cref="TypedEntityIdAttribute"/> для не составных id
+/// (единственный числовой параметр). Используется для универсального маппинга в EF Core через
+/// generic ValueConverter в JoinRpg.Common.EntityFrameworkCore.
+/// </summary>
+public interface IEntityId<TSelf, TValue>
+    where TSelf : class, IEntityId<TSelf, TValue>
+    where TValue : struct
+{
+    TValue Id { get; }
+
+    [return: NotNullIfNotNull(nameof(value))]
+    static abstract TSelf? FromOptional(TValue? value);
+}


### PR DESCRIPTION
## Что сделано
- Генератор `TypedEntityId` для не составных id (единственный int/long параметр) теперь добавляет интерфейс `IEntityId<TSelf,TValue>` и `[return: NotNullIfNotNull]` на соответствующий `FromOptional` — задел для generic-маппинга typed id в EF Core вместо рукописного конвертера под каждый тип (см. обсуждение по [bastilia-rating#174](https://github.com/bastilia-ru/bastilia-rating/pull/174)).
- Новый пакет `JoinRpg.Common.EntityFrameworkCore`: `EntityIdValueConverter<TId,TValue>` + `HaveEntityIdValueConversion<TId,TValue>()`/`EntityIdsSetValueGeneratedOnAdd()` для регистрации в `ConfigureConventions`/`OnModelCreating`.

Правка генератора не влияет ни на что до публикации пакета `JoinRpg.Common.PrimitiveTypes.SourceGenerator` и бампа версии в `Directory.Packages.props` — это отдельный шаг (как в #4624).

## Test plan
- [x] `dotnet build`/`dotnet test` для `JoinRpg.Common.PrimitiveTypes` и `JoinRpg.Common.EntityFrameworkCore` — чисто
- [x] Временный `ProjectReference` на генератор (вместо пакета) подтвердил, что `IEntityId<UserIdentification,int>`/`IEntityId<TelegramChatId,long>` генерируются верно, а конвертер и `EntityIdsSetValueGeneratedOnAdd` корректно работают на реальных типах — все 53 существующих теста `PrimitiveTypes.Test` зелёные
- [ ] Тестовый проект `JoinRpg.Common.EntityFrameworkCore.Test` (round-trip на реальных id) отправится отдельным PR после публикации пакета генератора и бампа версии — до этого он не компилируется

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnDWq4LL6WkYAZf4iGXgFF