### PR TITLE
refactor: заменить User на UserInfo в мастер-балансе финансов

### DIFF
--- a/src/JoinRpg.Domain/FinanceExtensions.cs
+++ b/src/JoinRpg.Domain/FinanceExtensions.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.DomainTypes.Characters;
@@ -206,15 +207,15 @@ public static class FinanceExtensions
 
     public static IEnumerable<MoneyTransfer> SendedByMaster(
         this IEnumerable<MoneyTransfer> transfers,
-        User master) => transfers.Where(mt => mt.SenderId == master.UserId);
+        UserIdentification masterId) => transfers.Where(mt => mt.SenderId == masterId.Value);
 
     public static IEnumerable<MoneyTransfer> ReceivedByMaster(
         this IEnumerable<MoneyTransfer> transfers,
-        User master) => transfers.Where(mt => mt.ReceiverId == master.UserId);
+        UserIdentification masterId) => transfers.Where(mt => mt.ReceiverId == masterId.Value);
 
     public static int SendedByMasterSum(this IReadOnlyCollection<MoneyTransfer> transfers,
-        User master) => transfers.Approved().SendedByMaster(master).Sum(mt => -mt.Amount);
+        UserIdentification masterId) => transfers.Approved().SendedByMaster(masterId).Sum(mt => -mt.Amount);
 
     public static int ReceivedByMasterSum(this IReadOnlyCollection<MoneyTransfer> transfers,
-        User master) => transfers.Approved().ReceivedByMaster(master).Sum(mt => mt.Amount);
+        UserIdentification masterId) => transfers.Approved().ReceivedByMaster(masterId).Sum(mt => mt.Amount);
 }

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.DomainTypes.ProjectMetadata.Payments;
@@ -90,12 +91,17 @@ public class FinancesController(
             .Select(pt => new PaymentTypeSummaryViewModel(pt, project.FinanceOperations))
             .Where(m => m.Total != 0).OrderByDescending(m => m.Total).ToArray();
 
+        var operations = project.FinanceOperations.ToArray();
+        var masterIds = MasterBalanceBuilder.GetMasterIds(operations, transfers);
+        var masters = await UserRepository.GetRequiredUserInfos(masterIds);
+
         var viewModel = new MoneyInfoTotalViewModel(projectInfo,
             transfers,
             uriService,
-            project.FinanceOperations.ToArray(),
+            operations,
             payments,
-            currentUserAccessor);
+            currentUserAccessor,
+            masters);
 
         return View(viewModel);
     }
@@ -255,8 +261,11 @@ public class FinancesController(
 
         var masterTransfers = await financeReportRepository.GetAllMoneyTransfers(projectId);
 
+        var masterIds = MasterBalanceBuilder.GetMasterIds(masterOperations, masterTransfers);
+        var masters = await UserRepository.GetRequiredUserInfos(masterIds);
+
         var summary =
-            MasterBalanceBuilder.ToMasterBalanceViewModels(masterOperations, masterTransfers, projectId);
+            MasterBalanceBuilder.ToMasterBalanceViewModels(masters, masterOperations, masterTransfers, projectId);
 
         var generator = exportDataService.GetGenerator(ExportType.Csv, summary,
     new MoneySummaryByMasterExporter(uriService));
@@ -295,7 +304,7 @@ public class FinancesController(
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
         var transfers =
             await financeReportRepository.GetMoneyTransfersForMaster(projectId, masterId);
-        var user = await UserRepository.GetById(masterId);
+        var user = await UserRepository.GetRequiredUserInfo(new UserIdentification(masterId));
 
         var operations = project.FinanceOperations
             .Where(fo => fo.State == FinanceOperationState.Approved)

--- a/src/JoinRpg.Portal/Views/Finances/_MasterBalance.cshtml
+++ b/src/JoinRpg.Portal/Views/Finances/_MasterBalance.cshtml
@@ -30,7 +30,7 @@
             @Html.DisplayFor(modelItem => item.Master)
             @if (ViewBag.ShowLinks == true)
             {
-                @Html.ActionLink("(подробнее)", "ByMaster", new {item.ProjectId, MasterId = item.Master.UserId})
+                @Html.ActionLink("(подробнее)", "ByMaster", new {item.ProjectId, MasterId = item.Master.UserId.Value})
             }
         </td>
         <td>

--- a/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserInfo.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserInfo.cshtml
@@ -1,0 +1,11 @@
+@using JoinRpg.Common.WebComponents
+@model JoinRpg.DomainTypes.Users.UserInfo
+@if (Model == null)
+{
+    <span>нет</span>
+    return;
+}
+<component
+  type="typeof(UserLink)"
+  render-mode="Static"
+  param-Model="@(new UserLinkViewModel(Model.UserId.Value, Model.DisplayName.DisplayName, ViewMode.Show))" />

--- a/src/JoinRpg.WebPortal.Models.Test/MoneySummaryByMasterExporterTest.cs
+++ b/src/JoinRpg.WebPortal.Models.Test/MoneySummaryByMasterExporterTest.cs
@@ -1,0 +1,72 @@
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Finances;
+using JoinRpg.DomainTypes.Interfaces;
+using JoinRpg.DomainTypes.Users;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.Web.Models.Exporters;
+
+namespace JoinRpg.WebPortal.Models.Test;
+
+// Регрессия на переход MasterBalanceViewModel.Master с User (EF-сущность) на UserInfo:
+// ComplexElementMemberColumn собирает Expression через несколько .Compile() (см. CombineGetters),
+// поэтому ошибка в выражении не всплывёт при dotnet build — только в рантайме на ExtractValue.
+public class MoneySummaryByMasterExporterTest
+{
+    private sealed class StubUriService : IUriService
+    {
+        public string Get(ILinkable link) => "/stub";
+        public Uri GetUri(ILinkable link) => new("/stub", UriKind.Relative);
+    }
+
+    private static UserInfo BuildUserInfo(TelegramSocialLink? telegram, string? phoneNumber)
+        => new UserInfo(
+            UserId: new UserIdentification(1),
+            Social: new UserSocialNetworks(telegram, null, null, null, ContactsAccessType.OnlyForMasters),
+            ActiveClaims: [],
+            ActiveProjects: [],
+            AllProjects: [],
+            IsAdmin: false,
+            SelectedAvatarId: null,
+            Email: new Email("master@example.com"),
+            EmailConfirmed: true,
+            UserFullName: new UserFullName(null, BornName.FromOptional("Иван"), SurName.FromOptional("Иванов"), null),
+            VerifiedProfileFlag: false,
+            PhoneNumber: phoneNumber,
+            HasPassword: false);
+
+    private static MasterBalanceViewModel BuildBalance(UserInfo master)
+        => new MasterBalanceViewModel(master, projectId: 1,
+            masterOperations: Array.Empty<FinanceOperation>(),
+            masterTransfers: Array.Empty<MoneyTransfer>());
+
+    private static Dictionary<string, object?> ExtractRow(MasterBalanceViewModel row)
+    {
+        var exporter = new MoneySummaryByMasterExporter(new StubUriService());
+        return exporter.ParseColumns().ToDictionary(c => c.Name ?? "", c => c.ExtractValue(row));
+    }
+
+    [Fact]
+    public void ExtractsMasterColumns_WhenTelegramPresent()
+    {
+        var master = BuildUserInfo(
+            telegram: new TelegramSocialLink(new TelegramChatId(123), new PrefferedName("ivan")),
+            phoneNumber: "+79001234567");
+
+        var values = ExtractRow(BuildBalance(master));
+
+        values["Мастер.Email"].ShouldBe(master.Email);
+        values["Телефон"].ShouldBe("+79001234567");
+        values["Telegram"].ShouldBe(master.Social.Telegram!.ToString());
+    }
+
+    [Fact]
+    public void ExtractsMasterColumns_WhenTelegramAbsent()
+    {
+        var master = BuildUserInfo(telegram: null, phoneNumber: null);
+
+        var values = ExtractRow(BuildBalance(master));
+
+        values["Телефон"].ShouldBeNull();
+        values["Telegram"].ShouldBeNull();
+    }
+}

--- a/src/JoinRpg.WebPortal.Models/Exporters/CustomExporter.cs
+++ b/src/JoinRpg.WebPortal.Models/Exporters/CustomExporter.cs
@@ -6,6 +6,7 @@ using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Interfaces;
+using JoinRpg.DomainTypes.Users;
 using JoinRpg.Helpers;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.UserProfile;
@@ -136,6 +137,9 @@ public abstract class CustomExporter<TRow>(IUriService uriService) : IGeneratorF
 
     [Pure]
     protected ITableColumn ShortUserColumn(Expression<Func<TRow, UserLinkViewModel?>> func, string? name = null) => ComplexElementMemberColumn(func, u => u.DisplayName, name);
+
+    [Pure]
+    protected ITableColumn ShortUserColumn(Expression<Func<TRow, UserInfo?>> func, string? name = null) => ComplexElementMemberColumn(func, u => u.DisplayName.DisplayName, name);
 
     [Pure]
     protected ITableColumn VkColumn(Expression<Func<TRow, User?>> func) => new TableColumn<Uri>("ВК", user => UserSocialLink.GetVKUri(func.Compile()(user)?.Extra?.Vk)?.Uri);

--- a/src/JoinRpg.WebPortal.Models/Exporters/MoneySummaryByMasterExporter.cs
+++ b/src/JoinRpg.WebPortal.Models/Exporters/MoneySummaryByMasterExporter.cs
@@ -9,11 +9,9 @@ public class MoneySummaryByMasterExporter(IUriService uriService) : CustomExport
         // Порядок полей тут важен, так как гуглдоки у людей опираются скорее всего на порядок колонок
         yield return ShortUserColumn(x => x.Master, "Мастер");
         yield return ComplexElementMemberColumn(x => x.Master, x => x.Email);
-        yield return ComplexElementMemberColumn(x => x.Master,
-            x => x.Extra,
-            x => x.PhoneNumber,
-            "Телефон");
-        yield return ComplexElementMemberColumn(x => x.Master, x => x.Extra, x => x.Telegram, "Telegram");
+        yield return ComplexElementMemberColumn(x => x.Master, x => x.PhoneNumber, "Телефон");
+        yield return ComplexElementMemberColumn(x => x.Master, x => x.Social,
+            s => s.Telegram == null ? null : s.Telegram.ToString(), "Telegram");
         // Выше должно быть ровно 4 поля с какими-то данными профиля мастера
         yield return IntColumn(x => x.Total);
         yield return IntColumn(x => x.ReceiveBalance);

--- a/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
@@ -2,6 +2,7 @@ using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.DomainTypes.Users;
+using JoinRpg.Helpers;
 
 namespace JoinRpg.Web.Models;
 
@@ -10,9 +11,9 @@ public static class MasterBalanceBuilder
     public static IReadOnlyCollection<UserIdentification> GetMasterIds(
         IReadOnlyCollection<FinanceOperation> masterOperations,
         IReadOnlyCollection<MoneyTransfer> masterTransfers)
-        => masterOperations.Select(fo => fo.PaymentType?.UserId)
-            .Where(userId => userId != null)
-            .Select(userId => userId!.Value)
+        => masterOperations.Select(fo => fo.PaymentType)
+            .WhereNotNull()
+            .Select(pt => pt.UserId)
             .Concat(masterTransfers.Select(mt => mt.ReceiverId))
             .Concat(masterTransfers.Select(mt => mt.SenderId))
             .Distinct()

--- a/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
@@ -1,28 +1,34 @@
+using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
-using JoinRpg.Domain;
-using JoinRpg.Helpers;
+using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Web.Models;
 
 public static class MasterBalanceBuilder
 {
+    public static IReadOnlyCollection<UserIdentification> GetMasterIds(
+        IReadOnlyCollection<FinanceOperation> masterOperations,
+        IReadOnlyCollection<MoneyTransfer> masterTransfers)
+        => masterOperations.Select(fo => fo.PaymentType?.UserId)
+            .Where(userId => userId != null)
+            .Select(userId => userId!.Value)
+            .Concat(masterTransfers.Select(mt => mt.ReceiverId))
+            .Concat(masterTransfers.Select(mt => mt.SenderId))
+            .Distinct()
+            .Select(userId => new UserIdentification(userId))
+            .ToArray();
+
     public static IReadOnlyCollection<MasterBalanceViewModel> ToMasterBalanceViewModels(
+        IReadOnlyCollection<UserInfo> masters,
         IReadOnlyCollection<FinanceOperation> masterOperations,
         IReadOnlyCollection<MoneyTransfer> masterTransfers,
         int projectId)
     {
-        var masters = masterOperations.Select(fo => fo.PaymentType?.User)
-            .WhereNotNull()
-            .Union(masterTransfers.Select(mt => mt.Receiver))
-            .Union(masterTransfers.Select(mt => mt.Sender))
-            .DistinctBy(master => master.UserId);
-
-
         var summary = masters.Select(master =>
                 new MasterBalanceViewModel(master, projectId, masterOperations, masterTransfers))
             .Where(fr => fr.AnythingEverHappens())
-            .OrderBy(fr => fr.Master.GetDisplayName());
+            .OrderBy(fr => fr.Master.DisplayName.DisplayName);
         return summary.ToArray();
     }
 }

--- a/src/JoinRpg.WebPortal.Models/Money/MasterBalanceViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MasterBalanceViewModel.cs
@@ -1,13 +1,14 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Web.Models;
 
 public class MasterBalanceViewModel
 {
     [Display(Name = "Мастер")]
-    public User Master { get; }
+    public UserInfo Master { get; }
 
     [Display(Name = "Денег на руках")]
     public int Total { get; }
@@ -27,7 +28,7 @@ public class MasterBalanceViewModel
     public int ProjectId { get; }
 
     public MasterBalanceViewModel(
-        User master,
+        UserInfo master,
         int projectId,
         IReadOnlyCollection<FinanceOperation> masterOperations,
         IReadOnlyCollection<MoneyTransfer> masterTransfers)
@@ -38,16 +39,16 @@ public class MasterBalanceViewModel
 
         Master = master;
         ProjectId = projectId;
-        ReceiveBalance = masterTransfers.ReceivedByMasterSum(master);
-        SendBalance = masterTransfers.SendedByMasterSum(master);
+        ReceiveBalance = masterTransfers.ReceivedByMasterSum(master.UserId);
+        SendBalance = masterTransfers.SendedByMasterSum(master.UserId);
         FeeBalance = masterOperations
             .Where(fo => fo.Approved)
-            .Where(fo => fo.PaymentType?.User?.UserId == master.UserId)
+            .Where(fo => fo.PaymentType?.UserId == master.UserId.Value)
             .Sum(fo => fo.MoneyAmount);
 
         ModerationBalance = masterOperations
             .Where(fo => fo.RequireModeration)
-            .Where(fo => fo.PaymentType?.User.UserId == master.UserId)
+            .Where(fo => fo.PaymentType?.UserId == master.UserId.Value)
             .Sum(fo => fo.MoneyAmount);
 
         Total = FeeBalance + ReceiveBalance + SendBalance;

--- a/src/JoinRpg.WebPortal.Models/Money/MoneyInfoForUserViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MoneyInfoForUserViewModel.cs
@@ -1,6 +1,6 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
-using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Users;
 using JoinRpg.Interfaces;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.Money;
@@ -8,14 +8,14 @@ using JoinRpg.Web.Models.Money;
 namespace JoinRpg.Web.Models;
 
 public class MoneyInfoForUserViewModel(IReadOnlyCollection<MoneyTransfer> transfers,
-    User master,
+    UserInfo master,
     IUriService urlHelper,
     IReadOnlyCollection<FinanceOperation> operations,
     PaymentTypeSummaryViewModel[] payments,
     ICurrentUserAccessor currentUserId,
     ProjectInfo projectInfo)
 {
-    public UserProfileDetailsViewModel UserDetails { get; } = new UserProfileDetailsViewModel(master.GetUserInfo(), projectInfo, currentUserId);
+    public UserProfileDetailsViewModel UserDetails { get; } = new UserProfileDetailsViewModel(master, projectInfo, currentUserId);
     public int ProjectId { get; } = projectInfo.ProjectId;
     public IReadOnlyCollection<MoneyTransferListItemViewModel> Transfers { get; } = transfers
             .OrderBy(f => f.Id)

--- a/src/JoinRpg.WebPortal.Models/Money/MoneyInfoTotalViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MoneyInfoTotalViewModel.cs
@@ -1,5 +1,6 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
+using JoinRpg.DomainTypes.Users;
 using JoinRpg.Interfaces;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.Money;
@@ -23,19 +24,14 @@ public class MoneyInfoTotalViewModel
         IUriService urlHelper,
         IReadOnlyCollection<FinanceOperation> operations,
         PaymentTypeSummaryViewModel[] payments,
-        ICurrentUserAccessor currentUserId)
+        ICurrentUserAccessor currentUserId,
+        IReadOnlyCollection<UserInfo> masters)
     {
-
-        var masters = operations.Select(fo => fo.PaymentType?.User)
-            .Union(transfers.Select(mt => mt.Receiver))
-            .Union(transfers.Select(mt => mt.Sender))
-            .Distinct();
-
         ProjectId = project.ProjectId;
 
         Operations = new FinOperationListViewModel(project.ProjectId, urlHelper, operations);
 
-        Balance = MasterBalanceBuilder.ToMasterBalanceViewModels(operations, transfers, project.ProjectId);
+        Balance = MasterBalanceBuilder.ToMasterBalanceViewModels(masters, operations, transfers, project.ProjectId);
 
         Transfers = transfers.Select(transfer =>
             new MoneyTransferListItemViewModel(transfer, currentUserId)).ToArray();


### PR DESCRIPTION
## Что сделано

`FinancesController.ByMaster` грузил мастера через `UserRepository.GetById` (EF-сущность `User`) вместо доменного `UserInfo`. Заменил на `GetRequiredUserInfo`.

Тип `User` для мастера использовался также в общей цепочке отображения баланса (`MasterBalanceViewModel`, `MasterBalanceBuilder`), которая расшарена между `ByMaster`, `MoneySummary` и `SummaryByMaster` — поэтому заменил везде, а не только в контроллере:

- `MasterBalanceViewModel.Master` и `MoneyInfoForUserViewModel` теперь типизированы `UserInfo`.
- `MasterBalanceBuilder` больше не строит список мастеров из EF-навигаций (`PaymentType.User`, `MoneyTransfer.Receiver/Sender`), а принимает уже загруженный `IReadOnlyCollection<UserInfo>`; добавлен хелпер `GetMasterIds` для сбора id мастеров из операций/переводов.
- `FinancesController.MoneySummary`/`SummaryByMaster` теперь пакетно грузят `UserInfo` через `IUserRepository.GetRequiredUserInfos` вместо неявной загрузки через EF Include.
- `CustomExporter` получил перегрузку `ShortUserColumn` для `UserInfo`, `MoneySummaryByMasterExporter` переведён на поля `UserInfo` (`Email`, `PhoneNumber`, `Social.Telegram`) вместо `User.Extra`.
- Добавлен `DisplayTemplates/UserInfo.cshtml` для рендера `UserInfo` через компонент `UserLink` (аналог существующего `DisplayTemplates/User.cshtml`).

## Test plan

- [x] `dotnet build` — вся солюшн собирается без ошибок
- [x] `dotnet format --verify-no-changes --severity error` — чисто
- [x] `dotnet test src/JoinRpg.WebPortal.Models.Test` — 193/193 passed
- [ ] Ручная проверка `/money/ByMaster`, `/money/MoneySummary`, `/money/SummaryByMaster` в браузере

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QStxsoAHqGVe5zyTMzFvL5