### PR TITLE
refactor: правило доступности поля поверх IFieldAvailabilityTarget

### DIFF
--- a/src/JoinRpg.Domain.Test/CharacterParentGroupExtensionsTest.cs
+++ b/src/JoinRpg.Domain.Test/CharacterParentGroupExtensionsTest.cs
@@ -21,4 +21,40 @@ public class CharacterParentGroupExtensionsTest
         result.ShouldHaveSingleItem();
         result[0].CharacterGroupId.ShouldBe(midGroup.CharacterGroupId);
     }
+
+    [Fact]
+    public void ParentGroupIdsToTop_ByProjectInfo_MatchesEntityWalk()
+    {
+        // Обход ленивых EF-навигаций и выборка по ProjectInfo должны давать одно и то же:
+        // на этом держится переход CustomFieldsViewModel на версию с ProjectInfo.
+        var mock = new MockedProject();
+        var rootGroup = mock.Project.CharacterGroups.Single(g => g.IsRoot);
+
+        var midGroup = mock.CreateCharacterGroup();
+        midGroup.ParentCharacterGroupIds = [rootGroup.CharacterGroupId];
+
+        var leafGroup = mock.CreateCharacterGroup();
+        leafGroup.ParentCharacterGroupIds = [midGroup.CharacterGroupId];
+
+        var inactiveGroup = mock.CreateCharacterGroup();
+        inactiveGroup.ParentCharacterGroupIds = [rootGroup.CharacterGroupId];
+        inactiveGroup.IsActive = false;
+
+        // Две ветки сразу: так проверяется и объединение, и дедупликация общего предка.
+        mock.Character.ParentCharacterGroupIds = [leafGroup.CharacterGroupId, inactiveGroup.CharacterGroupId];
+        mock.ReInitProjectInfo();
+
+#pragma warning disable CS0618 // сравниваем именно с устаревшей реализацией
+        var byEntityWalk = mock.Character.GetParentGroupIdsToTop();
+#pragma warning restore CS0618
+
+        mock.Character.GetParentGroupIdsToTop(mock.ProjectInfo)
+            .ShouldBe(byEntityWalk, ignoreOrder: true);
+
+        // Страж от вырожденного сравнения: набор должен быть непустым и содержать предков.
+        byEntityWalk.Select(g => g.CharacterGroupId)
+            .ShouldBe(
+                [rootGroup.CharacterGroupId, midGroup.CharacterGroupId, leafGroup.CharacterGroupId, inactiveGroup.CharacterGroupId],
+                ignoreOrder: true);
+    }
 }

--- a/src/JoinRpg.Domain.Test/FieldAvailabilityOverCharacterInfoTest.cs
+++ b/src/JoinRpg.Domain.Test/FieldAvailabilityOverCharacterInfoTest.cs
@@ -1,6 +1,5 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Mocks;
-using JoinRpg.Domain.Problems;
 using JoinRpg.Domain.Problems.CommonProblemFilters;
 using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.Characters;

--- a/src/JoinRpg.Domain.Test/FieldAvailabilityOverCharacterInfoTest.cs
+++ b/src/JoinRpg.Domain.Test/FieldAvailabilityOverCharacterInfoTest.cs
@@ -1,0 +1,147 @@
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.Domain.Problems;
+using JoinRpg.Domain.Problems.CommonProblemFilters;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+
+namespace JoinRpg.Domain.Test;
+
+/// <summary>
+/// Доступность поля и построенные поверх неё проблемы должны считаться одинаково для доменного
+/// агрегата <see cref="CharacterInfo"/> (ADR013) и для EF-сущности. Пока обе реализации живы,
+/// это единственное место, где расхождение станет видно.
+/// </summary>
+public class FieldAvailabilityOverCharacterInfoTest
+{
+    private readonly MockedProject mock = new();
+    private readonly CharacterGroup otherGroup;
+
+    public FieldAvailabilityOverCharacterInfoTest()
+    {
+        otherGroup = mock.CreateCharacterGroup();
+        mock.ReInitProjectInfo();
+    }
+
+    public static TheoryData<bool, bool, FieldBoundTo, CharacterType, bool> Cases()
+    {
+        var data = new TheoryData<bool, bool, FieldBoundTo, CharacterType, bool>();
+        foreach (var fieldIsActive in new[] { true, false })
+        {
+            foreach (var validForNpc in new[] { true, false })
+            {
+                foreach (var boundTo in new[] { FieldBoundTo.Character, FieldBoundTo.Claim })
+                {
+                    foreach (var characterType in Enum.GetValues<CharacterType>())
+                    {
+                        foreach (var limitToOtherGroup in new[] { true, false })
+                        {
+                            data.Add(fieldIsActive, validForNpc, boundTo, characterType, limitToOtherGroup);
+                        }
+                    }
+                }
+            }
+        }
+        return data;
+    }
+
+    [Theory, MemberData(nameof(Cases))]
+    public void AvailabilityShouldMatchEntityCalculation(
+        bool fieldIsActive,
+        bool validForNpc,
+        FieldBoundTo boundTo,
+        CharacterType characterType,
+        bool limitToOtherGroup)
+    {
+        var field = MakeField(fieldIsActive, validForNpc, boundTo, limitToOtherGroup);
+        var (entityTarget, aggregate) = MakePair(characterType);
+
+        field.IsAvailableForTarget(aggregate)
+            .ShouldBe(field.IsAvailableForTarget(entityTarget));
+    }
+
+    [Theory, MemberData(nameof(Cases))]
+    public void FieldNotSetProblemsShouldMatchEntityCalculation(
+        bool fieldIsActive,
+        bool validForNpc,
+        FieldBoundTo boundTo,
+        CharacterType characterType,
+        bool limitToOtherGroup)
+    {
+        var field = MakeField(fieldIsActive, validForNpc, boundTo, limitToOtherGroup);
+        var (entityTarget, aggregate) = MakePair(characterType);
+        var fieldWithValue = new FieldWithValue(field, value: null);
+        var filter = new FieldNotSetFilter();
+
+        filter.CheckField(aggregate, fieldWithValue).ToArray()
+            .ShouldBe(filter.CheckField(entityTarget, fieldWithValue).ToArray());
+    }
+
+    [Fact]
+    public void GroupRestrictionIsActuallyChecked()
+    {
+        // Страж от вырожденного сравнения выше: если бы ограничение по группам не работало,
+        // обе реализации согласованно возвращали бы true и тесты ничего бы не проверили.
+        // Поля добавляются до сборки агрегата: AddField пересоздаёт ProjectInfo, а агрегат
+        // привязан к конкретному экземпляру.
+        var restricted = MakeField(true, true, FieldBoundTo.Character, limitToOtherGroup: true);
+        var unrestricted = MakeField(true, true, FieldBoundTo.Character, limitToOtherGroup: false);
+        var (_, aggregate) = MakePair(CharacterType.Player);
+
+        restricted.IsAvailableForTarget(aggregate).ShouldBeFalse();
+        unrestricted.IsAvailableForTarget(aggregate).ShouldBeTrue();
+    }
+
+    private ProjectFieldInfo MakeField(bool isActive, bool validForNpc, FieldBoundTo boundTo, bool limitToOtherGroup)
+        => mock.AddField(field =>
+        {
+            field.FieldType = ProjectFieldType.String;
+            field.FieldBoundTo = boundTo;
+            field.IsActive = isActive;
+            field.ValidForNpc = validForNpc;
+            field.MandatoryStatus = MandatoryStatus.Required;
+            field.AvailableForCharacterGroupIds = limitToOtherGroup ? [otherGroup.CharacterGroupId] : [];
+        });
+
+    /// <summary>
+    /// Один и тот же персонаж в двух представлениях: обёртка над сущностью и доменный агрегат.
+    /// </summary>
+    private (CharacterItem Entity, CharacterInfo Aggregate) MakePair(CharacterType characterType)
+    {
+        var projectInfo = mock.ProjectInfo;
+
+        var character = mock.CreateCharacter($"Персонаж{characterType}");
+        character.CharacterType = characterType;
+        // CharacterTypeInfo не разрешает лимит слотов не-слоту, а сущность про это не знает.
+        character.CharacterSlotLimit = characterType == CharacterType.Slot ? 1 : null;
+
+        var entity = new CharacterBulkLoader().LoadCharacter(character, projectInfo);
+
+        var aggregate = new CharacterInfo(
+            new CharacterIdentification(projectInfo.ProjectId, character.CharacterId),
+            projectInfo,
+            character.CharacterName,
+            new CharacterTypeInfo(
+                characterType,
+                IsHot: false,
+                character.CharacterSlotLimit,
+                SlotName: null,
+                CharacterVisibility.Public),
+            hidePlayerForCharacter: false,
+            isActive: true,
+            inGame: false,
+            autoCreated: false,
+            new MarkdownString(""),
+            originalCharacterSlotId: null,
+            [.. character.GetDirectGroupIds()],
+            FieldLayerContainer.DeserializeFieldLayer(projectInfo, null),
+            [],
+            approvedClaimId: null,
+            DateTime.UtcNow,
+            new UserIdentification(mock.Master.UserId),
+            DateTime.UtcNow,
+            new UserIdentification(mock.Master.UserId));
+
+        return (entity, aggregate);
+    }
+}

--- a/src/JoinRpg.Domain/CharacterBulkLoader.cs
+++ b/src/JoinRpg.Domain/CharacterBulkLoader.cs
@@ -1,3 +1,5 @@
+using JoinRpg.DomainTypes.Characters;
+
 namespace JoinRpg.Domain;
 
 public class CharacterBulkLoader
@@ -16,4 +18,14 @@ public class CharacterBulkLoader
     }
 }
 
-public record class CharacterItem(Character Character, IReadOnlyCollection<CharacterGroupIdentification> ParentGroups);
+/// <summary>
+/// Обёртка над EF-сущностью для проверок доступности поля. Временная: существует, пока проверки
+/// проблем не переехали на <see cref="CharacterInfo"/> (ADR013), который реализует тот же интерфейс.
+/// </summary>
+public record class CharacterItem(Character Character, IReadOnlyCollection<CharacterGroupIdentification> ParentGroups)
+    : IFieldAvailabilityTarget
+{
+    CharacterType IFieldAvailabilityTarget.CharacterType => Character.CharacterType;
+
+    IReadOnlyCollection<CharacterGroupIdentification> IFieldAvailabilityTarget.ParentGroupIdsToTop => ParentGroups;
+}

--- a/src/JoinRpg.Domain/FieldExtensions.cs
+++ b/src/JoinRpg.Domain/FieldExtensions.cs
@@ -27,13 +27,14 @@ public static class FieldExtensions
         return IsAvailableForTargetCore(field, isNpc, targetGroups);
     }
 
-    public static bool IsAvailableForTarget(this ProjectFieldInfo field, CharacterItem target)
+    public static bool IsAvailableForTarget(this ProjectFieldInfo field, IFieldAvailabilityTarget target)
     {
         ArgumentNullException.ThrowIfNull(field);
+        ArgumentNullException.ThrowIfNull(target);
 
-        var isNpc = target.Character.CharacterType == CharacterType.NonPlayer;
+        var isNpc = target.CharacterType == CharacterType.NonPlayer;
 
-        return IsAvailableForTargetCore(field, isNpc, target.ParentGroups);
+        return IsAvailableForTargetCore(field, isNpc, target.ParentGroupIdsToTop);
     }
 
     private static bool IsAvailableForTargetCore(ProjectFieldInfo field, bool isNpc, IEnumerable<CharacterGroupIdentification>? targetGroups)

--- a/src/JoinRpg.Domain/FieldExtensions.cs
+++ b/src/JoinRpg.Domain/FieldExtensions.cs
@@ -4,15 +4,6 @@ namespace JoinRpg.Domain;
 
 public static class FieldExtensions
 {
-    [Obsolete("Pass ProjectInfo")]
-    public static bool IsAvailableForTarget(this ProjectFieldInfo field, Character? target)
-    {
-        ArgumentNullException.ThrowIfNull(field);
-
-        // Группы считаются обходом EF-навигации, а не по ProjectInfo — отсюда и Obsolete.
-        return IsAvailableForTargetCore(field, target?.CharacterType, target?.GetParentGroupIdsToTop());
-    }
-
     public static bool IsAvailableForTarget(this ProjectFieldInfo field, Character? target, ProjectInfo projectInfo)
         => field.IsAvailableForTarget(
             target is null ? null : new CharacterItem(target, [.. target.GetParentGroupIdsToTop(projectInfo)]));
@@ -25,17 +16,9 @@ public static class FieldExtensions
     {
         ArgumentNullException.ThrowIfNull(field);
 
-        return IsAvailableForTargetCore(field, target?.CharacterType, target?.ParentGroupIdsToTop);
-    }
-
-    private static bool IsAvailableForTargetCore(
-        ProjectFieldInfo field,
-        CharacterType? characterType,
-        IEnumerable<CharacterGroupIdentification>? targetGroups)
-    {
         return field.IsActive
-                  && (field.BoundTo == FieldBoundTo.Claim || field.ValidForNpc || characterType != CharacterType.NonPlayer)
-                  && (field.GroupsAvailableForIds.Count == 0 || (targetGroups?.Intersect(field.GroupsAvailableForIds).Any() ?? false));
+                  && (field.BoundTo == FieldBoundTo.Claim || field.ValidForNpc || target?.CharacterType != CharacterType.NonPlayer)
+                  && (field.GroupsAvailableForIds.Count == 0
+                      || (target?.ParentGroupIdsToTop.Intersect(field.GroupsAvailableForIds).Any() ?? false));
     }
-
 }

--- a/src/JoinRpg.Domain/FieldExtensions.cs
+++ b/src/JoinRpg.Domain/FieldExtensions.cs
@@ -9,38 +9,32 @@ public static class FieldExtensions
     {
         ArgumentNullException.ThrowIfNull(field);
 
-        var isNpc = target?.CharacterType == CharacterType.NonPlayer;
-
-        var targetGroups = target?.GetParentGroupIdsToTop().ToList();
-
-        return IsAvailableForTargetCore(field, isNpc, targetGroups);
+        // Группы считаются обходом EF-навигации, а не по ProjectInfo — отсюда и Obsolete.
+        return IsAvailableForTargetCore(field, target?.CharacterType, target?.GetParentGroupIdsToTop());
     }
 
     public static bool IsAvailableForTarget(this ProjectFieldInfo field, Character? target, ProjectInfo projectInfo)
+        => field.IsAvailableForTarget(
+            target is null ? null : new CharacterItem(target, [.. target.GetParentGroupIdsToTop(projectInfo)]));
+
+    /// <summary>
+    /// Доступно ли поле персонажу. <paramref name="target"/> == <c>null</c> означает «персонажа нет»:
+    /// тогда доступны только поля без ограничения по группам.
+    /// </summary>
+    public static bool IsAvailableForTarget(this ProjectFieldInfo field, IFieldAvailabilityTarget? target)
     {
         ArgumentNullException.ThrowIfNull(field);
 
-        var isNpc = target?.CharacterType == CharacterType.NonPlayer;
-
-        var targetGroups = target?.GetParentGroupIdsToTop(projectInfo).ToList();
-
-        return IsAvailableForTargetCore(field, isNpc, targetGroups);
+        return IsAvailableForTargetCore(field, target?.CharacterType, target?.ParentGroupIdsToTop);
     }
 
-    public static bool IsAvailableForTarget(this ProjectFieldInfo field, IFieldAvailabilityTarget target)
-    {
-        ArgumentNullException.ThrowIfNull(field);
-        ArgumentNullException.ThrowIfNull(target);
-
-        var isNpc = target.CharacterType == CharacterType.NonPlayer;
-
-        return IsAvailableForTargetCore(field, isNpc, target.ParentGroupIdsToTop);
-    }
-
-    private static bool IsAvailableForTargetCore(ProjectFieldInfo field, bool isNpc, IEnumerable<CharacterGroupIdentification>? targetGroups)
+    private static bool IsAvailableForTargetCore(
+        ProjectFieldInfo field,
+        CharacterType? characterType,
+        IEnumerable<CharacterGroupIdentification>? targetGroups)
     {
         return field.IsActive
-                  && (field.BoundTo == FieldBoundTo.Claim || field.ValidForNpc || !isNpc)
+                  && (field.BoundTo == FieldBoundTo.Claim || field.ValidForNpc || characterType != CharacterType.NonPlayer)
                   && (field.GroupsAvailableForIds.Count == 0 || (targetGroups?.Intersect(field.GroupsAvailableForIds).Any() ?? false));
     }
 

--- a/src/JoinRpg.Domain/Problems/CommonProblemFilters/FieldNotSetFilter.cs
+++ b/src/JoinRpg.Domain/Problems/CommonProblemFilters/FieldNotSetFilter.cs
@@ -5,7 +5,7 @@ namespace JoinRpg.Domain.Problems.CommonProblemFilters;
 
 internal class FieldNotSetFilter : IFieldRelatedProblemFilter<Character>, IFieldRelatedProblemFilter<Claim>
 {
-    public IEnumerable<FieldRelatedProblem> CheckField(CharacterItem target, FieldWithValue fieldWithValue)
+    public IEnumerable<FieldRelatedProblem> CheckField(IFieldAvailabilityTarget target, FieldWithValue fieldWithValue)
     {
         if (!fieldWithValue.Field.CanHaveValue)
         {

--- a/src/JoinRpg.Domain/Problems/CommonProblemFilters/InActiveVariantsFilter.cs
+++ b/src/JoinRpg.Domain/Problems/CommonProblemFilters/InActiveVariantsFilter.cs
@@ -4,7 +4,7 @@ namespace JoinRpg.Domain.Problems.CommonProblemFilters;
 
 internal class InActiveVariantsFilter : IFieldRelatedProblemFilter<Character>, IFieldRelatedProblemFilter<Claim>
 {
-    public IEnumerable<FieldRelatedProblem> CheckField(CharacterItem target, FieldWithValue fieldWithValue)
+    public IEnumerable<FieldRelatedProblem> CheckField(IFieldAvailabilityTarget target, FieldWithValue fieldWithValue)
     {
         foreach (var variant in fieldWithValue.GetDropdownValues())
         {

--- a/src/JoinRpg.Domain/Problems/IFieldRelatedProblemFilter.cs
+++ b/src/JoinRpg.Domain/Problems/IFieldRelatedProblemFilter.cs
@@ -4,5 +4,5 @@ namespace JoinRpg.Domain.Problems;
 
 public interface IFieldRelatedProblemFilter<in TObject> where TObject : IFieldContainter
 {
-    IEnumerable<FieldRelatedProblem> CheckField(CharacterItem target, FieldWithValue fieldWithValue);
+    IEnumerable<FieldRelatedProblem> CheckField(IFieldAvailabilityTarget target, FieldWithValue fieldWithValue);
 }

--- a/src/JoinRpg.Domain/Problems/ProblemValidator.cs
+++ b/src/JoinRpg.Domain/Problems/ProblemValidator.cs
@@ -52,7 +52,7 @@ internal class ProblemValidator<TObject>(
         }
     }
 
-    private IEnumerable<FieldRelatedProblem> ValidateField(CharacterItem target, FieldWithValue fieldWithValue)
+    private IEnumerable<FieldRelatedProblem> ValidateField(IFieldAvailabilityTarget target, FieldWithValue fieldWithValue)
     {
         foreach (var filter in fieldFilters)
         {

--- a/src/JoinRpg.DomainTypes/Characters/CharacterInfo.cs
+++ b/src/JoinRpg.DomainTypes/Characters/CharacterInfo.cs
@@ -21,7 +21,7 @@ namespace JoinRpg.DomainTypes.Characters;
 /// Полных данных о комментариях и о сюжетах здесь нет — это отдельные агрегаты.
 /// </para>
 /// </remarks>
-public record class CharacterInfo
+public record class CharacterInfo : IFieldAvailabilityTarget
 {
     private readonly Lazy<IReadOnlyCollection<CharacterGroupIdentification>> parentGroupIdsToTop;
     private readonly Lazy<int> activeClaimsCount;
@@ -167,6 +167,8 @@ public record class CharacterInfo
     }
 
     public bool IsPublic => CharacterTypeInfo.IsPublic;
+
+    public CharacterType CharacterType => CharacterTypeInfo.CharacterType;
 
     /// <summary>Утверждённая заявка, если она есть.</summary>
     public CharacterClaimInfo? ApprovedClaim { get; }

--- a/src/JoinRpg.DomainTypes/Characters/IFieldAvailabilityTarget.cs
+++ b/src/JoinRpg.DomainTypes/Characters/IFieldAvailabilityTarget.cs
@@ -1,0 +1,18 @@
+namespace JoinRpg.DomainTypes.Characters;
+
+/// <summary>
+/// Минимум сведений о персонаже, по которым решается, доступно ли ему поле проекта
+/// (см. <c>FieldExtensions.IsAvailableForTarget</c>) — тип персонажа и его группы вверх до корня.
+/// </summary>
+/// <remarks>
+/// Существует ради того, чтобы правило доступности поля было записано ровно один раз и работало
+/// и над доменным агрегатом <see cref="CharacterInfo"/> (ADR013), и над EF-сущностью, пока та ещё
+/// не мигрирована.
+/// </remarks>
+public interface IFieldAvailabilityTarget
+{
+    CharacterType CharacterType { get; }
+
+    /// <summary>Все группы персонажа вверх до корня, включая прямые.</summary>
+    IReadOnlyCollection<CharacterGroupIdentification> ParentGroupIdsToTop { get; }
+}

--- a/src/JoinRpg.WebPortal.Models/CustomFieldsViewModels.cs
+++ b/src/JoinRpg.WebPortal.Models/CustomFieldsViewModels.cs
@@ -112,11 +112,11 @@ public class FieldValueViewModel
 
         CanView = ch.HasViewableValue
                   && ch.Field.HasViewAccess(model.AccessArguments)
-                  && (ch.HasEditableValue || ch.Field.IsAvailableForTarget(model.Target));
+                  && (ch.HasEditableValue || ch.Field.IsAvailableForTarget(model.Target, model.ProjectInfo));
 
         CanEdit = model.AccessArguments.EditAllowed
                   && ch.Field.HasEditAccess(model.AccessArguments)
-                  && (ch.HasEditableValue || ch.Field.IsAvailableForTarget(model.Target));
+                  && (ch.HasEditableValue || ch.Field.IsAvailableForTarget(model.Target, model.ProjectInfo));
 
 
         // Detecting if field (or its values) has a price or not
@@ -191,6 +191,13 @@ public class CustomFieldsViewModel
     public AccessArguments AccessArguments { get; }
     [Editable(false)]
     public Character Target { get; }
+
+    /// <summary>
+    /// Нужен, чтобы доступность поля считалась по метаданным проекта, а не обходом ленивых
+    /// EF-навигаций <see cref="Character"/>.
+    /// </summary>
+    [Editable(false)]
+    public ProjectInfo ProjectInfo { get; }
 
     [Editable(false)]
     public IReadOnlyCollection<FieldValueViewModel> Fields { get; }
@@ -282,6 +289,7 @@ public class CustomFieldsViewModel
         }
         AccessArguments = accessArguments;
         Target = target;
+        ProjectInfo = projectInfo;
         var renderer = new JoinrpgMarkdownLinkRenderer(Target.Project, projectInfo);
         Fields = fields.Select(ch => CreateFieldValueView(ch, renderer, overrideValues)).ToList();
     }


### PR DESCRIPTION
Подготовка потребителей проблем к доменному агрегату `CharacterInfo` (ADR013) — без миграции самих потребителей.

## Что сделано

**1. `IFieldAvailabilityTarget`** (`JoinRpg.DomainTypes`) — минимум, по которому решается доступность поля персонажу: тип персонажа и группы вверх до корня. Реализуют и `CharacterInfo`, и обёртка над сущностью `CharacterItem`. Фильтры проблем (`IFieldRelatedProblemFilter`, `FieldNotSetFilter`, `InActiveVariantsFilter`) и `ProblemValidator` перешли на него — теперь агрегат годится им в качестве цели.

**2. Одно ядро правила.** Три перегрузки `IsAvailableForTarget` дублировали само правило, каждая со своим вычислением `isNpc` и групп. Теперь правило записано один раз — в версии над интерфейсом; версия над сущностью сводится к сборке `CharacterItem`. `null` означает «персонажа нет» — ровно та семантика, что была у перегрузок над `Character?`.

**3. `CustomFieldsViewModel` считает доступность по `ProjectInfo`.** `FieldValueViewModel` звал устаревшую перегрузку без `ProjectInfo`, а та обходила ленивые EF-навигации `Groups → ParentGroups` — на каждое поле при рендеринге страницы персонажа. `ProjectInfo` в конструктор и так приходил, но не сохранялся. После этого перегрузка `IsAvailableForTarget(ProjectFieldInfo, Character?)` осталась без вызовов и удалена.

## Проверка

Поведение не меняется, и это закреплено двумя тестами-оракулами, а не только сборкой:

- `FieldAvailabilityOverCharacterInfoTest` — один и тот же персонаж в двух представлениях (обёртка над сущностью и агрегат) по всем 96 комбинациям пяти факторов: активность поля, `ValidForNpc`, `FieldBoundTo`, `CharacterType`, ограничение по группам. Сверяются и доступность, и выдача `FieldNotSetFilter`. Плюс сторож на случай, если ограничение по группам молча перестанет работать и сравнение выродится.
- `ParentGroupIdsToTop_ByProjectInfo_MatchesEntityWalk` — обход навигаций против выборки по `ProjectInfo`: две ветки сразу (объединение и дедупликация общего предка) и неактивная группа.

Сборка, `dotnet format --verify-no-changes --severity error` и полный `dotnet test` чистые.

## Чего здесь нет

`CharacterItem` и `CharacterBulkLoader` остаются. Убрать их можно будет, только когда на агрегат переедет и путь `IProblemValidator<Claim>`, а ему нужен ещё не существующий агрегат заявки. Ни один продакшен-вызов пока не передаёт `CharacterInfo` в фильтры — интерфейс делает это возможным, потребитель будет отдельным PR (ближайший кандидат — страница списка персонажей, она свободна от `JoinrpgMarkdownLinkRenderer`).

Парные `GetParentGroupIdsToTop()`/`GetParentGroupsToTop()` без `ProjectInfo` живы: у них есть другие вызовы в `ClaimExtensions` и `SubscribeExtensions`.

Generated with [Claude Code](https://claude.ai/code)