### PR TITLE
fix: не дублировать «нет игрока» перед доступной кнопкой «Заявиться»

### DIFF
--- a/src/JoinRpg.Web.CharacterGroups/ProjectRoleGrid/ProjectRoleGridPlayerCell.razor
+++ b/src/JoinRpg.Web.CharacterGroups/ProjectRoleGrid/ProjectRoleGridPlayerCell.razor
@@ -24,8 +24,12 @@ else if (Row.ActiveClaimsCount > 0)
 {
     <text>@ClaimsCountText</text>
 }
-else
+else if (Row.Player.ApplyStatus.BusyStatus is not (CharacterBusyStatusView.Vacancy or CharacterBusyStatusView.HotVacancy))
 {
+    @* TODO: сейчас недостижимо — BusyStatus здесь всегда Vacancy/HotVacancy (нет заявок и
+       нет игрока не даёт других значений), а «приём заявок закрыт» в него не заложен.
+       Ветка заработает, когда ApplyForCharacterButton.IsAvailable и BusyStatus начнут
+       учитывать реальную возможность заявиться (например, project.IsAcceptingClaims). *@
     <text>нет&nbsp;игрока</text>
 }
 @if (Row.Player.Contacts is not null)


### PR DESCRIPTION
## Что сделано
- В сетке ролей (`ProjectRoleGridPlayerCell.razor`) текст «нет игрока» больше не показывается перед кнопкой «Заявиться», если заявиться на роль можно.
- Текст остаётся, если заявиться нельзя (по текущей логике `BusyStatus` это фактически недостижимая ветка — оставлен TODO-комментарий с пояснением, почему, и что нужно доработать, чтобы она заработала: учёт закрытия приёма заявок).

Generated with [Claude Code](https://claude.ai/code)