### PR TITLE
fix: дружелюбное сообщение для OnlyOneApprovedClaimException

### DIFF
--- a/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
+++ b/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
@@ -33,6 +33,30 @@ public class JoinMvcControllerBaseTest
         logger.ErrorCount.ShouldBe(0);
     }
 
+    // Регрессия: OnlyOneApprovedClaimException (у игрока уже есть одобренная заявка, а проект
+    // допускает только одного персонажа на игрока — ожидаемая бизнес-ситуация) должна показываться
+    // понятным сообщением и не логироваться как ошибка, а не проваливаться в default-ветку
+    // с LogError и "Неожиданная ошибка". См. #4691.
+    [Fact]
+    public void AddModelException_OnlyOneApprovedClaimException_ShouldAddFriendlyErrorWithoutLoggingError()
+    {
+        var logger = new RecordingLogger();
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContext(logger),
+            },
+        };
+
+        controller.CallAddModelException(new OnlyOneApprovedClaimException());
+
+        controller.ModelState.IsValid.ShouldBeFalse();
+        var error = controller.ModelState[""]!.Errors.ShouldHaveSingleItem();
+        error.ErrorMessage.ShouldBe("Заявка не принята: у игрока уже есть одобренная заявка на другого персонажа в этом проекте");
+        logger.ErrorCount.ShouldBe(0);
+    }
+
     private static DefaultHttpContext CreateHttpContext(ILogger<JoinMvcControllerBase> logger)
     {
         var httpContext = new DefaultHttpContext

--- a/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
+++ b/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
@@ -70,6 +70,9 @@ public abstract class JoinMvcControllerBase : Controller
             case JoinRpgSlotLimitedException _:
                 ModelState.AddModelError("", "Не удалось принять заявку: свободные места на эту роль закончились");
                 return;
+            case OnlyOneApprovedClaimException _:
+                ModelState.AddModelError("", "Заявка не принята: у игрока уже есть одобренная заявка на другого персонажа в этом проекте");
+                return;
             default:
 
                 logger.LogError(exception, "Исключение при обработке запроса");


### PR DESCRIPTION
## Что сделано
- Добавлен `case OnlyOneApprovedClaimException` в `JoinMvcControllerBase.AddModelException` — по аналогии с фиксом #4667 для `JoinRpgSlotLimitedException`. Дружелюбное сообщение вместо провала в default-ветку с `LogError` и «Неожиданная ошибка».
- Добавлен regression-тест `AddModelException_OnlyOneApprovedClaimException_ShouldAddFriendlyErrorWithoutLoggingError`.

Closes #4691

Generated with [Claude Code](https://claude.ai/code)