### PR TITLE
chore: обновить AWSSDK.S3/AWSSDK.SimpleEmailV2 до V4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
         <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
         <PackageVersion Include="Autofac" Version="9.3.2" />
         <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
-        <PackageVersion Include="AWSSDK.S3" Version="3.7.412.0" />
-        <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="3.7.412.0" />
+        <PackageVersion Include="AWSSDK.S3" Version="4.0.16" />
+        <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.5.8" />
         <PackageVersion Include="BitArmory.ReCaptcha" Version="5.0.1" />
         <PackageVersion Include="bunit" Version="2.9.0" />
         <PackageVersion Include="ClosedXML" Version="0.105.1" />

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -49,7 +49,7 @@
 - `JoinRpg.Domain` — доменная логика (методы-расширения над DataModel). Устаревший проект. Вместо использования сущностей БД с методами расширения в доменной логике, надо использовать доменные объекты в `JoinRpg.PrimitiveTypes`
 - `Joinrpg.Web.Identity` — реализация ASP.NET Core Identity (`MyUserStore`, `CurrentUserAccessor`, `ExternalLoginProfileExtractor`)
 - `JoinRpg.Web.UserProfile` — ViewModel профиля/соцсетей и билдер над доменным `UserInfo` (`ProviderDescViewModel`, `UserLoginInfoViewModel`, `UserLoginInfoViewModelBuilder`), без зависимости на `JoinRpg.DataModel`; используется и Portal, и IdPortal
-- `JoinRpg.BlobStorage` — абстракция файлового хранилища (AWS S3)
+- `JoinRpg.BlobStorage` — абстракция файлового хранилища (AWS S3, endpoint Yandex Object Storage). При создании `AmazonS3Config`/`AmazonSimpleEmailServiceV2Config` (см. также Postbox в `JoinRpg.Services.Notifications`) обязательно `RequestChecksumCalculation`/`ResponseChecksumValidation = WHEN_REQUIRED` — Yandex Object Storage и Postbox не поддерживают проактивные CRC32/CRC64-чексуммы, включённые по умолчанию в AWSSDK.S3/AWSSDK.SimpleEmailV2 начиная с 3.7.412.0 (см. [aws-sdk-net#3610](https://github.com/aws/aws-sdk-net/issues/3610)). Не убирать эту настройку как "лишнюю" при будущих апгрейдах SDK
 
 ### Services
 - `JoinRpg.Services.Interfaces` — контракты сервисов. 1 метод = 1 действие пользователя

--- a/src/JoinRpg.Services.Notifications/Senders/PostboxEmail/PostboxClientFactory.cs
+++ b/src/JoinRpg.Services.Notifications/Senders/PostboxEmail/PostboxClientFactory.cs
@@ -19,7 +19,6 @@ internal class PostboxClientFactory(IOptions<PostboxOptions> options)
             RequestChecksumCalculation = Amazon.Runtime.RequestChecksumCalculation.WHEN_REQUIRED,
             ResponseChecksumValidation = Amazon.Runtime.ResponseChecksumValidation.WHEN_REQUIRED,
             SignatureMethod = SigningAlgorithm.HmacSHA256,
-            SignatureVersion = "4",
             AuthenticationRegion = "ru-central1",
         };
 


### PR DESCRIPTION
## Что сделано
- Мажорный апгрейд `AWSSDK.S3` (3.7.412.0 → 4.0.16) и `AWSSDK.SimpleEmailV2` (3.7.412.0 → 4.0.5.8) в `Directory.Packages.props`.
- Единственная правка кода: в `PostboxClientFactory.cs` удалена `SignatureVersion = "4"` — свойство убрано из `Amazon.Runtime.ClientConfig` в V4, так как SDK теперь всегда использует SigV4.
- Воркэраунд для несовместимости с Yandex Object Storage/Postbox (`RequestChecksumCalculation`/`ResponseChecksumValidation = WHEN_REQUIRED`, см. [aws-sdk-net#3610](https://github.com/aws/aws-sdk-net/issues/3610)) сохранён без изменений — в V4 эта настройка не менялась.
- Добавлена заметка в `docs/structure.md`, чтобы этот воркэраунд не убрали как "лишний" при будущих апгрейдах.

## Test plan
- [x] `dotnet build` — без ошибок
- [x] `dotnet test` — все тесты зелёные
- [x] `dotnet format --verify-no-changes --severity error` — чисто
- [ ] Ручная проверка на dev/staging с реальным Yandex Object Storage/Postbox: загрузка аватарки и отправка письма без ошибок вида `NotImplemented: Header 'x-amz-checksum-...'`, health check `S3 storage` — Healthy

Generated with [Claude Code](https://claude.ai/code)