### PR TITLE
chore: объединить AWSSDK.* в одну dependabot-группу

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-    # https://github.com/aws/aws-sdk-net/issues/3610
-      - dependency-name: "AWSSDK.S3"
     # Версия зафиксирована в JoinRpg.Common.PrimitiveTypes.SourceGenerator.csproj намеренно низкой
     # (см. комментарий там) — анализатор не должен требовать более новый Roslyn, чем у потребителя.
     # Разрешаем только патч-версии, чтобы dependabot не поднимал minor/major.
@@ -46,6 +44,9 @@ updates:
       codeanalysis:
         patterns:
           - "Microsoft.CodeAnalysis*"
+      aws:
+        patterns:
+          - "AWSSDK.*"
 
   - package-ecosystem: "github-actions"
     directory: "/" 


### PR DESCRIPTION
## Что сделано
- Добавлена группа `aws` в dependabot.yml, объединяющая все пакеты `AWSSDK.*` в один PR
- Убрано исключение AWSSDK.S3 из ignore (issue aws/aws-sdk-net#3610 больше не актуален)

Generated with [Claude Code](https://claude.ai/code)