### PR TITLE
fix: регистронезависимое сравнение Provider в UserInfoRepository

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
@@ -5,11 +5,25 @@ using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.Interfaces;
 using JoinRpg.DomainTypes.Users;
 using LinqKit;
+using Microsoft.Extensions.Logging;
 
 namespace JoinRpg.Dal.Impl.Repositories;
 
 internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubscribeRepository
 {
+    // "Google" — раньше был рабочим провайдером входа, сейчас отключён (не регистрируется
+    // в IdentityConfigurator), но старые привязки в UserExternalLogins остались и это ожидаемо,
+    // в отличие от прочих нераспознанных значений Provider.
+    private const string LegacyGoogleProvider = "Google";
+
+    private static readonly string[] KnownExternalLoginProviders =
+    [
+        UserExternalLogin.TelegramProvider,
+        UserExternalLogin.VkProvider,
+        LegacyGoogleProvider,
+    ];
+
+
     public Task<User> GetById(int id) => ctx.UserSet.FindAsync(id) ?? throw new JoinRpgEntityNotFoundException(id, nameof(User));
     public Task<User> WithProfile(int userId)
     {
@@ -112,8 +126,15 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
         var results = await userQuery.ToListAsync();
 
         return [.. results.Select(result => {
-             var telegram = TelegramSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.TelegramProvider)?.Key, PrefferedName.FromOptional(result.Telegram));
-             var vk = VkSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => x.Provider == UserExternalLogin.VkProvider)?.Key, result.Vk, result.VkVerified);
+             var telegram = TelegramSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => string.Equals(x.Provider, UserExternalLogin.TelegramProvider, StringComparison.OrdinalIgnoreCase))?.Key, PrefferedName.FromOptional(result.Telegram));
+             var vk = VkSocialLink.FromUserData(result.ExternalLogins.SingleOrDefault(x => string.Equals(x.Provider, UserExternalLogin.VkProvider, StringComparison.OrdinalIgnoreCase))?.Key, result.Vk, result.VkVerified);
+
+             foreach (var unrecognized in result.ExternalLogins.Where(x => !KnownExternalLoginProviders.Any(known => string.Equals(known, x.Provider, StringComparison.OrdinalIgnoreCase))))
+             {
+                 ctx.Logger?.LogWarning(
+                     "У пользователя {userId} обнаружена внешняя привязка с нераспознанным провайдером {provider} (UserExternalLoginId={loginId})",
+                     result.UserId, unrecognized.Provider, unrecognized.UserExternalLoginId);
+             }
 
         var userFullName =
             new UserFullName(


### PR DESCRIPTION
## Что сделано
Найдено при расследовании инцидента: пользователь входил через ВК в свой профиль, но в личном кабинете видел соцсеть как непривязанную, а попытка привязать заново падала с «привязан к другому аккаунту». Админ в карточке пользователя тоже не видел ВК.

Причина — историческая вилка в данных `UserExternalLogins.Provider`: до 2018 привязка ВК писалась OWIN-библиотекой со схемой `"VKontakte"` (капитал K), после перехода на ASP.NET Core Identity — `"Vkontakte"` (см. `UserExternalLogin.VkProvider`). SQL Server сравнивает строки без учёта регистра, поэтому вход через ВК по старым записям продолжал работать через EF-запросы, а регистрозависимое сравнение в памяти (`LINQ-to-Objects` в `UserInfoRepository`) — нет.

- Сравнение `Provider` для Telegram и VK в `UserInfoRepository` теперь регистронезависимое (`StringComparison.OrdinalIgnoreCase`), как уже было сделано в `MyUserStore.RemoveLoginAsync`.
- Добавлено предупреждение в лог, если у пользователя встретился `Provider`, не входящий в список известных (`Vkontakte`/`telegram`/`Google`) — `Google` учтён отдельно как отключённый, но не забытый провайдер (раньше был рабочим способом входа, сейчас не регистрируется в `IdentityConfigurator`, но старые привязки в БД остались, и это ожидаемо).

Существующие данные с `Provider = 'VKontakte'` нормализуются отдельным скриптом на проде (не входит в этот PR).

## Test plan
- [x] `dotnet build` без ошибок
- [x] `dotnet format --verify-no-changes --severity error` на изменённый файл
- [ ] Юнит/интеграционный тест на регрессию не добавлен — `UserInfoRepository` сейчас не покрыт тестами такого уровня (нет готовой инфраструктуры для тестирования EF6-репозиториев с реальным контекстом); обсуждается отдельно