### PR TITLE
fix: унифицировать построение VK/Telegram SocialLink и верификацию

### DIFF
--- a/src/Common/JoinRpg.Common.PrimitiveTypes.Test/TelegramSocialLinkParseTest.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes.Test/TelegramSocialLinkParseTest.cs
@@ -72,4 +72,33 @@ public class TelegramSocialLinkParseTest
         TelegramSocialLink.TryParse(val, provider: null, out var parseResult).ShouldBeTrue();
         parseResult.ShouldBe(version);
     }
+
+    [Fact]
+    public void FromUserData_WithExternalLogin_IsVerified()
+    {
+        var result = TelegramSocialLink.FromUserData("12345", new PrefferedName("leo"));
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(12345);
+        result.IsVerified.ShouldBeTrue();
+        result.PrettyName!.Value.ShouldBe("leo");
+    }
+
+    [Fact]
+    public void FromUserData_WithoutExternalLoginButWithPrettyName_IsNotVerified()
+    {
+        var result = TelegramSocialLink.FromUserData(null, new PrefferedName("leo"));
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBeNull();
+        result.IsVerified.ShouldBeFalse();
+        result.PrettyName!.Value.ShouldBe("leo");
+        result.Link.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void FromUserData_WithoutExternalLoginAndWithoutPrettyName_ReturnsNull()
+    {
+        TelegramSocialLink.FromUserData(null, null).ShouldBeNull();
+    }
 }

--- a/src/Common/JoinRpg.Common.PrimitiveTypes/Users/SocialLink.cs
+++ b/src/Common/JoinRpg.Common.PrimitiveTypes/Users/SocialLink.cs
@@ -9,21 +9,29 @@ namespace JoinRpg.Common.PrimitiveTypes;
 /// </summary>
 public abstract record SocialLink(PrefferedName? PrettyName, bool IsVerified)
 {
-    public abstract long Id { get; }
+    public abstract long? Id { get; }
     public abstract Uri? Link { get; }
 }
 
 public sealed record TelegramSocialLink : SocialLink, ISpanParsable<TelegramSocialLink>
 {
-    public TelegramChatId ChatId { get; }
+    // Нет, если не привязан ExternalLogin (есть только legacy PrettyName из UserExtra.Telegram) —
+    // в этом случае это неверифицированный отображаемый контакт, слать через него сообщения нельзя.
+    public TelegramChatId? ChatId { get; }
 
-    public override long Id => ChatId.Value;
+    public override long? Id => ChatId?.Value;
 
     public override Uri? Link => PrettyName is null ? null : new Uri($"https://t.me/{PrettyName.Value}");
 
-    public TelegramSocialLink(TelegramChatId chatId, PrefferedName? prettyName = null, bool isVerified = false)
+    public TelegramSocialLink(TelegramChatId? chatId, PrefferedName? prettyName = null, bool isVerified = false)
         : base(NormalizeUserName(prettyName), isVerified)
     {
+        var normalizedPrettyName = NormalizeUserName(prettyName);
+        if (chatId is null && normalizedPrettyName is null)
+        {
+            throw new ArgumentException("Нужно указать либо chatId, либо prettyName.", nameof(chatId));
+        }
+
         ChatId = chatId;
     }
 
@@ -32,6 +40,20 @@ public sealed record TelegramSocialLink : SocialLink, ISpanParsable<TelegramSoci
 
     public static TelegramSocialLink? FromOptional(string? key, PrefferedName? userName, bool isVerified = false)
         => string.IsNullOrWhiteSpace(key) ? null : new TelegramSocialLink(new TelegramChatId(long.Parse(key)), userName, isVerified);
+
+    /// <summary>
+    /// Строит из привязанного ExternalLogin (даёт ChatId и верификацию) и/или legacy-поля
+    /// UserExtra.Telegram (даёт PrettyName). Если ExternalLogin отсутствует, а PrettyName есть,
+    /// ссылка всё равно строится (по PrettyName), но верифицированной не считается — отправлять
+    /// сообщения по ней нельзя, только показывать в профиле.
+    /// </summary>
+    public static TelegramSocialLink? FromUserData(string? externalLoginKey, PrefferedName? prettyName)
+    {
+        var hasExternalLogin = long.TryParse(externalLoginKey, out var chatId);
+        return hasExternalLogin || prettyName is not null
+            ? new TelegramSocialLink(hasExternalLogin ? new TelegramChatId(chatId) : null, prettyName, isVerified: hasExternalLogin)
+            : null;
+    }
 
     public static bool TryParse([NotNullWhen(true)] ReadOnlySpan<char> value, IFormatProvider? provider, [MaybeNullWhen(false)] out TelegramSocialLink result)
     {
@@ -73,25 +95,55 @@ public sealed record TelegramSocialLink : SocialLink, ISpanParsable<TelegramSoci
 
     private static PrefferedName? NormalizeUserName(PrefferedName? userName) => userName is null || string.IsNullOrWhiteSpace(userName.Value) ? null : userName;
 
-    public override string ToString() => PrettyName is null ? $"Telegram({Id})" : $"Telegram({Id}, @{PrettyName.Value})";
+    public override string ToString() => (ChatId, PrettyName) switch
+    {
+        (null, _) => $"Telegram(@{PrettyName?.Value})",
+        (_, null) => $"Telegram({Id})",
+        _ => $"Telegram({Id}, @{PrettyName.Value})",
+    };
 }
 
 public sealed record VkSocialLink : SocialLink
 {
-    private readonly long id;
+    private readonly long? id;
 
-    public override long Id => id;
+    public override long? Id => id;
 
-    public override Uri Link => new($"https://vk.com/id{Id}");
+    // Как и у Telegram: если числового id нет, ссылка всё равно строится по PrettyName (slug профиля).
+    public override Uri? Link => id is long numericId
+        ? new Uri($"https://vk.com/id{numericId}")
+        : PrettyName is null ? null : new Uri($"https://vk.com/{PrettyName.Value}");
 
-    public VkSocialLink(long id, PrefferedName? prettyName = null, bool isVerified = false)
+    public VkSocialLink(long? id, PrefferedName? prettyName = null, bool isVerified = false)
         : base(prettyName, isVerified)
     {
+        if (id is null && prettyName is null)
+        {
+            throw new ArgumentException("Нужно указать либо id, либо prettyName.", nameof(id));
+        }
+
         this.id = id;
     }
 
-    /// <summary>Строит из значения колонки UserExtra.Vk (формат "id123456").</summary>
-    public static VkSocialLink? FromOptional(string? vk, bool isVerified = false)
+    /// <summary>
+    /// Строит из привязанного ExternalLogin (приоритетно) или, если его нет, из legacy-поля
+    /// UserExtra.Vk. Легаси-поле обычно хранит числовой id (формат "id123456"), но если это не
+    /// число (старый slug профиля), используем его как PrettyName — ссылка всё равно будет рабочей.
+    /// Верификация (<paramref name="vkVerified"/>) учитывается, только если есть привязанный
+    /// ExternalLogin — легаси-запись без него верифицированной не считается.
+    /// </summary>
+    public static VkSocialLink? FromUserData(string? externalLoginKey, string? legacyVk, bool vkVerified)
+    {
+        var hasExternalLogin = long.TryParse(externalLoginKey, out var externalId);
+        var id = hasExternalLogin ? externalId : ParseLegacyId(legacyVk);
+        var prettyName = id is null ? PrefferedName.FromOptional(legacyVk) : null;
+
+        return id is null && prettyName is null
+            ? null
+            : new VkSocialLink(id, prettyName, isVerified: hasExternalLogin && vkVerified);
+    }
+
+    private static long? ParseLegacyId(string? vk)
     {
         if (string.IsNullOrWhiteSpace(vk))
         {
@@ -99,8 +151,8 @@ public sealed record VkSocialLink : SocialLink
         }
 
         var trimmed = vk.StartsWith("id", StringComparison.OrdinalIgnoreCase) ? vk[2..] : vk;
-        return long.TryParse(trimmed, out var parsedId) ? new VkSocialLink(parsedId, isVerified: isVerified) : null;
+        return long.TryParse(trimmed, out var parsedId) ? parsedId : null;
     }
 
-    public override string ToString() => $"Vk({Id})";
+    public override string ToString() => Id is not null ? $"Vk({Id})" : $"Vk({PrettyName})";
 }

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents.Test/ContactComponentsTest.cs
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents.Test/ContactComponentsTest.cs
@@ -62,11 +62,22 @@ public class ContactComponentsTest
     public void TelegramLink_WithUserName_RendersLink()
     {
         using var ctx = new BunitContext();
-        var contact = new TelegramSocialLink(new TelegramChatId(123456), new PrefferedName("joinrpg"));
+        var contact = new TelegramSocialLink(new TelegramChatId(123456), new PrefferedName("joinrpg"), isVerified: true);
         var cut = ctx.Render<TelegramLink>(p => p.Add(x => x.Contact, contact));
         cut.Markup.ShouldContain("https://t.me/joinrpg");
         cut.Markup.ShouldContain(JoinIconDefinitions.Get(JoinIconType.Telegram).IconName);
         cut.Markup.ShouldContain("white-space: nowrap");
+        cut.Markup.ShouldNotContain(JoinIconDefinitions.Get(JoinIconType.Info).IconName);
+    }
+
+    [Fact]
+    public void TelegramLink_NotVerified_ShowsUnverifiedIcon()
+    {
+        using var ctx = new BunitContext();
+        var contact = new TelegramSocialLink(null, new PrefferedName("joinrpg"), isVerified: false);
+        var cut = ctx.Render<TelegramLink>(p => p.Add(x => x.Contact, contact));
+        cut.Markup.ShouldContain("https://t.me/joinrpg");
+        cut.Markup.ShouldContain(JoinIconDefinitions.Get(JoinIconType.Info).IconName);
     }
 
     [Fact]
@@ -99,9 +110,29 @@ public class ContactComponentsTest
     public void VkLink_WithValue_RendersVkLink()
     {
         using var ctx = new BunitContext();
-        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, new VkSocialLink(123)));
+        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, new VkSocialLink(123, isVerified: true)));
         cut.Markup.ShouldContain("https://vk.com/id123");
         cut.Markup.ShouldContain("ВК:");
         cut.Markup.ShouldContain("white-space: nowrap");
+        cut.Markup.ShouldNotContain(JoinIconDefinitions.Get(JoinIconType.Info).IconName);
+    }
+
+    [Fact]
+    public void VkLink_NotVerified_ShowsUnverifiedIcon()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, new VkSocialLink(123, isVerified: false)));
+        cut.Markup.ShouldContain("https://vk.com/id123");
+        cut.Markup.ShouldContain(JoinIconDefinitions.Get(JoinIconType.Info).IconName);
+    }
+
+    [Fact]
+    public void VkLink_WithIdAndPrettyName_HrefByIdTextByPrettyName()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<VkLink>(p => p.Add(x => x.Contact, new VkSocialLink(123, new PrefferedName("durov"))));
+        cut.Markup.ShouldContain("https://vk.com/id123");
+        cut.Markup.ShouldNotContain("vk.com/durov");
+        cut.Markup.ShouldContain(">durov<");
     }
 }

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents/TelegramLink.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents/TelegramLink.razor
@@ -19,6 +19,10 @@
                 @ChildContent
             }
         </ContactLink>
+        @if (Contact is not null && !Contact.IsVerified)
+        {
+            <JoinIcon Icon="JoinIconType.Info" Title="Telegram не подтвержден" />
+        }
     }
 }
 

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents/VkLink.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents/VkLink.razor
@@ -1,9 +1,16 @@
 @{
-    var effectiveSegment = Link?.Value ?? (Contact is null ? null : $"id{Contact.Id}");
+    // Ссылка — всегда по числовому id, если он есть (он стабилен, в отличие от короткого имени
+    // профиля). А вот отображаемый текст — по PrettyName, если он есть, так он читаемее.
+    var hrefSegment = Link?.Value ?? (Contact is null ? null : Contact.Id is long id ? $"id{id}" : Contact.PrettyName?.Value);
+    var displaySegment = Link?.Value ?? Contact?.PrettyName?.Value ?? hrefSegment;
 }
-@if (effectiveSegment is not null)
+@if (hrefSegment is not null)
 {
-    <ContactLink Prefix="ВК:" Href="@($"https://vk.com/{effectiveSegment}")">@effectiveSegment</ContactLink>
+    <ContactLink Prefix="ВК:" Href="@($"https://vk.com/{hrefSegment}")">@displaySegment</ContactLink>
+    @if (Contact is not null && !Contact.IsVerified)
+    {
+        <JoinIcon Icon="JoinIconType.Info" Title="ВК не подтвержден" />
+    }
 }
 
 @code {

--- a/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
@@ -112,8 +112,8 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
         var results = await userQuery.ToListAsync();
 
         return [.. results.Select(result => {
-             var telegram = TelegramSocialLink.FromOptional(result.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key, new PrefferedName(result.Telegram), isVerified: true);
-             var vk = VkSocialLink.FromOptional(result.Vk, result.VkVerified);
+             var telegram = TelegramSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key, PrefferedName.FromOptional(result.Telegram));
+             var vk = VkSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.VkProvider)?.Key, result.Vk, result.VkVerified);
 
         var userFullName =
             new UserFullName(

--- a/src/JoinRpg.Domain/UserExtensions.cs
+++ b/src/JoinRpg.Domain/UserExtensions.cs
@@ -10,8 +10,8 @@ public static class UserExtensions
     [Obsolete("Это неэффективный метод, если у пользователя не загружены проекты. Лучше грузить UserInfo из репозитория")]
     public static UserInfo GetUserInfo(this User user)
     {
-        var telegram = TelegramSocialLink.FromOptional(user.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key, PrefferedName.FromOptional(user.Extra?.Telegram), isVerified: true);
-        var vk = VkSocialLink.FromOptional(user.Extra?.Vk, user.Extra?.VkVerified ?? false);
+        var telegram = TelegramSocialLink.FromUserData(user.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key, PrefferedName.FromOptional(user.Extra?.Telegram));
+        var vk = VkSocialLink.FromUserData(user.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.VkProvider)?.Key, user.Extra?.Vk, user.Extra?.VkVerified ?? false);
 
         return new UserInfo(
             user.GetId(),

--- a/src/JoinRpg.Services.Notifications/NotificationServiceImpl.cs
+++ b/src/JoinRpg.Services.Notifications/NotificationServiceImpl.cs
@@ -103,9 +103,9 @@ public partial class NotificationServiceImpl(
     private IEnumerable<NotificationAddress> GetChannels(UserInfo user)
     {
         yield return NotificationAddress.Ui();
-        if (user.Social.Telegram is not null)
+        if (user.Social.Telegram?.ChatId is TelegramChatId chatId)
         {
-            yield return new NotificationAddress(user.Social.Telegram.ChatId);
+            yield return new NotificationAddress(chatId);
         }
 
         if (user.Email is not null)

--- a/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
@@ -131,6 +131,27 @@ public class ProjectRoleGridViewModelBuilderTests
     }
 
     [Fact]
+    public void Build_AllMode_TelegramWithoutExternalLoginIsNotVerified()
+    {
+        var character = _mock.CreateCharacter("Вася");
+        _mock.Player.Extra = new UserExtra
+        {
+            Telegram = "vasya_tg",
+            SocialNetworksAccess = ContactsAccessType.OnlyForMasters, // в All — игнорируется
+        };
+        // ExternalLogin не привязан — только legacy-имя из профиля.
+        _mock.CreateApprovedClaim(character, _mock.Player);
+
+        var result = BuildGrid(Config(contacts: ProjectRolesListVisibilityMode.All), [character]);
+
+        var contacts = result.Rows.ShouldHaveSingleItem().ShouldBeOfType<ProjectRoleGridCharacterRowViewModel>()
+            .Player!.Contacts.ShouldNotBeNull();
+        contacts.Telegram.ShouldNotBeNull();
+        contacts.Telegram.PrettyName!.Value.ShouldBe("vasya_tg");
+        contacts.Telegram.IsVerified.ShouldBeFalse();
+    }
+
+    [Fact]
     public void Build_PublicOnly_HidesContactsUnlessPlayerAllowed()
     {
         var character = _mock.CreateCharacter("Вася");

--- a/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
+++ b/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
@@ -269,16 +269,19 @@ internal static class ProjectRoleGridViewModelBuilder
 
         // Telegram строим как канонический TelegramSocialLink (числовой Id из привязанного логина +
         // @username), как в UserExtensions.GetUserInfo. Это переиспользует компонент TelegramLink.
-        var telegram = TelegramSocialLink.FromOptional(
+        var telegram = TelegramSocialLink.FromUserData(
             player.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key,
-            PrefferedName.FromOptional(player.Extra?.Telegram),
-            isVerified: true);
+            PrefferedName.FromOptional(player.Extra?.Telegram));
+
+        var vk = VkSocialLink.FromUserData(
+            player.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.VkProvider)?.Key,
+            player.Extra?.Vk,
+            player.Extra?.VkVerified ?? false);
 
         // Email — непубличный контакт, показывается только в режиме All.
-        // VkVerified не проверяем для решения о показе (как в markdown-рендерере).
         return new UserContacts(
             contactsColumn == ProjectRolesListVisibilityMode.All ? Email.FromOptional(player.Email) : null,
-            VkSocialLink.FromOptional(player.Extra?.Vk, player.Extra?.VkVerified ?? false),
+            vk,
             telegram,
             LiveJournalId.FromOptional(player.Extra?.Livejournal));
     }


### PR DESCRIPTION
## Что сделано

- VK и Telegram теперь строятся единообразно во всех трёх местах (`UserExtensions.GetUserInfo`, `UserInfoRepository`, `ProjectRoleGridViewModelBuilder`):
  - Id всегда берётся из привязанного `ExternalLogin`, если он есть.
  - Если `ExternalLogin` нет — используется legacy-поле `UserExtra` (`Vk`/`Telegram`), но контакт считается **неверифицированным**.
  - `PrettyName` при этом всё равно даёт рабочую ссылку (`vk.com/{slug}`, `t.me/{username}`), даже когда числового id нет — раньше такой контакт терялся целиком.
- `SocialLink.Id` стал `long?`, `TelegramSocialLink.ChatId` — `TelegramChatId?` (нет числового chat id — нет и возможности слать сообщения через бота, только показывать контакт в профиле). Обновлён единственный messaging-потребитель (`NotificationServiceImpl`), чтобы не пытаться слать сообщение при отсутствующем `ChatId`.
- В `VkLink` ссылка (`href`) строится по числовому id (стабильнее), а отображаемый текст — по `PrettyName`, если он есть.
- В `VkLink`/`TelegramLink` добавлена иконка «не подтверждён» (`JoinIconType.Info`) по аналогии с существующей иконкой у email.

## Test plan

- [x] `dotnet build` всего решения
- [x] `dotnet test` для `JoinRpg.Common.PrimitiveTypes.Test`, `JoinRpg.WebPortal.Managers.Test`, `JoinRpg.Domain.Test`, `JoinRpg.Common.WebComponents.Test`, `JoinRpg.Services.Notifications.Tests`
- [x] `dotnet format --verify-no-changes --severity error`

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012aBtfGP2Knr2omfzLX55Jq