### PR TITLE
feat: отметка «Нет пароля» в профиле пользователя для администратора

### DIFF
--- a/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
@@ -26,6 +26,12 @@
             {
                 <br /><component type="typeof(PhoneLink)" render-mode="Static" param-Contact="@Model.PhoneNumber" />
             }
+            @if (Model.ViewAsAdmin && !Model.HasPassword)
+            {
+                <br />
+                <span>Нет пароля</span>
+                <join-icon icon="Info" title="У пользователя не задан пароль" />
+            }
             @if (Model.Telegram?.PrettyName is not null)
             {
                 <br /><component type="typeof(TelegramLink)" render-mode="Static" param-Contact="@Model.Telegram" />

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -51,6 +51,7 @@ public class UserProfileDetailsViewModel
     public VkSocialLink? Vk { get; }
     public Email? Email { get; }
     public bool EmailConfirmed { get; }
+    public bool HasPassword { get; }
     [DisplayName("ФИО")]
     public string? FullName { get; }
 
@@ -93,6 +94,7 @@ public class UserProfileDetailsViewModel
         {
             Email = user.Email;
             EmailConfirmed = user.EmailConfirmed;
+            HasPassword = user.HasPassword;
             FullName = user.UserFullName.FullName;
             PhoneNumber = PhoneNumber.FromOptional(user.PhoneNumber);
             IsVerifiedUser = user.VerifiedProfileFlag;


### PR DESCRIPTION
## Что сделано
- В `UserProfileDetailsViewModel` добавлено поле `HasPassword` (из уже существующего `UserInfo.HasPassword`).
- В шаблоне профиля пользователя (`UserProfileDetailsViewModel.cshtml`) администратору показывается отметка «Нет пароля» с иконкой, если у пользователя не задан пароль — по аналогии с существующей отметкой «Email не подтвержден».

Generated with [Claude Code](https://claude.ai/code)