### PR TITLE
fix: добавить пробел между текстом проблемы и датой

### DIFF
--- a/src/JoinRpg.Web.Claims/ProblemBadge.razor
+++ b/src/JoinRpg.Web.Claims/ProblemBadge.razor
@@ -5,7 +5,7 @@
     }
     @Model.ProblemTypeText@if (Model.ProblemTime is not null)
     {
-        <text> </text>
+        <text>&nbsp;</text>
     }
     <EventTime Model="Model.ProblemTime" />@if (!string.IsNullOrWhiteSpace(Model.Extra))
     {


### PR DESCRIPTION
## Что сделано
- Исправлено отображение проблемы в `ProblemBadge.razor`: между текстом проблемы (например, «По заявке нет решения») и датой теперь выводится неразрывный пробел, чтобы не слипались строки вида «По заявке нет решения15 июля».
- Замена обычного пробела на `&nbsp;` сделана в соответствии с принятым в проекте подходом.

Closes #4657

Generated with [Claude Code](https://claude.ai/code)