### PR TITLE
test: JoinRpg.Common.EntityFrameworkCore.Test + bump SourceGenerator до 2026.7.32

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
         <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
         <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.11" />
@@ -87,6 +88,6 @@
         <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
         <PackageVersion Include="Xunit.SkippableFact" Version="1.5.85" />
         <!-- Using NuGet package instead of ProjectReference to avoid recompilation issues with language server -->
-        <PackageVersion Include="JoinRpg.Common.PrimitiveTypes.SourceGenerator" Version="2026.7.14" />
+        <PackageVersion Include="JoinRpg.Common.PrimitiveTypes.SourceGenerator" Version="2026.7.32" />
     </ItemGroup>
 </Project>

--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Common/">
     <Project Path="src/Common/JoinRpg.Common.BastiliaRatingClient/JoinRpg.Common.BastiliaRatingClient.csproj" Id="6a466ef2-b96b-473f-95df-04c08b04cae8" />
+    <Project Path="src/Common/JoinRpg.Common.EntityFrameworkCore.Test/JoinRpg.Common.EntityFrameworkCore.Test.csproj" />
     <Project Path="src/Common/JoinRpg.Common.EntityFrameworkCore/JoinRpg.Common.EntityFrameworkCore.csproj" />
     <Project Path="src/Common/JoinRpg.Common.KogdaIgraClient/JoinRpg.Common.KogdaIgraClient.csproj" Id="881e9784-9199-4f85-b173-9e91a15403e2" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.SourceGenerator/JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj" />

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -89,6 +89,6 @@
 ### Tests
 - `JoinRpg.TestHelpers` — общие тестовые утилиты
 - `JoinRpg.DataModel.Mocks` — моки DataModel
-- Тестовые проекты для каждого слоя: Domain, Services.Impl, Portal, IdPortal, Managers, Models, PrimitiveTypes, PrimitiveTypes.SourceGenerator, Markdown, Helpers, Notifications, KogdaIgra, CommonUI.Models
+- Тестовые проекты для каждого слоя: Domain, Services.Impl, Portal, IdPortal, Managers, Models, PrimitiveTypes, PrimitiveTypes.SourceGenerator, Markdown, Helpers, Notifications, KogdaIgra, CommonUI.Models, EntityFrameworkCore
 
 Не используем Moq/NSubstitute. Предпочитаем классические юнит-тесты мокистким.

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/EntityIdConversionExtensionsTest.cs
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/EntityIdConversionExtensionsTest.cs
@@ -1,0 +1,59 @@
+using JoinRpg.Common.EntityFrameworkCore;
+using JoinRpg.Common.PrimitiveTypes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace JoinRpg.Common.EntityFrameworkCore.Test;
+
+public class EntityIdConversionExtensionsTest
+{
+    private class Widget
+    {
+        public UserIdentification Id { get; set; } = null!;
+        public TelegramChatId ChatId { get; set; } = null!;
+    }
+
+    private class WidgetContext(DbContextOptions<WidgetContext> options) : DbContext(options)
+    {
+        public DbSet<Widget> Widgets => Set<Widget>();
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            configurationBuilder.Properties<UserIdentification>().HaveEntityIdValueConversion<UserIdentification, int>();
+            configurationBuilder.Properties<TelegramChatId>().HaveEntityIdValueConversion<TelegramChatId, long>();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.EntityIdsSetValueGeneratedOnAdd();
+        }
+    }
+
+    private static WidgetContext CreateContext() =>
+        new(new DbContextOptionsBuilder<WidgetContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public void ShouldRoundTripIntAndLongBasedIds()
+    {
+        using var context = CreateContext();
+        context.Widgets.Add(new Widget { Id = new UserIdentification(42), ChatId = new TelegramChatId(-1004315256401) });
+        context.SaveChanges();
+
+        var widget = context.Widgets.Single();
+
+        widget.Id.ShouldBe(new UserIdentification(42));
+        widget.ChatId.ShouldBe(new TelegramChatId(-1004315256401));
+    }
+
+    [Fact]
+    public void ShouldMarkSingleColumnPrimaryKeyAsValueGeneratedOnAdd()
+    {
+        using var context = CreateContext();
+
+        var keyProperty = context.Model.FindEntityType(typeof(Widget))!.FindPrimaryKey()!.Properties.Single();
+
+        keyProperty.ValueGenerated.ShouldBe(ValueGenerated.OnAdd);
+    }
+}

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/GlobalUsings.cs
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Shouldly;
+global using Xunit;

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/JoinRpg.Common.EntityFrameworkCore.Test.csproj
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/JoinRpg.Common.EntityFrameworkCore.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JoinRpg.Common.EntityFrameworkCore\JoinRpg.Common.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\JoinRpg.Common.PrimitiveTypes\JoinRpg.Common.PrimitiveTypes.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Что сделано
- Follow-up к #4651: пакет `JoinRpg.Common.PrimitiveTypes.SourceGenerator` с `IEntityId<TSelf,TValue>` опубликован, версия в `Directory.Packages.props` забампана до `2026.7.32`.
- Добавлен `JoinRpg.Common.EntityFrameworkCore.Test` — round-trip и identity-колонка для PK на реальных `UserIdentification` (int) и `TelegramChatId` (long) через EF Core InMemory-провайдер.

## Test plan
- [x] `dotnet test src/Common/JoinRpg.Common.EntityFrameworkCore.Test` — 2/2 зелёных против реально опубликованного пакета `2026.7.32`
- [x] `dotnet test src/Common/JoinRpg.Common.PrimitiveTypes.Test` — 53/53 без регрессий
- [x] `dotnet format --verify-no-changes` для затронутых проектов — чисто

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnDWq4LL6WkYAZf4iGXgFF