### PR TITLE
fix: не считать привязку соцсети к себе же ошибкой в LinkLoginCallback

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -142,6 +142,18 @@ public class ManageController(
             if (result.Errors.Any(i => i.Code == "LoginAlreadyAssociated"))
             {
                 var existingOwner = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
+
+                // ASP.NET Core Identity считает LoginAlreadyAssociated ошибкой даже когда
+                // привязка уже принадлежит этому же пользователю (не проверяет existingOwner
+                // на совпадение с user). Для нас это не ошибка, а способ добить профиль данными
+                // из соцсети — например, дозаполнить Extra.Vk/VkVerified для привязок, сделанных
+                // до перехода на текущий стек авторизации.
+                if (existingOwner?.Id == user.Id)
+                {
+                    await externalLoginProfileExtractor.TryExtractProfile(user, loginInfo);
+                    return RedirectToAction("SetupProfile");
+                }
+
                 logger.LogInformation("Пользователь {userId} пытался привязать {loginProvider} / {loginProviderKey}, но этот внешний логин уже привязан к аккаунту {existingOwnerId}",
                     userId, loginInfo.LoginProvider, loginInfo.ProviderKey, existingOwner?.Id);
                 return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked });

--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -150,6 +150,8 @@ public class ManageController(
                 // до перехода на текущий стек авторизации.
                 if (existingOwner?.Id == user.Id)
                 {
+                    logger.LogInformation("Пользователь {userId} повторно привязал уже свой {loginProvider} / {loginProviderKey} — дозаполняем профиль",
+                        userId, loginInfo.LoginProvider, loginInfo.ProviderKey);
                     await externalLoginProfileExtractor.TryExtractProfile(user, loginInfo);
                     return RedirectToAction("SetupProfile");
                 }


### PR DESCRIPTION
## Что сделано

Продолжение расследования из #4698. У пользователя, чья привязка ВК — legacy-запись (сделана до перехода на текущий стек ASP.NET Core Identity), в профиле никогда не заполняются `UserExtra.Vk`/`VkVerified`, и это невозможно починить через UI кнопкой «Привязать ВК».

Причина: `ManageController.LinkLoginCallback` вызывает `userManager.AddLoginAsync(user, loginInfo)`. Стандартная реализация ASP.NET Core Identity перед добавлением ищет существующего владельца этой привязки (`FindByLoginAsync`) и при любом найденном владельце возвращает `LoginAlreadyAssociated` — **не проверяя, что найденный владелец это тот же самый пользователь**. В итоге:

- пользователь видит «Данная соцсеть уже привязана к другому аккаунту», хотя привязана она к его собственному аккаунту;
- код никогда не доходит до `ExternalLoginProfileExtractor.TryExtractProfile(...)`, которая единственная заполняет `Extra.Vk`/`VkVerified` — то есть дозаполнить профиль для таких пользователей через обычный UI-флоу принципиально нельзя.

Фикс: если `existingOwner.Id == user.Id` (привязка действительно принадлежит текущему пользователю), не считаем это ошибкой — вызываем `TryExtractProfile` и возвращаем обычный успех.

## Test plan
- [x] `dotnet build` без ошибок
- [x] `dotnet format --verify-no-changes --severity error` на изменённый файл
- [ ] Ручная проверка на проде на пользователе с legacy-привязкой ВК (после мерджа)