### PR TITLE
fix: отдельная страница конфликта аккаунтов вместо Lockout при входе через соцсеть

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -388,7 +388,11 @@ public class AccountController(
                             var existingOwner = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
                             logger.LogWarning("Не удалось привязать {loginProvider} / {loginProviderKey} к аккаунту {userId} (email {email}), т.к. этот внешний логин уже привязан к аккаунту {existingOwnerId}",
                                 loginInfo.LoginProvider, loginInfo.ProviderKey, user.Id, email, existingOwner?.Id);
-                            return View("Lockout");
+                            return View("AccountConflict", new AccountConflictViewModel
+                            {
+                                LoginProviderDisplayName = loginInfo.ProviderDisplayName ?? loginInfo.LoginProvider,
+                                Email = email,
+                            });
                         }
 
                         logger.LogError("Неожиданная ошибка при привязке {loginProvider} / {loginProviderKey} к аккаунту {userId}: {loginResult}",

--- a/src/JoinRpg.Portal/Views/Account/AccountConflict.cshtml
+++ b/src/JoinRpg.Portal/Views/Account/AccountConflict.cshtml
@@ -1,0 +1,19 @@
+@model JoinRpg.Web.Models.AccountConflictViewModel
+@{
+    ViewBag.Title = "Конфликт аккаунтов";
+}
+
+<h2>@ViewBag.Title</h2>
+<div>
+    <p class="alert alert-warning">
+        Вы пытаетесь войти через <b>@Model.LoginProviderDisplayName</b>, но этот аккаунт @Model.LoginProviderDisplayName
+        уже привязан к <b>другому</b> аккаунту на joinrpg.ru — не к тому, что зарегистрирован на почту
+        <b>@Model.Email</b>.
+    </p>
+    <p>
+        Скорее всего, у вас на сайте случайно оказалось два разных аккаунта: один создан на эту почту,
+        а второй давно привязан к вашему @Model.LoginProviderDisplayName. Самостоятельно объединить их
+        нельзя — <a href="mailto:support@joinrpg.ru">обратитесь в техподдержку</a>, укажите оба email,
+        которыми вы пользуетесь на сайте, и мы разберёмся.
+    </p>
+</div>

--- a/src/JoinRpg.WebPortal.Models/UserProfile/AccountViewModels.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/AccountViewModels.cs
@@ -109,3 +109,9 @@ public class ForgotPasswordViewModel
     [Display(Name = "Email")]
     public string Email { get; set; }
 }
+
+public class AccountConflictViewModel
+{
+    public required string LoginProviderDisplayName { get; set; }
+    public required string Email { get; set; }
+}


### PR DESCRIPTION
## Что сделано
- При входе через внешний логин (VK/Google), когда провайдер найден по email на одном аккаунте, но сам внешний логин уже привязан к другому аккаунту (`LoginAlreadyAssociated`), раньше показывался generic `View("Lockout")` — пользователь видел «Locked out» без объяснения причины.
- Добавлена отдельная страница `AccountConflict` с понятным текстом: вы входите через VK/Google, который привязан к другому аккаунту, не к тому, что на этой почте — это конфликт аккаунтов, обратитесь в техподдержку.
- Остальные ветки (неожиданные ошибки `AddLoginAsync`) по-прежнему показывают `Lockout` — это действительно непредвиденные ошибки, не тот же случай.

## Контекст
Обнаружено при разборе реального инцидента: пользователь с двумя аккаунтами (один создан на email, второй давно привязан к его VK) при попытке входа через VK 9 раз подряд утыкался в Lockout, хотя проблема была именно в конфликте двух аккаунтов.

## Test plan
- [ ] `dotnet build` — собирается без ошибок
- [ ] Вручную воспроизвести сценарий (два аккаунта, VK привязан к другому) и проверить, что показывается новая страница с текстом

🤖 Generated with [Claude Code](https://claude.com/claude-code)