### PR TITLE
refactor: перенести TelegramLoginValidator в JoinRpg.Common.Telegram

### DIFF
--- a/src/Common/JoinRpg.Common.Telegram/Registration.cs
+++ b/src/Common/JoinRpg.Common.Telegram/Registration.cs
@@ -11,6 +11,7 @@ public static class Registration
     public static IServiceCollection AddJoinTelegram(this IServiceCollection services)
     {
         _ = services
+            .AddTransient<TelegramLoginValidator>()
             .AddTransient<TelegramNotificationServiceImpl>()
             .AddTransient<StubTelegramNotificationService>()
             .AddTransient<ITelegramNotificationService>(services =>

--- a/src/Common/JoinRpg.Common.Telegram/TelegramAuthorizationResult.cs
+++ b/src/Common/JoinRpg.Common.Telegram/TelegramAuthorizationResult.cs
@@ -1,4 +1,4 @@
-namespace JoinRpg.Portal.Infrastructure.Authentication.Telegram;
+namespace JoinRpg.Common.Telegram;
 
 public enum TelegramAuthorizationResult
 {

--- a/src/Common/JoinRpg.Common.Telegram/TelegramLoginValidator.cs
+++ b/src/Common/JoinRpg.Common.Telegram/TelegramLoginValidator.cs
@@ -1,9 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
-using JoinRpg.Common.Telegram;
 using Microsoft.Extensions.Options;
 
-namespace JoinRpg.Portal.Infrastructure.Authentication.Telegram;
+namespace JoinRpg.Common.Telegram;
 
 /// <summary>
 /// A helper class used to verify authorization data.

--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -5,7 +5,6 @@ using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Users;
 using JoinRpg.Interfaces;
 using JoinRpg.Portal.Infrastructure.Authentication;
-using JoinRpg.Portal.Infrastructure.Authentication.Telegram;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Services.Interfaces.Avatars;
 using JoinRpg.Web.Helpers;

--- a/src/JoinRpg.Portal/Infrastructure/Authentication/AuthenticationConfigurator.cs
+++ b/src/JoinRpg.Portal/Infrastructure/Authentication/AuthenticationConfigurator.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Joinrpg.Web.Identity;
-using JoinRpg.Portal.Infrastructure.Authentication.Telegram;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -20,9 +19,6 @@ internal static class AuthenticationConfigurator
     {
 
         _ = services.AddJoinIdentity();
-
-        _ = services
-            .AddTransient<TelegramLoginValidator>();
 
         _ = services.AddAntiforgery(options => options.HeaderName = "X-CSRF-TOKEN");
 


### PR DESCRIPTION
## Что сделано

- `TelegramLoginValidator` и `TelegramAuthorizationResult` перенесены из `JoinRpg.Portal/Infrastructure/Authentication/Telegram` в `JoinRpg.Common.Telegram` (namespace `JoinRpg.Common.Telegram`), без изменений логики — это 1-в-1 перенос кода.
- Регистрация `TelegramLoginValidator` в DI объединена внутри `AddJoinTelegram()` (в `Registration.cs`), вместо отдельного вызова в `AuthenticationConfigurator.AddJoinAuth()`. Теперь вся Telegram-инфраструктура (уведомления + валидация логина) подключается одной точкой входа.
- В `AuthenticationConfigurator.cs` и `ManageController.cs` убраны лишние `using` на старое пространство имён.

Поведение не меняется — это чисто структурный рефакторинг, готовящий почву для переиспользования Telegram-логина за пределами `Portal`.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvDs7wCpHXbKXM6iNGzVzX