### PR TITLE
fix: не логировать переполнение слота при одобрении заявки как ошибку

### DIFF
--- a/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
+++ b/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
@@ -1,0 +1,79 @@
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.Domain;
+using JoinRpg.Portal.Controllers.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace JoinRpg.Portal.Test.Controllers.Common;
+
+public class JoinMvcControllerBaseTest
+{
+    // Регрессия: JoinRpgSlotLimitedException (переполнение слота при одобрении заявки мастером —
+    // ожидаемая бизнес-ситуация) должна показываться игроку понятным сообщением и не логироваться
+    // как ошибка, а не проваливаться в default-ветку с LogError и "Неожиданная ошибка".
+    [Fact]
+    public void AddModelException_SlotLimitedException_ShouldAddFriendlyErrorWithoutLoggingError()
+    {
+        var mock = new MockedProject();
+        var logger = new RecordingLogger();
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContext(logger),
+            },
+        };
+
+        controller.CallAddModelException(new JoinRpgSlotLimitedException(mock.Character));
+
+        controller.ModelState.IsValid.ShouldBeFalse();
+        var error = controller.ModelState[""]!.Errors.ShouldHaveSingleItem();
+        error.ErrorMessage.ShouldBe("Не удалось принять заявку: свободные места на эту роль закончились");
+        logger.ErrorCount.ShouldBe(0);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(ILogger<JoinMvcControllerBase> logger)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = new TestServiceProvider().WithService(logger),
+        };
+        return httpContext;
+    }
+
+    private sealed class TestController : JoinMvcControllerBase
+    {
+        public void CallAddModelException(Exception exception) => AddModelException(exception);
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        private readonly Dictionary<Type, object> services = new();
+
+        public TestServiceProvider WithService<T>(T service) where T : notnull
+        {
+            services[typeof(T)] = service;
+            return this;
+        }
+
+        public object? GetService(Type serviceType) => services.TryGetValue(serviceType, out var service) ? service : null;
+    }
+
+    private sealed class RecordingLogger : ILogger<JoinMvcControllerBase>
+    {
+        public int ErrorCount { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Error)
+            {
+                ErrorCount++;
+            }
+        }
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
+++ b/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
@@ -67,6 +67,9 @@ public abstract class JoinMvcControllerBase : Controller
             case JoinFieldScheduleShouldBeUniqueException _:
                 ModelState.AddModelError("", "Невозможно добавить второе поле с настройками расписания");
                 return;
+            case JoinRpgSlotLimitedException _:
+                ModelState.AddModelError("", "Не удалось принять заявку: свободные места на эту роль закончились");
+                return;
             default:
 
                 logger.LogError(exception, "Исключение при обработке запроса");


### PR DESCRIPTION
## Проблема

В логах появляются ERROR вида «JoinRpgSlotLimitedException (Couldn't add more characters because slot is full)» при одобрении заявки мастером — при этом это ожидаемая бизнес-ситуация: несколько заявок подано на многослотовую роль, и к моменту одобрения очередной заявки места на неё уже закончились (их заняли другие одобренные заявки).

Причина: `JoinMvcControllerBase.AddModelException` не знал про `JoinRpgSlotLimitedException` и такое исключение попадало в `default`-ветку — логировалось через `LogError` и показывало мастеру «Неожиданная ошибка, обратитесь в техподдержку» вместо понятного сообщения. Это, в частности, объясняет повторные попытки одобрить заявку одним и тем же мастером: он видел «неожиданную ошибку» и логично пробовал снова, вместо того чтобы понять, что слот заполнен.

## Что сделано

- `JoinRpgSlotLimitedException` добавлен в список известных бизнес-исключений в `AddModelException`, показывается понятным сообщением «Не удалось принять заявку: свободные места на эту роль закончились», без логирования как ошибки.
- Добавлен юнит-тест, воспроизводящий баг (ошибочный ERROR-лог и общее сообщение) и проверяющий фикс.

## Test plan

- [x] `dotnet build` без новых ошибок
- [x] Новый тест `JoinMvcControllerBaseTest` проходит