### PR TITLE
feat: обязательный PKCE и refresh token в OAuth-сервере IdPortal

### DIFF
--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthClientService.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthClientService.cs
@@ -51,11 +51,13 @@ internal class OAuthClientService(IOpenIddictApplicationManager manager) : IOAut
                 Permissions.Endpoints.Authorization,
                 Permissions.Endpoints.Token,
                 Permissions.GrantTypes.AuthorizationCode,
+                Permissions.GrantTypes.RefreshToken,
                 Permissions.ResponseTypes.Code,
                 Permissions.Prefixes.Scope + Scopes.OpenId,
                 Permissions.Prefixes.Scope + Scopes.Email,
                 Permissions.Prefixes.Scope + Scopes.Phone,
                 Permissions.Prefixes.Scope + Scopes.Profile,
+                Permissions.Prefixes.Scope + Scopes.OfflineAccess,
             }
         };
         foreach (var uri in redirectUris)

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
@@ -65,9 +65,13 @@ public static class OAuthServerRegistration
                     ;
 
 
-                options.AllowAuthorizationCodeFlow();
+                options.AllowAuthorizationCodeFlow()
+                       .RequireProofKeyForCodeExchange();
 
-                options.RegisterScopes(Scopes.OpenId, Scopes.Email, Scopes.Phone, Scopes.Profile);
+                options.AllowRefreshTokenFlow();
+                options.SetRefreshTokenLifetime(TimeSpan.FromDays(90));
+
+                options.RegisterScopes(Scopes.OpenId, Scopes.Email, Scopes.Phone, Scopes.Profile, Scopes.OfflineAccess);
 
                 if (certOptions?.Signing?.Base64 is { } signingBase64)
                 {

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Infrastructure/IdPortalApplicationFactory.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Infrastructure/IdPortalApplicationFactory.cs
@@ -112,10 +112,12 @@ public class IdPortalApplicationFactory : WebApplicationFactory<Program>, IAsync
                 Permissions.Endpoints.Authorization,
                 Permissions.Endpoints.Token,
                 Permissions.GrantTypes.AuthorizationCode,
+                Permissions.GrantTypes.RefreshToken,
                 Permissions.ResponseTypes.Code,
                 Permissions.Prefixes.Scope + Scopes.OpenId,
                 Permissions.Prefixes.Scope + Scopes.Email,
                 Permissions.Prefixes.Scope + Scopes.Profile,
+                Permissions.Prefixes.Scope + Scopes.OfflineAccess,
             },
         };
         descriptor.RedirectUris.Add(new Uri(TestRedirectUri));

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthServerScenario.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthServerScenario.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace JoinRpg.IdPortal.Test.Scenarios;
@@ -11,72 +12,12 @@ public class OAuthServerScenario(IdPortalApplicationFactory factory)
     public async Task AuthorizationCodeFlow_ReturnsAccessToken()
     {
         var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var (verifier, challenge) = CreatePkcePair();
 
-        // Step 1: GET /connect/authorize - should redirect to login
-        var authorizeUrl = BuildAuthorizeUrl();
-        var authorizeResponse = await client.GetAsync(authorizeUrl);
-
-        authorizeResponse.StatusCode.ShouldBe(HttpStatusCode.Found);
-        var loginRedirect = authorizeResponse.Headers.Location?.ToString();
-        loginRedirect.ShouldNotBeNull();
-        loginRedirect.ShouldContain("Login");
-
-        // Step 2: GET /Account/Login
-        var loginPageResponse = await client.GetAsync(loginRedirect);
-        loginPageResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
-
-        // Step 3: POST login credentials to the form action URL (which preserves ReturnUrl)
-        var loginDoc = await loginPageResponse.AsHtmlDocument();
-        var loginFields = loginDoc.GetFormFields();
-        loginFields["Input.Email"] = IdPortalApplicationFactory.TestUserEmail;
-        loginFields["Input.Password"] = IdPortalApplicationFactory.TestUserPassword;
-
-        var loginResponse = await client.PostAsync(loginDoc.GetFormAction(loginRedirect), new FormUrlEncodedContent(loginFields!));
-        loginResponse.StatusCode.ShouldBe(HttpStatusCode.Found);
-
-        // Step 4: Follow redirect back to /connect/authorize
-        var afterLoginRedirect = loginResponse.Headers.Location?.ToString();
-        afterLoginRedirect.ShouldNotBeNull();
-
-        // Follow redirects until we get the code (may be multiple redirects)
-        string? code = null;
-        var maxRedirects = 5;
-        var currentUrl = afterLoginRedirect;
-        while (maxRedirects-- > 0 && code is null)
-        {
-            var redirectResponse = await client.GetAsync(currentUrl);
-            if (redirectResponse.StatusCode == HttpStatusCode.Found)
-            {
-                var nextLocation = redirectResponse.Headers.Location?.ToString();
-                nextLocation.ShouldNotBeNull();
-
-                if (nextLocation.StartsWith(IdPortalApplicationFactory.TestRedirectUri, StringComparison.OrdinalIgnoreCase))
-                {
-                    var codeUri = new Uri(nextLocation);
-                    var queryParams = System.Web.HttpUtility.ParseQueryString(codeUri.Query);
-                    code = queryParams["code"];
-                    break;
-                }
-                currentUrl = nextLocation;
-            }
-            else
-            {
-                break;
-            }
-        }
-
+        var code = (await RunAuthorizationCodeStepsAsync(client, challenge))?["code"];
         code.ShouldNotBeNull("Authorization code should be in redirect to callback URI");
 
-        // Step 5: Exchange code for token
-        var tokenResponse = await client.PostAsync("/connect/token", new FormUrlEncodedContent(
-        [
-            new KeyValuePair<string?, string?>("grant_type", "authorization_code"),
-            new KeyValuePair<string?, string?>("code", code),
-            new KeyValuePair<string?, string?>("redirect_uri", IdPortalApplicationFactory.TestRedirectUri),
-            new KeyValuePair<string?, string?>("client_id", IdPortalApplicationFactory.TestClientId),
-            new KeyValuePair<string?, string?>("client_secret", IdPortalApplicationFactory.TestClientSecret),
-        ]));
-
+        var tokenResponse = await ExchangeCodeForTokenAsync(client, code, verifier);
         tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<Dictionary<string, object?>>();
@@ -84,6 +25,49 @@ public class OAuthServerScenario(IdPortalApplicationFactory factory)
         tokenJson.ShouldContainKey("access_token");
         tokenJson.ShouldContainKey("token_type");
         tokenJson["token_type"]!.ToString()!.ToLowerInvariant().ShouldBe("bearer");
+    }
+
+    [Fact]
+    public async Task AuthorizationCodeFlow_WithoutPkce_IsRejected()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        // Required PKCE is validated by OpenIddict before our AuthorizeMethod runs at all -
+        // the request is rejected with 400 directly, even before the login redirect.
+        var authorizeResponse = await client.GetAsync(BuildAuthorizeUrl(codeChallenge: null, scope: "openid email profile"));
+
+        authorizeResponse.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var body = await authorizeResponse.Content.ReadAsStringAsync();
+        body.ShouldContain("invalid_request");
+    }
+
+    [Fact]
+    public async Task RefreshTokenFlow_ReturnsNewAccessToken()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var (verifier, challenge) = CreatePkcePair();
+
+        var code = (await RunAuthorizationCodeStepsAsync(client, challenge, scope: "openid email offline_access"))?["code"];
+        code.ShouldNotBeNull();
+
+        var tokenResponse = await ExchangeCodeForTokenAsync(client, code, verifier);
+        tokenResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var tokenJson = await tokenResponse.Content.ReadFromJsonAsync<Dictionary<string, object?>>();
+        var refreshToken = tokenJson?["refresh_token"]?.ToString();
+        refreshToken.ShouldNotBeNull("Requesting offline_access should issue a refresh token");
+
+        var refreshResponse = await client.PostAsync("/connect/token", new FormUrlEncodedContent(
+        [
+            new KeyValuePair<string?, string?>("grant_type", "refresh_token"),
+            new KeyValuePair<string?, string?>("refresh_token", refreshToken),
+            new KeyValuePair<string?, string?>("client_id", IdPortalApplicationFactory.TestClientId),
+            new KeyValuePair<string?, string?>("client_secret", IdPortalApplicationFactory.TestClientSecret),
+        ]));
+
+        refreshResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var refreshJson = await refreshResponse.Content.ReadFromJsonAsync<Dictionary<string, object?>>();
+        refreshJson.ShouldNotBeNull();
+        refreshJson.ShouldContainKey("access_token");
     }
 
     [Fact]
@@ -106,20 +90,40 @@ public class OAuthServerScenario(IdPortalApplicationFactory factory)
         userInfo["email"]!.ToString().ShouldBe(IdPortalApplicationFactory.TestUserEmail);
     }
 
-    private string BuildAuthorizeUrl() =>
+    private static (string Verifier, string Challenge) CreatePkcePair()
+    {
+        var verifier = Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+        var challenge = Base64UrlEncode(SHA256.HashData(System.Text.Encoding.ASCII.GetBytes(verifier)));
+        return (verifier, challenge);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static string BuildAuthorizeUrl(string? codeChallenge, string scope) =>
         $"/connect/authorize?client_id={IdPortalApplicationFactory.TestClientId}" +
         $"&response_type=code" +
-        $"&scope=openid%20email%20profile" +
-        $"&redirect_uri={Uri.EscapeDataString(IdPortalApplicationFactory.TestRedirectUri)}";
+        $"&scope={Uri.EscapeDataString(scope)}" +
+        $"&redirect_uri={Uri.EscapeDataString(IdPortalApplicationFactory.TestRedirectUri)}" +
+        (codeChallenge is null ? "" : $"&code_challenge={Uri.EscapeDataString(codeChallenge)}&code_challenge_method=S256");
 
-    private async Task<string?> GetAccessTokenAsync()
+    private static Task<HttpResponseMessage> ExchangeCodeForTokenAsync(HttpClient client, string? code, string? codeVerifier) =>
+        client.PostAsync("/connect/token", new FormUrlEncodedContent(
+        [
+            new KeyValuePair<string?, string?>("grant_type", "authorization_code"),
+            new KeyValuePair<string?, string?>("code", code),
+            new KeyValuePair<string?, string?>("redirect_uri", IdPortalApplicationFactory.TestRedirectUri),
+            new KeyValuePair<string?, string?>("client_id", IdPortalApplicationFactory.TestClientId),
+            new KeyValuePair<string?, string?>("client_secret", IdPortalApplicationFactory.TestClientSecret),
+            .. codeVerifier is null ? [] : new[] { new KeyValuePair<string?, string?>("code_verifier", codeVerifier) },
+        ]));
+
+    /// Drives GET /connect/authorize through login and follows redirects up to the callback URI,
+    /// returning its query string (either "code"+"state" on success, or "error" on rejection).
+    private static async Task<System.Collections.Specialized.NameValueCollection?> RunAuthorizationCodeStepsAsync(HttpClient client, string? codeChallenge, string scope = "openid email profile")
     {
-        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
-        var authorizeUrl = BuildAuthorizeUrl();
-
-        var authorizeResponse = await client.GetAsync(authorizeUrl);
+        var authorizeResponse = await client.GetAsync(BuildAuthorizeUrl(codeChallenge, scope));
         var loginRedirect = authorizeResponse.Headers.Location?.ToString();
-
         if (loginRedirect is null)
         {
             return null;
@@ -133,54 +137,50 @@ public class OAuthServerScenario(IdPortalApplicationFactory factory)
 
         var loginResponse = await client.PostAsync(loginDoc.GetFormAction(loginRedirect), new FormUrlEncodedContent(loginFields!));
         var afterLoginRedirect = loginResponse.Headers.Location?.ToString();
-
         if (afterLoginRedirect is null)
         {
             return null;
         }
 
-        string? code = null;
         var maxRedirects = 5;
         var currentUrl = afterLoginRedirect;
-        while (maxRedirects-- > 0 && code is null)
+        while (maxRedirects-- > 0)
         {
             var redirectResponse = await client.GetAsync(currentUrl);
-            if (redirectResponse.StatusCode == HttpStatusCode.Found)
-            {
-                var nextLocation = redirectResponse.Headers.Location?.ToString();
-                if (nextLocation is null)
-                {
-                    break;
-                }
-
-                if (nextLocation.StartsWith(IdPortalApplicationFactory.TestRedirectUri, StringComparison.OrdinalIgnoreCase))
-                {
-                    var codeUri = new Uri(nextLocation);
-                    code = System.Web.HttpUtility.ParseQueryString(codeUri.Query)["code"];
-                    break;
-                }
-                currentUrl = nextLocation;
-            }
-            else
+            if (redirectResponse.StatusCode != HttpStatusCode.Found)
             {
                 break;
             }
+
+            var nextLocation = redirectResponse.Headers.Location?.ToString();
+            if (nextLocation is null)
+            {
+                break;
+            }
+
+            if (nextLocation.StartsWith(IdPortalApplicationFactory.TestRedirectUri, StringComparison.OrdinalIgnoreCase))
+            {
+                var callbackUri = new Uri(nextLocation);
+                return System.Web.HttpUtility.ParseQueryString(callbackUri.Query);
+            }
+            currentUrl = nextLocation;
         }
 
+        return null;
+    }
+
+    private async Task<string?> GetAccessTokenAsync()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var (verifier, challenge) = CreatePkcePair();
+
+        var code = (await RunAuthorizationCodeStepsAsync(client, challenge))?["code"];
         if (code is null)
         {
             return null;
         }
 
-        var tokenResponse = await client.PostAsync("/connect/token", new FormUrlEncodedContent(
-        [
-            new KeyValuePair<string?, string?>("grant_type", "authorization_code"),
-            new KeyValuePair<string?, string?>("code", code),
-            new KeyValuePair<string?, string?>("redirect_uri", IdPortalApplicationFactory.TestRedirectUri),
-            new KeyValuePair<string?, string?>("client_id", IdPortalApplicationFactory.TestClientId),
-            new KeyValuePair<string?, string?>("client_secret", IdPortalApplicationFactory.TestClientSecret),
-        ]));
-
+        var tokenResponse = await ExchangeCodeForTokenAsync(client, code, verifier);
         if (!tokenResponse.IsSuccessStatusCode)
         {
             return null;


### PR DESCRIPTION
## Что сделано

Первый шаг из [ADR012](docs/adr012-llm-mcp-access.md) (авторизация для MCP/LLM-клиентов): доводим OAuth-сервер IdPortal до требований OAuth 2.1.

- PKCE (S256) обязателен для `authorization_code` (`RequireProofKeyForCodeExchange()`).
- Разрешён refresh token flow (`AllowRefreshTokenFlow()`, срок жизни 90 дней), scope `offline_access` зарегистрирован.
- Существующие клиенты (создаваемые через `OAuthClientService`/тестовую фабрику) получили permission на `refresh_token` и `offline_access` — это не меняет их поведение, пока клиент сам не запросит `offline_access`.

## Проверка совместимости с прод-клиентами

Так как `RequireProofKeyForCodeExchange()` — глобальная настройка, перед включением проверены исходники известных клиентов IdPortal:

- **bastilia-rating** ([bastilia-ru/bastilia-rating](https://github.com/bastilia-ru/bastilia-rating)) использует SDK `OpenIddict.Client`, который всегда отправляет PKCE для authorization code flow — не опция, встроенное поведение.
- **kogda-igra** ([joinrpg/kogda-igra](https://github.com/joinrpg/kogda-igra)) — самописный PHP-клиент, PKCE (S256) реализован явно.

Оба уже совместимы. `kogda-igra` не числится в закоммиченном `appsettings.json` — значит зарегистрирован отдельно (админка/деплой-конфиг); **перед выкладкой в прод стоит свериться со списком реальных `OpenIddictApplication` в БД IdPortal**, чтобы не пропустить других клиентов.

## Тесты

- `AuthorizationCodeFlow_ReturnsAccessToken` — обновлён, теперь проходит PKCE.
- `AuthorizationCodeFlow_WithoutPkce_IsRejected` — новый, подтверждает что запрос без `code_challenge` отклоняется на `/connect/authorize` с `invalid_request`.
- `RefreshTokenFlow_ReturnsNewAccessToken` — новый, полный цикл authorization_code → refresh_token.
- Остальные сценарии IdPortal (17/17) и юнит-тесты OAuthServer (9/9) — без регрессий.

## Test plan

- [x] `dotnet test src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer.Test` — 9/9
- [x] `dotnet test src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test` — 17/17 (1 skip, не связан с изменениями)
- [x] `dotnet format --verify-no-changes --severity error` — чисто

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NSH2mdKjwR1eTQdW4JAVig