### PR TITLE
docs: уточнить, что --severity error не ловит IDE0005 в dotnet format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ dotnet format                                             # Применить �
 dotnet format --verify-no-changes --severity error        # Проверка (CI)
 ```
 
+`--severity error` не ловит diagnostics уровня warning — например, IDE0005 (неиспользуемые/лишние using, в т.ч. ставшие лишними из-за `GlobalUsings.cs`) в корневом `.editorconfig` намеренно понижен до `warning`. Чтобы реально проверить usings, запускать `dotnet format <проект>.csproj --verify-no-changes` без `--severity error` (или явно с `--severity warn`).
+
 ### Коммиты
 
 При создании коммита всегда открывать редактор, чтобы пользователь мог исправить сообщение:


### PR DESCRIPTION
## Что сделано

CLAUDE.md рекомендует `dotnet format --verify-no-changes --severity error` как способ проверки форматирования в CI. Это вводит в заблуждение: корневой `.editorconfig` намеренно понижает `dotnet_diagnostic.IDE0005.severity` до `warning` (комментарий: «требуется для работы reference trimmer»). IDE0005 — анализатор неиспользуемых/лишних using-директив (в т.ч. ставших лишними из-за `GlobalUsings.cs` проекта). Так как `--severity error` показывает только diagnostics уровня error и выше, эта команда молча пропускает файлы с реальными нарушениями IDE0005.

Проверено эмпирически: в `src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs` было два using-а, полностью дублирующих `GlobalUsings.cs` проекта (`JoinRpg.Common.PrimitiveTypes` и `Microsoft.AspNetCore.Identity`). `dotnet format <csproj> --verify-no-changes --severity error` завершался с кодом 0 (успех), а `dotnet format <csproj> --verify-no-changes` (без переопределения severity, т.е. по порогу из `.editorconfig`) корректно находил оба нарушения и завершался с кодом 2.

Добавлена короткая заметка под блоком команд, объясняющая это и указывающая правильный способ проверки usings.

## Test plan

- [x] Изменение только в CLAUDE.md — документация, кода не касается
- [x] Проверено визуально, что абзац читается естественно вместе с блоком команд

Generated with [Claude Code](https://claude.ai/code)