### PR TITLE
feat: добавить HasPassword в UserInfo

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
@@ -105,6 +105,7 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
                 user.VerifiedProfileFlag,
                 user.Extra.PhoneNumber,
                 user.Auth.EmailConfirmed,
+                HasPassword = user.PasswordHash != null,
             };
 
 
@@ -132,7 +133,8 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
             result.EmailConfirmed,
             userFullName,
             result.VerifiedProfileFlag,
-            result.PhoneNumber
+            result.PhoneNumber,
+            result.HasPassword
             );
         })];
     }

--- a/src/JoinRpg.DataModel.Mocks/MockedProject.cs
+++ b/src/JoinRpg.DataModel.Mocks/MockedProject.cs
@@ -14,7 +14,7 @@ public class MockedProject
     public Project Project { get; }
     public CharacterGroup Group { get; }
     public User Player { get; } = new User() { UserId = 1, PrefferedName = "Player", Email = "player@example.com", Claims = new HashSet<Claim>() };
-    public UserInfo PlayerInfo = new UserInfo(new UserIdentification(1), Social: new UserSocialNetworks(null, null, null, null, ContactsAccessType.Public), [], [], [], IsAdmin: false, SelectedAvatarId: null, new Email("player@example.com"), EmailConfirmed: true, new UserFullName(new PrefferedName("Player"), null, null, null), false, null);
+    public UserInfo PlayerInfo = new UserInfo(new UserIdentification(1), Social: new UserSocialNetworks(null, null, null, null, ContactsAccessType.Public), [], [], [], IsAdmin: false, SelectedAvatarId: null, new Email("player@example.com"), EmailConfirmed: true, new UserFullName(new PrefferedName("Player"), null, null, null), false, null, HasPassword: false);
     public User Master { get; } = new User() { UserId = 2, PrefferedName = "Master", Email = "master@example.com", Claims = new HashSet<Claim>() };
 
     public ProjectFieldInfo MasterOnlyFieldInfo { get; set; }

--- a/src/JoinRpg.Domain/UserExtensions.cs
+++ b/src/JoinRpg.Domain/UserExtensions.cs
@@ -25,7 +25,8 @@ public static class UserExtensions
             user.Auth.EmailConfirmed,
             user.ExtractFullName(),
             user.VerifiedProfileFlag,
-            user.Extra?.PhoneNumber
+            user.Extra?.PhoneNumber,
+            user.PasswordHash != null
             );
     }
 

--- a/src/JoinRpg.DomainTypes/Users/UserInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserInfo.cs
@@ -14,7 +14,8 @@ public record class UserInfo(
     bool EmailConfirmed,
     UserFullName UserFullName,
     bool VerifiedProfileFlag,
-    string? PhoneNumber)
+    string? PhoneNumber,
+    bool HasPassword)
 {
     public UserDisplayName DisplayName { get; } = new UserDisplayName(UserFullName, Email);
 

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer.Test/GetUserInfoMethodTest.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer.Test/GetUserInfoMethodTest.cs
@@ -39,7 +39,8 @@ public class GetUserInfoMethodTest
             EmailConfirmed: emailConfirmed,
             UserFullName: new UserFullName(null, BornName.FromOptional(bornName), SurName.FromOptional(surName), FatherName.FromOptional(fatherName)),
             VerifiedProfileFlag: false,
-            PhoneNumber: phoneNumber);
+            PhoneNumber: phoneNumber,
+            HasPassword: false);
     }
 
     private static IOptions<JoinRpgHostNamesOptions> DefaultOptions => Options.Create(new JoinRpgHostNamesOptions

--- a/src/JoinRpg.Services.Notifications.Tests/TelegramSenderJobServiceTests.cs
+++ b/src/JoinRpg.Services.Notifications.Tests/TelegramSenderJobServiceTests.cs
@@ -97,7 +97,8 @@ public class TelegramSenderJobServiceTests
             EmailConfirmed: true,
             new UserFullName(new PrefferedName("Master"), null, null, null),
             VerifiedProfileFlag: false,
-            PhoneNumber: null));
+            PhoneNumber: null,
+            HasPassword: false));
 
         public Task<User> GetById(int id) => throw new NotSupportedException();
         public Task<User> WithProfile(int userId) => throw new NotSupportedException();


### PR DESCRIPTION
## Что сделано
- В доменный тип `UserInfo` (`JoinRpg.DomainTypes.Users`) добавлено поле `HasPassword`, заполняется из `user.PasswordHash != null`.
- Обновлены оба места построения `UserInfo` (`UserInfoRepository.GetUserInfosByPredicate`, `UserExtensions.GetUserInfo`) и тестовые фикстуры, ломавшиеся из-за нового обязательного позиционного параметра.

## Зачем
Доменному типу пользователя не хватало признака наличия пароля — он нужен потребителям, работающим со способами входа в аккаунт (например, чтобы понять, можно ли безопасно отвязать последний внешний логин).

## Test plan
- [x] `dotnet build Joinrpg.slnx` — 0 ошибок
- [x] `dotnet test` для Domain.Test, DomainTypes.Test, Services.Impl.Test, WebPortal.Models.Test, WebPortal.Managers.Test, IdPortal.OAuthServer.Test, Portal.Test, Services.Notifications.Tests — все зелёные
- [x] `dotnet format --verify-no-changes --severity error` по изменённым файлам

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvDs7wCpHXbKXM6iNGzVzX