### PR TITLE
fix: убрать лишние lazy load User при построении списка заявок

### DIFF
--- a/src/JoinRpg.WebPortal.Models.Test/ClaimListBuilderTest.cs
+++ b/src/JoinRpg.WebPortal.Models.Test/ClaimListBuilderTest.cs
@@ -1,0 +1,24 @@
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.Web.Models.ClaimList;
+
+namespace JoinRpg.WebPortal.Models.Test;
+
+public class ClaimListBuilderTest
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    // Регрессия для #4670: GetLastComment раньше вызывал User.GetUserInfo(), который
+    // обращается к user.Auth без null-conditional. В реальном приложении это оборачивалось
+    // в лишний lazy load почти на каждую заявку в списке; в этом тесте (без EF-контекста)
+    // непрогруженный Auth равен null и вызов падает с NullReferenceException.
+    [Fact]
+    public void GetLastCommentDoesNotTouchUnloadedNavigationProperties()
+    {
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+
+        var result = ClaimListBuilder.GetLastComment(claim, AccessArguments.None);
+
+        result.By.UserId.Value.ShouldBe(Mock.Player.UserId);
+    }
+}

--- a/src/JoinRpg.WebPortal.Models/ClaimList/ClaimListBuilder.cs
+++ b/src/JoinRpg.WebPortal.Models/ClaimList/ClaimListBuilder.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes.Users;
 using JoinRpg.Common.WebComponents;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
@@ -82,7 +83,7 @@ public static class ClaimListBuilder
             );
     }
 
-    public static (DateTime At, UserInfo By) GetLastComment(Claim claim, AccessArguments accessArguments)
+    public static (DateTime At, UserInfoHeader By) GetLastComment(Claim claim, AccessArguments accessArguments)
     {
         var lastComment = (At: claim.CreateDate, By: claim.Player);
 
@@ -101,7 +102,7 @@ public static class ClaimListBuilder
             lastComment = (At: claim.LastMasterCommentAt.Value.DateTime, By: claim.LastMasterCommentBy!);
         }
 
-        return (lastComment.At, lastComment.By.GetUserInfo());
+        return (lastComment.At, lastComment.By.ToUserInfoHeader());
     }
 
     public static DateTime GetLastCommentTime(Claim claim, AccessArguments accessArguments)


### PR DESCRIPTION
## Что сделано
- `ClaimListBuilder.GetLastComment` вызывал устаревший `User.GetUserInfo()`, который обращается к `ProjectAcls`, `Claims`, `Auth`, `Allrpg`, `ExternalLogins`, `Extra`. Запрос списка заявок грузит только `Player.Extra` через `Include`, поэтому каждое обращение к остальным навигациям превращалось в отдельный lazy-load SQL — умноженный на число заявок в списке (см. мониторинг в issue).
- Заменил на `ToUserInfoHeader()`, которому достаточно уже загруженных скалярных полей.
- Добавлен регрессионный тест `ClaimListBuilderTest`, воспроизводящий баг: без EF-контекста непрогруженный `User.Auth` равен `null`, старый код падал с `NullReferenceException`.

Closes #4670

Generated with [Claude Code](https://claude.ai/code)