### PR TITLE
fix: не переносить значения полей старого персонажа при перемещении и принятии заявки

### DIFF
--- a/src/JoinRpg.Domain.Test/FieldSaveHelperTest.cs
+++ b/src/JoinRpg.Domain.Test/FieldSaveHelperTest.cs
@@ -2,6 +2,7 @@ using JoinRpg.DataModel;
 using JoinRpg.DataModel.Mocks;
 using JoinRpg.Domain.CharacterFields;
 using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
 using Xunit.Abstractions;
 
 namespace JoinRpg.Domain.Test;
@@ -177,6 +178,49 @@ public class FieldSaveHelperTest
         // master-only значение персонажа не должно утечь в JSON заявки (PublicOnly унаследованного слоя сохранён)
         claim.JsonData.ShouldNotContain("master-secret");
         claim.JsonData.ShouldContain("player-value");
+    }
+
+    [Fact]
+    public void MovedClaimApprovalShouldNotLeakOldCharacterFieldValueIntoNewCharacter()
+    {
+        // Регрессия: подали заявку на персонажа A (у него уже стоит значение поля) -> переместили
+        // заявку на персонажа B -> приняли заявку. До фикса значение поля персонажа A (в т.ч.
+        // "специальных" полей имени/описания, см. CharacterExistsStrategyBase.SetCharacterDescription)
+        // утекало в Claim.JsonData при подаче заявки и затем перезаписывало персонажа B при принятии.
+        _original = new MockedProject();
+        var mock = new MockedProject();
+
+        // Поле должно быть публичным (как обычно настроены "специальные" поля имени/описания персонажа),
+        // иначе PublicOnly()-фильтр CharacterLayer в SaveToClaimOnlyStrategy отсечёт его ещё до бага.
+        MockedProject.AssignFieldValues(mock.Character, new FieldWithValue(mock.PublicFieldInfo, "OldCharacterValue"));
+
+        var claim = mock.CreateClaim(mock.Character, mock.Player);
+
+        // Игрок подаёт заявку, не трогая это поле явно
+        _ = InitFieldSaveHelper().SaveCharacterFields(
+            mock.Player.UserId,
+            claim,
+            new Dictionary<int, string?>(),
+            mock.ProjectInfo);
+
+        var characterB = mock.CreateCharacter("CharacterB");
+
+        // Мастер перемещает заявку на другого персонажа (JoinRpg.Services.Impl.Claims.ClaimServiceImpl.MoveByMaster
+        // меняет только claim.Character/CharacterId, Claim.JsonData не трогает)
+        claim.Character = characterB;
+        claim.CharacterId = characterB.CharacterId;
+
+        claim.ClaimStatus = ClaimStatus.Approved;
+        characterB.ApprovedClaim = claim;
+        characterB.ApprovedClaimId = claim.ClaimId;
+
+        _ = InitFieldSaveHelper().SaveCharacterFields(
+            mock.Player.UserId,
+            claim,
+            new Dictionary<int, string?>(),
+            mock.ProjectInfo);
+
+        characterB.JsonData.ShouldNotContain("OldCharacterValue");
     }
 
     [Fact]

--- a/src/JoinRpg.Domain/CharacterFields/SaveToClaimOnlyStrategy.cs
+++ b/src/JoinRpg.Domain/CharacterFields/SaveToClaimOnlyStrategy.cs
@@ -21,8 +21,14 @@ internal class SaveToClaimOnlyStrategy(Claim claim,
 
     protected override void SerializeFields(Dictionary<int, FieldWithValue> fields)
     {
-        //TODO do not save fields that have values same as character's
-        Claim.JsonData = fields.Values.SerializeFields();
+        // Character-bound поля, унаследованные от текущего персонажа (не введённые игроком в этой заявке),
+        // не должны попадать в Claim.JsonData: иначе при последующем перемещении заявки на другого персонажа
+        // и её принятии эти значения перезапишут поля нового персонажа.
+        var fieldsToSave = fields.Values.Where(f =>
+            f.Field.BoundTo == FieldBoundTo.Claim ||
+            CharacterFieldLayers.CharacterLayer.LayerData.GetValueOrDefault(f.Field.Id)?.Value != f.Value);
+
+        Claim.JsonData = fieldsToSave.SerializeFields();
     }
 
     protected override void SetCharacterNameFromPlayer()


### PR DESCRIPTION
## Проблема

После перемещения заявки на другого персонажа и её принятия у нового персонажа менялись имя и описание на имя/описание персонажа, с которого заявку переместили.

Воспроизведение:
1. Игрок подаёт заявку на персонажа A.
2. Заявку перемещают на персонажа B (на этом шаге всё ещё корректно).
3. Заявку принимают — у персонажа B имя/описание становятся такими же, как у персонажа A.

Если сначала принять заявку, а потом переместить — баг не проявляется.

## Причина

`SaveToClaimOnlyStrategy.SerializeFields` при сохранении неподтверждённой заявки сериализовал в `Claim.JsonData` **все** поля из объединённого слоя (заявка + персонаж), включая character-bound значения, унаследованные от текущего персонажа, а не введённые игроком (был помечен `//TODO do not save fields that have values same as character's`).

Последовательность:
1. При подаче заявки на персонажа A в `Claim.JsonData` незаметно оседают значения его полей (в т.ч. имени/описания — они реализованы как «специальные» character-bound поля).
2. `MoveByMaster` меняет только `CharacterId`, `Claim.JsonData` не трогает — персонаж B пока не задет.
3. При принятии заявки (`SaveToCharacterAndClaimStrategy`) слой заявки перекрывает слой персонажа B, и унаследованные от A значения переносятся в `Character.JsonData` персонажа B, а `CharacterExistsStrategyBase.SetCharacterDescription` перезаписывает его `CharacterName`/`Description`.

## Фикс

`SaveToClaimOnlyStrategy.SerializeFields` теперь не сохраняет в `Claim.JsonData` character-bound поля, значение которых совпадает со значением из слоя персонажа (т.е. не были явно изменены в рамках этого сохранения).

## Тест

Добавлен регрессионный тест `FieldSaveHelperTest.MovedClaimApprovalShouldNotLeakOldCharacterFieldValueIntoNewCharacter`, воспроизводящий сценарий: подача → перемещение → принятие → проверка, что значение поля старого персонажа не попало в нового. Проверено, что без фикса тест падает.

Generated with [Claude Code](https://claude.ai/code)