### PR TITLE
fix: переименовать пункт меню «Помощь» в «Справочник»

### DIFF
--- a/src/JoinRpg.Portal/Views/Shared/_LoginPartial.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/_LoginPartial.cshtml
@@ -38,6 +38,6 @@ else
 <ul class="nav navbar-nav navbar-right">
     <li><a asp-controller="Account" asp-action="Register">Регистрация</a></li>
     <li><a asp-controller="Account" asp-action="Login">Войти</a></li>
-    <li><a href="https://docs.joinrpg.ru">Справочник</a></li>
+    <li><a href="https://docs.joinrpg.ru"><join-icon icon="Help" /> Справочник</a></li>
 </ul>
 }

--- a/src/JoinRpg.Portal/Views/Shared/_LoginPartial.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/_LoginPartial.cshtml
@@ -20,7 +20,7 @@
                 <ul class="dropdown-menu">
                     <li class="dropdown-item">@Html.ActionLink("Профиль", "Me", "User", new { area = "" }, null)</li>
                     <li class="dropdown-item">@Html.ActionLink("Настройки", "SetupProfile", "Manage", new { area = "" }, null)</li>
-                    <li class="dropdown-item"><a href="https://docs.joinrpg.ru"><join-icon icon="Help" /> Помощь</a></li>
+                    <li class="dropdown-item"><a href="https://docs.joinrpg.ru"><join-icon icon="Help" /> Справочник</a></li>
                     @if (User.IsInRole("admin"))
                     {
                         <li class="dropdown-item">
@@ -38,6 +38,6 @@ else
 <ul class="nav navbar-nav navbar-right">
     <li><a asp-controller="Account" asp-action="Register">Регистрация</a></li>
     <li><a asp-controller="Account" asp-action="Login">Войти</a></li>
-    <li><a href="https://docs.joinrpg.ru">Помощь</a></li>
+    <li><a href="https://docs.joinrpg.ru">Справочник</a></li>
 </ul>
 }


### PR DESCRIPTION
## Что сделано
- Пункт меню «Помощь» переименован в «Справочник» (в выпадающем меню пользователя и в шапке для неавторизованных)

Generated with [Claude Code](https://claude.ai/code)