### PR TITLE
fix: показывать меню проекта на странице «нет доступа к проекту»

### DIFF
--- a/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
+++ b/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel.Mocks;
 using JoinRpg.Domain;
@@ -6,6 +7,7 @@ using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.Portal.Infrastructure;
 using JoinRpg.Portal.Infrastructure.DiscoverFilters;
 using JoinRpg.Web.Models;
+using JoinRpg.Web.ProjectCommon;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;

--- a/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
+++ b/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
@@ -1,0 +1,94 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.ProjectMetadata;
+using JoinRpg.Portal.Infrastructure;
+using JoinRpg.Portal.Infrastructure.DiscoverFilters;
+using JoinRpg.Web.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+
+namespace JoinRpg.Portal.Test.Infrastructure;
+
+public class CaptureNoAccessExceptionFilterTest
+{
+    private static DefaultHttpContext CreateHttpContext(ProjectInfo projectInfo)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items[Constants.ProjectIdName] = projectInfo.ProjectId.Value;
+        httpContext.RequestServices = new TestServiceProvider()
+            .WithService<IProjectMetadataRepository>(new FakeProjectMetadataRepository(projectInfo));
+        return httpContext;
+    }
+
+    [Fact]
+    public async Task OnExceptionAsync_NoAccessToProjectException_ShouldSetProjectIdInViewData()
+    {
+        var mock = new MockedProject();
+        var httpContext = CreateHttpContext(mock.ProjectInfo);
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var context = new ExceptionContext(actionContext, new List<IFilterMetadata>())
+        {
+            Exception = new NoAccessToProjectException(mock.ProjectInfo, userId: null),
+        };
+
+        var filter = new CaptureNoAccessExceptionFilter(new FakeProjectMetadataRepository(mock.ProjectInfo));
+
+        await filter.OnExceptionAsync(context);
+
+        var viewResult = context.Result.ShouldBeOfType<ViewResult>();
+        viewResult.ViewName.ShouldBe("ErrorNoAccessToProject");
+        viewResult.ViewData.ShouldNotBeNull();
+        viewResult.ViewData[Constants.ProjectIdName].ShouldBe(mock.ProjectInfo.ProjectId.Value);
+        viewResult.Model.ShouldBeOfType<NoAccessToProjectViewModel>();
+    }
+
+    [Fact]
+    public async Task OnExceptionAsync_ProjectDeactivatedException_ShouldSetProjectIdInViewData()
+    {
+        var mock = new MockedProject();
+        var httpContext = CreateHttpContext(mock.ProjectInfo);
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var context = new ExceptionContext(actionContext, new List<IFilterMetadata>())
+        {
+            Exception = new ProjectDeactivatedException(mock.ProjectInfo.ProjectId),
+        };
+
+        var filter = new CaptureNoAccessExceptionFilter(new FakeProjectMetadataRepository(mock.ProjectInfo));
+
+        await filter.OnExceptionAsync(context);
+
+        var viewResult = context.Result.ShouldBeOfType<ViewResult>();
+        viewResult.ViewName.ShouldBe("ErrorNotActiveProject");
+        viewResult.ViewData.ShouldNotBeNull();
+        viewResult.ViewData[Constants.ProjectIdName].ShouldBe(mock.ProjectInfo.ProjectId.Value);
+    }
+
+    private class TestServiceProvider : IServiceProvider
+    {
+        private readonly Dictionary<Type, object> services = new();
+
+        public TestServiceProvider WithService<T>(T service)
+        {
+            services[typeof(T)] = service!;
+            return this;
+        }
+
+        public object? GetService(Type serviceType) => services.TryGetValue(serviceType, out var service) ? service : null;
+    }
+
+    private class FakeProjectMetadataRepository(ProjectInfo projectInfo) : IProjectMetadataRepository
+    {
+        public Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId, bool ignoreCache = false)
+            => Task.FromResult(projectInfo);
+
+        public Task<JoinRpg.DomainTypes.ProjectMetadata.ProjectDetails> GetProjectDetails(ProjectIdentification projectId)
+            => Task.FromResult(new JoinRpg.DomainTypes.ProjectMetadata.ProjectDetails(new MarkdownString(""), [], false));
+
+        public void PrimeCache(ProjectInfo projectInfo) { }
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -531,6 +531,7 @@ public class AccountController(
     {
         if (projectId is int projectIdValue)
         {
+            ViewBag.ProjectId = projectIdValue;
             var projectInfo = await projectMetadataRepository.GetProjectMetadata(new(projectIdValue));
             return View("ErrorNoAccessToProject", NoAccessToProjectViewModelBuilder.Build(projectInfo));
         }

--- a/src/JoinRpg.Portal/Infrastructure/CaptureNoAccessExceptionFilter.cs
+++ b/src/JoinRpg.Portal/Infrastructure/CaptureNoAccessExceptionFilter.cs
@@ -1,5 +1,6 @@
 using JoinRpg.Data.Interfaces;
 using JoinRpg.Domain;
+using JoinRpg.Portal.Infrastructure.DiscoverFilters;
 using JoinRpg.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -19,19 +20,21 @@ public class CaptureNoAccessExceptionFilter(IProjectMetadataRepository projectMe
                 ViewName = "ErrorNoAccessToProject",
                 ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
             };
+            viewResult.ViewData[Constants.ProjectIdName] = noAccessException.ProjectId.Value;
             var projectInfo = await projectMetadataRepository.GetProjectMetadata(noAccessException.ProjectId);
             viewResult.ViewData.Model = NoAccessToProjectViewModelBuilder.Build(projectInfo, noAccessException.Permission);
             filterContext.Result = viewResult;
         }
 
 
-        if (filterContext.Exception is ProjectDeactivatedException)
+        if (filterContext.Exception is ProjectDeactivatedException projectDeactivatedException)
         {
             var viewResult = new ViewResult()
             {
                 ViewName = "ErrorNotActiveProject",
                 ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
             };
+            viewResult.ViewData[Constants.ProjectIdName] = projectDeactivatedException.ProjectId.Value;
             filterContext.Result = viewResult;
         }
     }


### PR DESCRIPTION
Closes #4659

Rebase and CI fix for #4660: added missing `using` directives (`JoinRpg.Common.PrimitiveTypes`, `JoinRpg.Web.ProjectCommon`) in `CaptureNoAccessExceptionFilterTest.cs` that broke the build.

Co-authored-by: Leonid Tsarev <909808+leotsarev@users.noreply.github.com>

Generated with [Claude Code](https://claude.ai/code)