### PR TITLE
feat: отображаемое имя игрока в CharacterClaimInfo

### DIFF
--- a/docs/adr013-character-info.md
+++ b/docs/adr013-character-info.md
@@ -109,7 +109,7 @@ public record class CharacterInfo
 ```csharp
 public record class CharacterClaimInfo(
     ClaimIdentification ClaimId,
-    UserIdentification PlayerId,
+    UserInfoHeader Player,     // PlayerId остался производным свойством, см. уточнение в п.4
     ClaimStatus Status,
     ClaimDenialReason? DenialStatus,
     UserIdentification ResponsibleMasterId,
@@ -202,12 +202,25 @@ XML-doc типа.
 | `FinanceOperation[]`, `RecurrentPayment[]` | нужна только сумма `FeePaid` |
 | `AccommodationRequest` целиком | нужна только `Cost` |
 | `UserSubscription[]` | своя ручка `IUserSubscribeRepository` |
-| Профиль и контакты игрока (`User`, `UserExtra`, `ExternalLogins`) | только `UserIdentification`. Профиль меняется независимо от персонажа, а его включение раздуло бы агрегат — см. ADR011, где контакты составляют заметную долю payload сетки. Отображение — bulk через `IUserRepository.GetUserInfoHeaders(ids)` |
+| Контакты, аватар и соцсети игрока (`UserExtra`, `ExternalLogins`) | только `UserInfoHeader` — id и отображаемое имя (см. уточнение ниже). Остальной профиль меняется независимо от персонажа, а его включение раздуло бы агрегат — см. ADR011, где контакты составляют заметную долю payload сетки. Отображение — bulk через `IUserRepository.GetUserInfoHeaders(ids)` |
 | `AccessArguments` | тип user-independent (см. «Решение») |
 | Заявки игрока в других персонажах | `AddClaimForbideReason.OnlyOneCharacter` требует данных по всему проекту — приходят параметром в `UserInfo` |
 
 Вне `DomainTypes` остаются: `GetBusyStatus` (возвращает UI-enum), `ValidateIfCanAddClaim` (нужен
 `UserInfo`), `CalculateClaimBalance`, фильтры проблем.
+
+#### Уточнение: отображаемое имя игрока входит в агрегат
+
+Изначально в `CharacterClaimInfo` лежал только `UserIdentification PlayerId`. Практика показала,
+что этого мало: когда в проекте не настроено поле-имя, **имя персонажа записывается по имени
+игрока** (`SaveToCharacterAndClaimStrategy`), то есть отображаемое имя нужно не для показа, а для
+доменной операции. Протаскивать его мимо агрегата отдельным параметром — значит завести ещё один
+канал данных о персонаже помимо `CharacterInfo`, ровно от чего этот ADR и уходит.
+
+Поэтому `PlayerId` заменён на `UserInfoHeader Player` (сам `PlayerId` остался производным
+свойством, так что потребители не изменились). Цена — один join к `User` за пять колонок имени
+и email в проекции загрузчика, без N+1. Граница остаётся прежней: **имя — да, контакты,
+телефон, соцсети и аватар — нет.**
 
 ### 5. Загрузчик
 
@@ -264,7 +277,7 @@ public interface ICharacterInfoRepository
 | `UgClaim(Claim, FeePaid)` | `CharacterClaimInfo` целиком | нет |
 | `AccessArgumentsFactory.Create(UgDto, …)` | `ApprovedClaim?.PlayerId`, `IsPublic` | нет |
 | `BusyStatusExtensions.GetBusyStatus` ×3 | `CharacterTypeInfo`, `ApprovedClaimId is not null`, `HasActiveClaims` | нет |
-| `UnifiedGrid/ItemBuilder` | `PlayerId`, `Status` / `DenialStatus`, `CreateDate`, `CheckInDate`, `ResponsibleMasterId`, финансы, `Last*CommentAt` ×3 | имя игрока — bulk `IUserRepository` |
+| `UnifiedGrid/ItemBuilder` | `PlayerId`, `Status` / `DenialStatus`, `CreateDate`, `CheckInDate`, `ResponsibleMasterId`, финансы, `Last*CommentAt` ×3, `Player` | нет |
 | `FinanceExtensions.CalculateClaimBalance` | `FeePaid`, `CurrentFee`, `PreferentialFeeUser`, `Fields`, `AccommodationFee`, `ProjectInfo.ProjectFinanceSettings` | **была дырка**: расписание взносов в `ProjectFinanceSettings` отсутствовало, добавлено (см. «Статус»). Попутно уходит мутирующий кеш `Claim.FieldsFee` |
 | `CharacterView` | `Id`, `UpdatedAt`, `IsActive`, `IsPublic`, `InGame`, `CharacterTypeInfo`, `ApprovedClaim`, `Claims`, `DirectGroups`, `CharacterFields`, `CharacterName`, `Description` | `GroupHeader.ParentGroupIds` — уже в `ProjectInfo.Groups` |
 | `ProjectRoleGridViewModelBuilder` | всё выше + `HidePlayerForCharacter`, `ActiveClaimsCount`, `IntrestingGroupsForDisplay`, `GetFieldLayers` | контакты игрока — bulk (это улучшает ADR011) |

--- a/src/JoinRpg.Dal.Impl.Tests/CharacterInfoMapperTest.cs
+++ b/src/JoinRpg.Dal.Impl.Tests/CharacterInfoMapperTest.cs
@@ -76,6 +76,11 @@ public class CharacterInfoMapperTest
     private static CharacterInfoClaimRow MakeClaimRow(
         int claimId = 1,
         int playerUserId = 1,
+        string? playerPrefferedName = null,
+        string? playerBornName = null,
+        string? playerSurName = null,
+        string? playerFatherName = null,
+        string playerEmail = "player@example.com",
         ClaimStatus claimStatus = ClaimStatus.AddedByUser,
         ClaimDenialReason? claimDenialStatus = null,
         int responsibleMasterUserId = 2,
@@ -94,6 +99,11 @@ public class CharacterInfoMapperTest
         {
             ClaimId = claimId,
             PlayerUserId = playerUserId,
+            PlayerPrefferedName = playerPrefferedName,
+            PlayerBornName = playerBornName,
+            PlayerSurName = playerSurName,
+            PlayerFatherName = playerFatherName,
+            PlayerEmail = playerEmail,
             ClaimStatus = claimStatus,
             ClaimDenialStatus = claimDenialStatus,
             ResponsibleMasterUserId = responsibleMasterUserId,
@@ -386,5 +396,71 @@ public class CharacterInfoMapperTest
         claim.CreateDate.ShouldBe(createDate);
         claim.LastUpdateDateTime.ShouldBe(lastUpdate);
         claim.CheckInDate.ShouldBe(checkIn);
+    }
+
+    // 9в. Игрок заявки: отображаемое имя собирается из тех же частей, что и везде в проекте.
+
+    [Fact]
+    public void Map_ClaimPlayer_ShouldPreferPrefferedName()
+    {
+        var row = MakeRow(claims:
+        [
+            MakeClaimRow(
+                playerUserId: 42,
+                playerPrefferedName: "Лёха",
+                playerBornName: "Алексей",
+                playerSurName: "Иванов",
+                playerEmail: "alexey@example.com"),
+        ]);
+
+        var player = CharacterInfoMapper.Map(row, ProjectInfo).Claims.Single().Player;
+
+        player.UserId.ShouldBe(new UserIdentification(42));
+        player.DisplayName.DisplayName.ShouldBe("Лёха");
+        player.DisplayName.FullName.ShouldBe("Алексей Иванов");
+    }
+
+    [Fact]
+    public void Map_ClaimPlayerWithoutPrefferedName_ShouldFallBackToFullName()
+    {
+        var row = MakeRow(claims:
+        [
+            MakeClaimRow(playerBornName: "Алексей", playerSurName: "Иванов"),
+        ]);
+
+        CharacterInfoMapper.Map(row, ProjectInfo).Claims.Single()
+            .Player.DisplayName.DisplayName.ShouldBe("Алексей Иванов");
+    }
+
+    [Fact]
+    public void Map_ClaimPlayerWithoutAnyName_ShouldFallBackToEmailUserPart()
+    {
+        // Регистрация не требует имени, поэтому пустое имя — обычный случай, а не крайний.
+        var row = MakeRow(claims: [MakeClaimRow(playerEmail: "alexey@example.com")]);
+
+        CharacterInfoMapper.Map(row, ProjectInfo).Claims.Single()
+            .Player.DisplayName.DisplayName.ShouldBe("alexey");
+    }
+
+    [Fact]
+    public void Map_ClaimPlayer_ShouldMatchEntityDisplayName()
+    {
+        // Страж от перепутанных колонок: маппер должен дать ровно то же, что общая сборка имени
+        // из сущности. Иначе имя персонажа, записанное по игроку, разойдётся с остальным сайтом.
+        var user = _mock.Player;
+
+        var row = MakeRow(claims:
+        [
+            MakeClaimRow(
+                playerUserId: user.UserId,
+                playerPrefferedName: user.PrefferedName,
+                playerBornName: user.BornName,
+                playerSurName: user.SurName,
+                playerFatherName: user.FatherName,
+                playerEmail: user.Email),
+        ]);
+
+        CharacterInfoMapper.Map(row, ProjectInfo).Claims.Single()
+            .Player.DisplayName.ShouldBe(user.ExtractDisplayName());
     }
 }

--- a/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoMapper.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoMapper.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes.Users;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
 
@@ -44,7 +45,15 @@ internal static class CharacterInfoMapper
     private static CharacterClaimInfo MapClaim(CharacterInfoClaimRow row, ProjectInfo projectInfo)
         => new(
             new ClaimIdentification(projectInfo.ProjectId, row.ClaimId),
-            new UserIdentification(row.PlayerUserId),
+            new UserInfoHeader(
+                new UserIdentification(row.PlayerUserId),
+                new UserDisplayName(
+                    new UserFullName(
+                        PrefferedName.FromOptional(row.PlayerPrefferedName),
+                        BornName.FromOptional(row.PlayerBornName),
+                        SurName.FromOptional(row.PlayerSurName),
+                        FatherName.FromOptional(row.PlayerFatherName)),
+                    new Email(row.PlayerEmail))),
             row.ClaimStatus,
             row.ClaimDenialStatus,
             new UserIdentification(row.ResponsibleMasterUserId),

--- a/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoRepository.cs
@@ -90,6 +90,13 @@ internal class CharacterInfoRepository(MyDbContext ctx, IProjectMetadataReposito
                 {
                     ClaimId = claim.ClaimId,
                     PlayerUserId = claim.PlayerUserId,
+                    // Один join к User на всю выборку, без N+1: только то, из чего складывается
+                    // отображаемое имя. Контакты и соцсети сюда не тянем (ADR011).
+                    PlayerPrefferedName = claim.Player.PrefferedName,
+                    PlayerBornName = claim.Player.BornName,
+                    PlayerSurName = claim.Player.SurName,
+                    PlayerFatherName = claim.Player.FatherName,
+                    PlayerEmail = claim.Player.Email,
                     ClaimStatus = claim.ClaimStatus,
                     ClaimDenialStatus = claim.ClaimDenialStatus,
                     ResponsibleMasterUserId = claim.ResponsibleMasterUserId,

--- a/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoRows.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/CharacterInfoRows.cs
@@ -40,6 +40,15 @@ internal sealed class CharacterInfoClaimRow
 {
     public required int ClaimId { get; init; }
     public required int PlayerUserId { get; init; }
+
+    // Части отображаемого имени игрока. Плоско, а не объектом: собрать UserDisplayName внутри
+    // EF6-проекции нельзя, сборка живёт в маппере. Образец — ClaimsRepositoryImpl.
+    public required string? PlayerPrefferedName { get; init; }
+    public required string? PlayerBornName { get; init; }
+    public required string? PlayerSurName { get; init; }
+    public required string? PlayerFatherName { get; init; }
+    public required string PlayerEmail { get; init; }
+
     public required ClaimStatus ClaimStatus { get; init; }
     public required ClaimDenialReason? ClaimDenialStatus { get; init; }
     public required int ResponsibleMasterUserId { get; init; }

--- a/src/JoinRpg.Domain.Test/ClaimBalanceOverCharacterInfoTest.cs
+++ b/src/JoinRpg.Domain.Test/ClaimBalanceOverCharacterInfoTest.cs
@@ -118,7 +118,7 @@ public class ClaimBalanceOverCharacterInfoTest
 
         var claim = new CharacterClaimInfo(
             claimId,
-            new UserIdentification(mock.Player.UserId),
+            mock.Player.ToUserInfoHeader(),
             ClaimStatus.Approved,
             DenialStatus: null,
             ResponsibleMasterId: new UserIdentification(mock.Master.UserId),

--- a/src/JoinRpg.DomainTypes.Test/Characters/CharacterInfoTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/Characters/CharacterInfoTest.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Common.PrimitiveTypes.Users;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.ProjectMetadata;
@@ -441,6 +442,9 @@ public class CharacterInfoTest
             new DateTime(2024, 1, 2),
             DefaultMasterId);
 
+    private static UserInfoHeader MakePlayer(UserIdentification userId)
+        => new(userId, new UserDisplayName($"Игрок{userId.Value}", null));
+
     private static CharacterClaimInfo MakeClaim(
         ProjectInfo projectInfo,
         int claimId,
@@ -450,7 +454,7 @@ public class CharacterInfoTest
         Dictionary<int, string>? fields = null)
         => new(
             new ClaimIdentification(ProjectId, claimId),
-            playerId ?? PlayerId,
+            MakePlayer(playerId ?? PlayerId),
             status,
             DenialStatus: null,
             responsibleMasterId ?? DefaultMasterId,

--- a/src/JoinRpg.DomainTypes/Characters/Claims/CharacterClaimInfo.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/CharacterClaimInfo.cs
@@ -1,3 +1,5 @@
+using JoinRpg.Common.PrimitiveTypes.Users;
+
 namespace JoinRpg.DomainTypes.Characters.Claims;
 
 /// <summary>
@@ -5,7 +7,12 @@ namespace JoinRpg.DomainTypes.Characters.Claims;
 /// Несёт ровно то, что нужно гридам, подсчёту проблем и расчёту баланса; полных данных о
 /// комментариях (сами <c>Comment</c> / <c>CommentDiscussion</c>) и о сюжетах здесь нет.
 /// </summary>
-/// <param name="PlayerId">Игрок, подавший заявку.</param>
+/// <param name="Player">
+/// Игрок, подавший заявку, вместе с отображаемым именем. Имя входит в агрегат, потому что по нему
+/// именуется персонаж, когда в проекте не настроено поле-имя; остальной профиль (контакты, аватар,
+/// соцсети) сюда по-прежнему не входит — он живёт своей жизнью и грузится через
+/// <c>IUserRepository</c>.
+/// </param>
 /// <param name="DenialStatus">
 /// Причина отказа. Показывать её можно не всем — фильтруется снаружи по
 /// <see cref="AccessArguments.CanViewDenialStatus"/>.
@@ -20,7 +27,7 @@ namespace JoinRpg.DomainTypes.Characters.Claims;
 /// </param>
 public record class CharacterClaimInfo(
     ClaimIdentification ClaimId,
-    UserIdentification PlayerId,
+    UserInfoHeader Player,
     ClaimStatus Status,
     ClaimDenialReason? DenialStatus,
     UserIdentification ResponsibleMasterId,
@@ -36,6 +43,9 @@ public record class CharacterClaimInfo(
     int AccommodationFee,
     FieldLayerContainer Fields)
 {
+    /// <summary>Игрок, подавший заявку.</summary>
+    public UserIdentification PlayerId => Player.UserId;
+
     /// <summary>Заявка утверждена (в том числе если игрок уже зарегистрирован на игре).</summary>
     public bool IsApproved => Status is ClaimStatus.Approved or ClaimStatus.CheckedIn;
 


### PR DESCRIPTION
## Что сделано

Первый из трёх шагов миграции `FieldSaveStrategyBase` на `CharacterInfo` (ADR013). Самостоятельный: ничего кроме агрегата не трогает.

`CharacterClaimInfo` несла об игроке только `UserIdentification`. Этого не хватает: когда в проекте не настроено поле-имя, **имя персонажа записывается по имени игрока** (`SaveToCharacterAndClaimStrategy`), то есть отображаемое имя нужно доменной операции, а не показу. Протаскивать его отдельным параметром мимо агрегата — значит завести второй канал данных о персонаже, ровно от чего ADR013 и уходит.

- `UserIdentification PlayerId` → `UserInfoHeader Player`; `PlayerId` остался производным свойством, поэтому **ни один потребитель агрегата не изменился** — правились только места построения (три, все в тестах).
- В проекцию `CharacterInfoRepository` добавлен join к `User` за пятью колонками имени и email, сборка `UserDisplayName` — в маппере. Образец — `ClaimsRepositoryImpl.cs:169-185`; N+1 нет.
- В `docs/adr013-character-info.md` уточнена граница: имя игрока входит в агрегат, контакты, телефон, соцсети и аватар — по-прежнему нет.

## Проверка

Четыре новых теста в `CharacterInfoMapperTest`: приоритет предпочитаемого имени, откат к полному имени, откат к части email до `@` (регистрация имени не требует, так что это обычный случай), и страж от перепутанных колонок — результат маппера сверяется с общей сборкой имени из сущности.

`dotnet build`, `dotnet format --verify-no-changes --severity error` и полный `dotnet test` чистые (Dal.Impl.Tests 71, DomainTypes.Test 430, Domain.Test 246, падений нигде нет).

## Чего здесь нет

Сами стратегии сохранения полей не тронуты — это следующие два PR: сначала вынести из них запись в возвращаемый результат, затем перевести чтение на `CharacterInfo`.

Generated with [Claude Code](https://claude.ai/code)