### PR TITLE
feat: показывать ссылку на конфликтующий аккаунт при ошибке привязки соцсети

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -158,7 +158,7 @@ public class ManageController(
 
                 logger.LogInformation("Пользователь {userId} пытался привязать {loginProvider} / {loginProviderKey}, но этот внешний логин уже привязан к аккаунту {existingOwnerId}",
                     userId, loginInfo.LoginProvider, loginInfo.ProviderKey, existingOwner?.Id);
-                return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked });
+                return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked, ConflictUserId = existingOwner?.Id });
             }
             logger.LogError("Unexpected error during linking user to another account: {loginError}", result.Errors.First().Code);
             return RedirectToAction("SetupProfile", new { Message = ManageMessageId.Error });
@@ -190,7 +190,7 @@ public class ManageController(
         if (u is not null)
         {
             logger.LogWarning("Телеграмм аккаунт {telegramUserId} уже был привязан к пользователю {userName}", telegramUserId, u.UserName);
-            return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked });
+            return RedirectToAction("SetupProfile", new { Message = ManageMessageId.SocialLoginAlreadyLinked, ConflictUserId = u.Id });
         }
 
 
@@ -202,7 +202,7 @@ public class ManageController(
     }
 
     [HttpGet]
-    public async Task<ActionResult> SetupProfile([FromServices] IOptions<TelegramLoginOptions> options, bool checkContactsMessage = false, ManageMessageId? message = null)
+    public async Task<ActionResult> SetupProfile([FromServices] IOptions<TelegramLoginOptions> options, bool checkContactsMessage = false, ManageMessageId? message = null, int? conflictUserId = null)
     {
         _ = await avatarService.EnsureAvatarPresent(currentUserAccessor.UserId);
 
@@ -238,6 +238,7 @@ public class ManageController(
             HasPassword = user.PasswordHash != null,
             Avatars = new UserAvatarListViewModel(user),
             Message = message,
+            ConflictingAccountUrl = conflictUserId is null ? null : Url.Action("Details", "User", new { userId = conflictUserId }),
             TelegramBotName = options.Value.BotName,
             PassportData = user.Extra?.PassportData ?? "",
             RegistrationAddress = user.Extra?.RegistrationAddress ?? "",

--- a/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
+++ b/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
@@ -21,6 +21,10 @@
             ManageMessageId.RemoveLoginSuccess => "Соцсеть отвязана",
             _ => "Неизвестная ошибка",
         })
+        @if (Model.Message == ManageMessageId.SocialLoginAlreadyLinked && Model.ConflictingAccountUrl != null)
+        {
+            <text>: <a href="@Model.ConflictingAccountUrl">@Model.ConflictingAccountUrl</a></text>
+        }
 </div>
 }
 

--- a/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
@@ -60,6 +60,7 @@ public class EditUserProfileViewModel
 
     public UserAvatarListViewModel Avatars { get; set; }
     public ManageMessageId? Message { get; set; }
+    public string? ConflictingAccountUrl { get; set; }
 
     [ReadOnly(true)]
     public string TelegramBotName { get; set; } = null!;


### PR DESCRIPTION
## Что сделано
- При ошибке «Данная соцсеть уже привязана к другому аккаунту» (обычный OAuth-логин и Telegram) теперь показывается ссылка на профиль конфликтующего аккаунта.
- `ManageController` передаёт `ConflictUserId` через редирект на `SetupProfile`, который строит ссылку на `/user/{id}`.

## Test plan
- [x] `dotnet build` без ошибок
- [x] `dotnet format --verify-no-changes` без замечаний
- [ ] Ручная проверка в браузере (не проверялось)

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125q7XvBgdVLFEBoKbaQeZh