### PR TITLE
fix: не показывать в отчёте горячих ролей проекты без будущей игры

### DIFF
--- a/src/JoinRpg.Dal.Impl.Tests/ProjectPredicatesTest.cs
+++ b/src/JoinRpg.Dal.Impl.Tests/ProjectPredicatesTest.cs
@@ -1,0 +1,62 @@
+using JoinRpg.Dal.Impl.Repositories;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Projects;
+using Shouldly;
+using Xunit;
+
+namespace JoinRpg.Dal.Impl.Tests;
+
+public class ProjectPredicatesTest
+{
+    private static Project CreateProject(IEnumerable<KogdaIgraGame>? games = null) => new()
+    {
+        Active = true,
+        Details = new ProjectDetails(),
+        KogdaIgraGames = [.. (games ?? [])],
+    };
+
+    private static bool HasFutureKogdaIgraGame(Project project)
+        => ProjectPredicates.HasFutureKogdaIgraGame().Compile()(project);
+
+    // Баг: админский отчёт о горячих ролях (AdminHotRolesList) показывал роли из проектов,
+    // у которых нет ни одной непрошедшей игры КогдаИгра — то есть больше, чем реально
+    // рекламируется через SingleHotRoleAdvertisementJob (там есть проверка NearestFutureKogdaIgraCard).
+
+    [Fact]
+    public void NoGames_ShouldNotHaveFutureGame()
+        => HasFutureKogdaIgraGame(CreateProject()).ShouldBeFalse();
+
+    [Fact]
+    public void OnlyPastGame_ShouldNotHaveFutureGame()
+        => HasFutureKogdaIgraGame(CreateProject([
+            new KogdaIgraGame { KogdaIgraGameId = 1, Active = true, Begin = DateTime.UtcNow.AddDays(-30), Name = "Прошедшая игра" }
+        ])).ShouldBeFalse();
+
+    [Fact]
+    public void FutureGame_ShouldHaveFutureGame()
+        => HasFutureKogdaIgraGame(CreateProject([
+            new KogdaIgraGame { KogdaIgraGameId = 1, Active = true, Begin = DateTime.UtcNow.AddDays(30), Name = "Будущая игра" }
+        ])).ShouldBeTrue();
+
+    [Fact]
+    public void OnlyInactiveFutureGame_ShouldNotHaveFutureGame()
+        // Неактивная привязка (например, ошибочно созданная) — игнорируется, как и у KogdaIgraMissingGamesPredicate
+        => HasFutureKogdaIgraGame(CreateProject([
+            new KogdaIgraGame { KogdaIgraGameId = 1, Active = false, Begin = DateTime.UtcNow.AddDays(30), Name = "Неактивная будущая игра" }
+        ])).ShouldBeFalse();
+
+    [Fact]
+    public void MixedPastAndFutureGames_ShouldHaveFutureGame()
+        // Сериал: прошедшая игра уже была, но заявлена следующая часть — проект остаётся кандидатом
+        => HasFutureKogdaIgraGame(CreateProject([
+            new KogdaIgraGame { KogdaIgraGameId = 1, Active = true, Begin = DateTime.UtcNow.AddDays(-30), Name = "Прошедшая игра" },
+            new KogdaIgraGame { KogdaIgraGameId = 2, Active = true, Begin = DateTime.UtcNow.AddDays(30), Name = "Будущая игра" },
+        ])).ShouldBeTrue();
+
+    [Fact]
+    public void GameWithNullBegin_ShouldNotHaveFutureGame()
+        // Дата начала ещё не синхронизирована — не считаем это будущей игрой
+        => HasFutureKogdaIgraGame(CreateProject([
+            new KogdaIgraGame { KogdaIgraGameId = 1, Active = true, Begin = null, Name = "Без даты начала" }
+        ])).ShouldBeFalse();
+}

--- a/src/JoinRpg.Dal.Impl/Repositories/HotCharactersRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/HotCharactersRepository.cs
@@ -11,6 +11,7 @@ internal class HotCharactersRepository(MyDbContext ctx) : IHotCharactersReposito
             .AsExpandable()
             .Where(ProjectPredicates.Status(ProjectLifecycleStatus.ActiveClaimsOpen))
             .Where(ProjectPredicates.Public())
+            .Where(ProjectPredicates.HasFutureKogdaIgraGame())
             .SelectMany(c => c.Characters)
             .Where(CharacterPredicates.Hot())
             .ApplyPaginationEf(pagination, c => c.CharacterId)

--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectPredicates.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectPredicates.cs
@@ -69,4 +69,7 @@ internal static class ProjectPredicates
     }
 
     internal static Expression<Func<Project, bool>> Public() => p => p.Details.IsPublicProject;
+
+    internal static Expression<Func<Project, bool>> HasFutureKogdaIgraGame() =>
+        p => p.KogdaIgraGames.Any(g => g.Active && g.Begin > DateTime.UtcNow);
 }

--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
@@ -185,6 +185,7 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
         var query = AllProjects
             .Where(ProjectPredicates.Status(ProjectLifecycleStatus.ActiveClaimsOpen))
             .Where(ProjectPredicates.Public())
+            .Where(ProjectPredicates.HasFutureKogdaIgraGame())
             .Where(p => p.Characters.AsQueryable().Any(CharacterPredicates.Hot()))
             .Select(p => new
             {


### PR DESCRIPTION
## Проблема

Админский отчёт о горячих ролях (`AdminHotRolesList`) показывал больше ролей, чем реально уходит в рекламу. `SingleHotRoleAdvertisementJob` пропускает проект, если у него нет непрошедшей карточки КогдаИгры (`NearestFutureKogdaIgraCard`), а выборка для отчёта такого условия не проверяла — попадали проекты, у которых заявки формально ещё открыты, но ближайшая игра уже прошла (или не назначена).

## Что сделано

- Вынес условие «есть непрошедшая игра» в `ProjectPredicates.HasFutureKogdaIgraGame()` — `KogdaIgraGames.Any(g => g.Active && g.Begin > DateTime.UtcNow)`, по аналогии с `NearestFutureKogdaIgraCard`.
- Применил этот предикат в `HotCharactersRepository.GetHotCharactersFromPublicProjects()` (отчёт горячих ролей) и в `ProjectRepository.GetPublicProjectsOpenForHotRoleAdvertisement()` (общая рассылка рекламы) — теперь оба места фильтруют проекты одинаково, на уровне SQL-запроса.
- Добавил юнит-тесты `ProjectPredicatesTest` (compile+invoke предиката in-memory, по образцу `KogdaIgraMissingGamesPredicateTest`): без игр, только прошедшая игра, будущая игра, неактивная будущая игра, сериал (прошедшая+будущая), игра без даты начала.

## Test plan

- [x] `dotnet build` всего решения — без ошибок
- [x] `dotnet test src/JoinRpg.Dal.Impl.Tests --filter ProjectPredicatesTest` — 6/6 пройдено
- [ ] Ручная проверка отчёта `/admin/hot-roles` на dev/staging

Generated with [Claude Code](https://claude.ai/code)