### PR TITLE
fix: разрешить отвязать неподтверждённый соцаккаунт

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -11,6 +11,7 @@ using JoinRpg.Web.Models;
 using JoinRpg.Web.Models.UserProfile;
 using JoinRpg.Web.UserProfile;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -32,12 +33,17 @@ public class ManageController(
 
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<ActionResult> RemoveLogin(string loginProvider, string providerKey)
+    public async Task<ActionResult> RemoveLogin(string loginProvider, string? providerKey)
     {
         var userId = currentUserAccessor.UserId;
         var user = await userManager.FindByIdAsync(userId.ToString());
         ManageMessageId? message;
-        var result = await userManager.RemoveLoginAsync(user, loginProvider, providerKey);
+        // Пустой providerKey означает, что настоящей привязки (ExternalLogin) нет — это
+        // legacy-контакт без подтверждения (см. UserLoginInfoViewModelBuilder), для него нечего
+        // отвязывать через RemoveLoginAsync, только очистить legacy-поле.
+        var result = string.IsNullOrEmpty(providerKey)
+            ? IdentityResult.Success
+            : await userManager.RemoveLoginAsync(user, loginProvider, providerKey);
         if (result.Succeeded)
         {
             await externalLoginProfileExtractor.CleanAfterLogin(user, loginProvider);

--- a/src/JoinRpg.Web.UserProfile/UserLoginInfoViewModelBuilder.cs
+++ b/src/JoinRpg.Web.UserProfile/UserLoginInfoViewModelBuilder.cs
@@ -28,13 +28,18 @@ public static class UserLoginInfoViewModelBuilder
             }
             else
             {
+                // Непровереннную привязку тоже можно удалить: если есть ExternalLogin (link.Id
+                // != null, например у VK, где верификация — отдельный legacy-флаг), удаляется
+                // он; если это только legacy pretty-name без ExternalLogin (link.Id == null),
+                // удаляется сам legacy-контакт (см. UserServiceImpl.RemoveVkFromProfile/
+                // RemoveTelegramFromProfile — они не требуют ExternalLogin).
                 return new UserLoginInfoViewModel()
                 {
                     AllowLink = link is null,
-                    AllowUnlink = false,
+                    AllowUnlink = link is not null,
                     IsOnlyLoginMethod = false,
                     LoginProvider = provider,
-                    ProviderKey = null,
+                    ProviderKey = link?.Id?.ToString(),
                     NeedToReLink = link is not null,
                     ProviderLink = link?.Link,
                 };

--- a/src/JoinRpg.WebPortal.Managers.Test/UserProfile/UserLoginInfoViewModelBuilderTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/UserProfile/UserLoginInfoViewModelBuilderTests.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.DomainTypes.Users;
 using JoinRpg.Web.UserProfile;
 
@@ -65,15 +64,34 @@ public class UserLoginInfoViewModelBuilderTests
     }
 
     [Fact]
-    public void GetSocialLogins_ProfileValuePresentButNotVerified_NeedsRelink()
+    public void GetSocialLogins_ProfileValuePresentButNotVerified_NeedsRelinkButCanBeUnlinked()
     {
+        // Непровереннный VK всё равно хранится как ExternalLogin (Id есть), значит его можно
+        // отвязать, не подтверждая — не только предложить повторную привязку.
         var user = BuildUserInfo(vk: new VkSocialLink(123, isVerified: false));
 
         var vk = user.GetSocialLogins().Single(x => x.LoginProvider == ProviderDescViewModel.Vk);
 
         vk.AllowLink.ShouldBeFalse();
-        vk.AllowUnlink.ShouldBeFalse();
+        vk.AllowUnlink.ShouldBeTrue();
         vk.NeedToReLink.ShouldBeTrue();
+        vk.ProviderKey.ShouldBe("123");
+    }
+
+    [Fact]
+    public void GetSocialLogins_LegacyProfileValueWithoutExternalLogin_NeedsRelinkButCanBeUnlinked()
+    {
+        // Только legacy-поле (PrettyName без числового Id) — ExternalLogin отсутствует, но
+        // сам legacy-контакт всё равно можно удалить (ProviderKey пуст — контроллер очищает
+        // legacy-поле напрямую, не трогая ExternalLogin).
+        var user = BuildUserInfo(vk: new VkSocialLink(null, new PrefferedName("durov")));
+
+        var vk = user.GetSocialLogins().Single(x => x.LoginProvider == ProviderDescViewModel.Vk);
+
+        vk.AllowLink.ShouldBeFalse();
+        vk.AllowUnlink.ShouldBeTrue();
+        vk.NeedToReLink.ShouldBeTrue();
+        vk.ProviderKey.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Что сделано
- Когда `UserLoginInfoViewModel.NeedToReLink == true`, теперь можно отвязать/удалить непровереннный соцаккаунт, а не только подтвердить его заново.
- Если привязка реально сохранена как `ExternalLogin` (например VK, где верификация — отдельный legacy-флаг), удаляется она.
- Если это чисто legacy pretty-name без `ExternalLogin`, контроллер `RemoveLogin` очищает только legacy-поле (`UserServiceImpl.RemoveVkFromProfile`/`RemoveTelegramFromProfile`), не вызывая `RemoveLoginAsync`.
- Добавлены/обновлены юнит-тесты в `UserLoginInfoViewModelBuilderTests`.

## Test plan
- [x] `dotnet test src/JoinRpg.WebPortal.Managers.Test --filter UserLoginInfoViewModelBuilderTests` — 7/7 passed
- [x] `dotnet build src/JoinRpg.Portal` — без ошибок
- [x] `dotnet format --verify-no-changes` на изменённых файлах — чисто

Generated with [Claude Code](https://claude.ai/code)