### PR TITLE
fix: логировать неудачное авто-принятие заявок

### DIFF
--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -904,14 +904,36 @@ internal class ClaimServiceImpl(
 
     private async Task AutoApproveClaimIfNeeded(Claim claim, ProjectInfo projectInfo)
     {
-        // Не принимаем автоматически заявки, если игрок не предоставил доступ к паспорту
-        if (claim.Project.Details.AutoAcceptClaims &&
-            (claim.PlayerAllowedSenstiveData || !projectInfo.ProfileRequirementSettings.SensitiveDataRequired))
+        if (!claim.Project.Details.AutoAcceptClaims)
         {
-            var responsibleMaster = await UserRepository.GetRequiredUserInfo(new UserIdentification(claim.ResponsibleMasterUserId));
-            impersonateAccessor.StartImpersonate(responsibleMaster.UserId, responsibleMaster.DisplayName, responsibleMaster.IsAdmin);
+            return;
+        }
+
+        var claimId = claim.GetId();
+
+        // Не принимаем автоматически заявки, если игрок не предоставил доступ к паспорту
+        if (!claim.PlayerAllowedSenstiveData && projectInfo.ProfileRequirementSettings.SensitiveDataRequired)
+        {
+            logger.LogInformation(
+                "Claim ({claimId}) was not auto-approved: sensitive data access is required but not granted by player",
+                claimId);
+            return;
+        }
+
+        var responsibleMaster = await UserRepository.GetRequiredUserInfo(new UserIdentification(claim.ResponsibleMasterUserId));
+        impersonateAccessor.StartImpersonate(responsibleMaster.UserId, responsibleMaster.DisplayName, responsibleMaster.IsAdmin);
+        try
+        {
             //TODO[Localize]
-            await ApproveByMaster(claim.GetId(), "Ваша заявка была принята автоматически");
+            await ApproveByMaster(claimId, "Ваша заявка была принята автоматически");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Claim ({claimId}) auto-approve failed", claimId);
+            throw;
+        }
+        finally
+        {
             impersonateAccessor.StopImpersonate();
         }
     }


### PR DESCRIPTION
## Что сделано
- `AutoApproveClaimIfNeeded` (`ClaimServiceImpl.cs`) теперь логирует случай, когда авто-принятие включено, но не сработало для конкретной заявки (не предоставлен доступ к чувствительным данным) — `LogInformation`.
- Логируется исключение из `ApproveByMaster` (например, `ClaimWrongStatusException`), которое раньше молча вылетало наружу без специфичного лога — `LogError`, исключение по-прежнему пробрасывается дальше.
- `impersonateAccessor.StopImpersonate()` перенесён в `finally`, чтобы не оставлять импресонацию активной при ошибке авто-принятия.

## Test plan
- `dotnet build src/JoinRpg.Services.Impl` — без новых ошибок/предупреждений.
- `dotnet format --verify-no-changes` для изменённого файла — чисто.

Generated with [Claude Code](https://claude.ai/code)