### PR TITLE
fix: заменить DateTime.Add(TimeSpan) на DbFunctions.DiffDays в KogdaIgraMissingGamesPredicate

### DIFF
--- a/src/JoinRpg.Dal.Impl.Tests/KogdaIgraMissingGamesPredicateTest.cs
+++ b/src/JoinRpg.Dal.Impl.Tests/KogdaIgraMissingGamesPredicateTest.cs
@@ -1,3 +1,5 @@
+using System.Data.Entity;
+using System.Linq.Expressions;
 using JoinRpg.Dal.Impl.Repositories;
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Projects;
@@ -44,8 +46,32 @@ public class KogdaIgraMissingGamesPredicateTest
             KogdaIgraGames = [.. (games ?? [])],
         };
 
+    // GetPredicate() использует DbFunctions.DiffDays — канонические DbFunctions умеют
+    // транслироваться EF6 в SQL, но при прямом вызове вне LINQ to Entities кидают
+    // NotSupportedException. Для юнит-тестов подменяем такой вызов эквивалентной
+    // арифметикой на чистых DateTime, чтобы можно было Compile() и выполнить in-memory.
     private static bool TestPredicate(Project project, DateTime lastUpdated)
-        => KogdaIgraMissingGamesPredicate.GetPredicate(Now).Compile()(project, lastUpdated);
+    {
+        var predicate = (Expression<Func<Project, DateTime, bool>>)new DbFunctionsDiffDaysRewriter()
+            .Visit(KogdaIgraMissingGamesPredicate.GetPredicate(Now));
+        return predicate.Compile()(project, lastUpdated);
+    }
+
+    private sealed class DbFunctionsDiffDaysRewriter : ExpressionVisitor
+    {
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType == typeof(DbFunctions) && node.Method.Name == nameof(DbFunctions.DiffDays))
+            {
+                var start = Expression.Convert(Visit(node.Arguments[0]), typeof(DateTime));
+                var end = Expression.Convert(Visit(node.Arguments[1]), typeof(DateTime));
+                var totalDays = Expression.Property(Expression.Subtract(end, start), nameof(TimeSpan.TotalDays));
+                return Expression.Convert(Expression.Convert(totalDays, typeof(int)), typeof(int?));
+            }
+
+            return base.VisitMethodCall(node);
+        }
+    }
 
     // --- Нет привязок ---
 

--- a/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraMissingGamesPredicate.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/KogdaIgraMissingGamesPredicate.cs
@@ -16,12 +16,14 @@ internal static class KogdaIgraMissingGamesPredicate
     /// </summary>
     public static Expression<Func<Project, DateTime, bool>> GetPredicate(DateTime now)
     {
-        var gap = TimeSpan.FromDays(60);
+        const int gapDays = 60;
         return (project, lastUpdated) =>
             project.Active &&
             !project.Details.DisableKogdaIgraMapping &&
             !project.KogdaIgraGames.Any(g => g.Active && (g.End == null || g.End >= now)) &&
             (!project.KogdaIgraGames.Any(g => g.Active)
-                || lastUpdated > project.KogdaIgraGames.Where(g => g.Active).Max(g => g.End!.Value).Add(gap));
+                // EF6 не умеет транслировать в SQL ни DateTime.Add(TimeSpan)/AddDays, ни арифметику
+                // над DateTime (+ TimeSpan, .Ticks) — только канонические DbFunctions.
+                || DbFunctions.DiffDays(project.KogdaIgraGames.Where(g => g.Active).Max(g => g.End!.Value), lastUpdated) > gapDays);
     }
 }

--- a/src/JoinRpg.IntegrationTests/Scenarios/KogdaIgraMissingGamesScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/KogdaIgraMissingGamesScenario.cs
@@ -1,0 +1,81 @@
+using System.Data.Entity;
+using System.Net;
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Dal.Impl;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Projects;
+using JoinRpg.DomainTypes;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+using JoinRpg.Web.AdminTools;
+using JoinRpg.Web.ProjectCommon.Projects;
+
+namespace JoinRpg.IntegrationTest.Scenarios;
+
+public class KogdaIgraMissingGamesScenario(JoinApplicationFactory factory) : IClassFixture<JoinApplicationFactory>
+{
+    // Регрессия: EF6 не умел транслировать DateTime.Add(TimeSpan) в SQL и падал
+    // System.NotSupportedException на реальном запросе GetProjectsForAdmin(ActiveWithoutKogdaIgra),
+    // когда у проекта была активная привязка к КогдаИгра, закончившаяся давно.
+    [Fact]
+    public async Task GetProjectsForAdmin_ActiveWithoutKogdaIgra_ProjectWithLongEndedActiveGame_ShouldAppearInList()
+    {
+        const string adminEmail = "admin-ki@example.com";
+        const string password = "Password123!";
+
+        UserIdentification adminId;
+        ProjectIdentification projectId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            (adminId, _) = await TestUserProjectHelpers.CreateTestUserWithEmailAsync(
+                scope.ServiceProvider, adminEmail, password);
+
+            var myDb = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            var dbAdmin = myDb.Set<JoinRpg.DataModel.User>().Include("Auth").Single(u => u.Email == adminEmail);
+            dbAdmin.Auth.IsAdmin = true;
+            await myDb.SaveChangesAsync();
+
+            projectId = await TestUserProjectHelpers.CreateProjectAsync(
+                scope.ServiceProvider, adminId, "Проект-сериал с давно закончившейся игрой");
+        }
+
+        // Активная привязка к КогдаИгра, закончившаяся 90 дней назад — как раз тот случай,
+        // на котором предикат вызывал DateTime.Add(TimeSpan) при трансляции в SQL.
+        using (var scope = factory.Services.CreateScope())
+        {
+            var myDb = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            var project = await myDb.Set<Project>()
+                .Include(p => p.KogdaIgraGames)
+                .Include(p => p.Details)
+                .SingleAsync(p => p.ProjectId == projectId.Value);
+
+            // Тестовый проект создаётся с ShouldNotBeOnKogdaIgra — снимаем флаг,
+            // иначе предикат исключит проект независимо от игр.
+            project.Details.DisableKogdaIgraMapping = false;
+
+            project.KogdaIgraGames.Add(new KogdaIgraGame
+            {
+                KogdaIgraGameId = projectId.Value + 1_000_000,
+                Name = "Тестовая игра КогдаИгра",
+                JsonGameData = "{}",
+                Active = true,
+                End = DateTime.UtcNow.AddDays(-90),
+                UpdateRequestedAt = DateTimeOffset.UtcNow,
+                LastUpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await myDb.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClient();
+        client = await TestUserProjectHelpers.CreateAuthenticatedClientAsync(client, adminEmail, password);
+
+        var response = await client.GetAsync(
+            $"webapi/projects/GetProjectsForAdmin?criteria={ProjectSelectionCriteria.ActiveWithoutKogdaIgra}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ProjectAdminListItemViewModel>>();
+        projects.ShouldNotBeNull();
+        projects.ShouldContain(p => p.ProjectId.Value == projectId.Value);
+    }
+}


### PR DESCRIPTION
## Проблема

`GET /webapi/projects/GetProjectsForAdmin?criteria=ActiveWithoutKogdaIgra` падал с

```
System.NotSupportedException: LINQ to Entities does not recognize the method 'System.DateTime Add(System.TimeSpan)'
```

Источник — `KogdaIgraMissingGamesPredicate.GetPredicate()` (попал в релиз вчера, #4131): `DateTime.Add(TimeSpan)` не транслируется EF6 в SQL.

## Что сделано

- `DateTime.Add(TimeSpan)` заменён на `DbFunctions.DiffDays` — единственный вариант из проверенных (`.Add`, `.AddDays`, оператор `+`, `.Ticks`), который EF6 реально транслирует в SQL для этого случая (остальные тоже падают, только с другими исключениями — `NotSupportedException` или `ArgumentException: DbArithmeticExpression arguments must have a numeric common type`).
- Добавлен интеграционный тест (`KogdaIgraMissingGamesScenario`), который поднимает реальный SQL Server (Testcontainers) и бьёт по настоящему эндпоинту через `JoinApplicationFactory` — воспроизводит регрессию на старом коде (500) и проходит на исправленном. Юнит-тесты предиката такую регрессию не ловили, так как гоняют `Expression.Compile()` напрямую, минуя трансляцию в SQL.
- Юнит-тесты `KogdaIgraMissingGamesPredicateTest` адаптированы: `DbFunctions.DiffDays` кидает исключение при вызове вне LINQ to Entities, поэтому для `Compile()`-тестов такой вызов подменяется эквивалентной арифметикой через `ExpressionVisitor`.

## Test plan

- [x] `dotnet test src/JoinRpg.Dal.Impl.Tests --filter KogdaIgraMissingGamesPredicateTest` — 21/21
- [x] `dotnet test src/JoinRpg.IntegrationTests --filter KogdaIgraMissingGamesScenario` — падает на старом коде (500), проходит на новом
- [x] `dotnet test src/JoinRpg.IntegrationTests` — полный прогон, 156/156

Generated with [Claude Code](https://claude.com/claude-code)