### PR TITLE
feat: кулдаун проекта и детерминированный выбор роли в рекламе горячих вакансий

### DIFF
--- a/docs/adr010-hot-vacancy-advertisement.md
+++ b/docs/adr010-hot-vacancy-advertisement.md
@@ -2,41 +2,46 @@
 
 ## Статус
 
-Частично реализовано. Первая итерация (MVP) поднимает сквозной путь только для
-`SingleHotRole` поверх **захардкоженных** канала/расписания и без реального лога — см.
-«Статус реализации» ниже. Хранение в БД (§2), безопасность секрета бота (§5) и UI (§8)
-отложены; новые поля DataModel по-прежнему требуют согласования с @leotsarev (см.
+Частично реализовано. Первая итерация (MVP) подняла сквозной путь только для `SingleHotRole`
+поверх **захардкоженных** канала/расписания; лог рекламы (`AdvertisementLog`) с тех пор
+переведён на реальное хранение в БД (#4653) — см. «Статус реализации» ниже. Хранение
+каналов/расписаний в БД (§2), безопасность секрета бота (§5) и UI (§8) по-прежнему отложены;
+новые поля DataModel по-прежнему требуют согласования с @leotsarev (см.
 [CLAUDE.md](../CLAUDE.md)), когда до них дойдёт очередь.
 
 ## Статус реализации
 
 MVP (`JoinRpg.Services.Advertisement` + `JoinRpg.Services.Advertisement.Test`) реализует
-только вертикальный срез — один способ (`SingleHotRole`), один вид канала (Telegram), без
-хранения в БД:
+только вертикальный срез — один способ (`SingleHotRole`), один вид канала (Telegram); канал и
+расписание захардкожены, но лог рекламы хранится в БД по-настоящему:
 
 - ✅ **§1 Доменные типы** — реализовано, с упрощениями: нет отдельного
   `AdvertisementChannelKind`, вид канала определяется через `is TelegramChannelSettings`; нет
   обёртки `WeeklyAdvertisementSchedule` — дни недели хранятся прямо в
   `AdvertisementScheduleInfo.Days`.
-- ❌ **§2 Хранение в БД** — не реализовано. Таблиц `AdvertisementChannels` /
-  `AdvertisementSchedules` / `AdvertisementLog` нет; канал и расписание захардкожены
-  (`HardcodedAdvertisementChannelRepository`, `HardcodedAdvertisementScheduleRepository`), лог
-  не пишется (`NullAdvertisementLogRepository.RecordAdvertisement` — no-op, а
-  `GetHotCharactersAdvertisementInfo` всегда отдаёт `AdvertisementCount: 0`,
-  `AlreadySentForSchedule: false`). Как следствие, **anti-repeat из §4 фактически не работает** —
-  роль может быть отреклармирована повторно на следующий день.
+- ⚠️ **§2 Хранение в БД** — частично. Таблица `AdvertisementLog` есть (миграция
+  `202608261348069_AddAdvertisementLog`), `AdvertisementLogRepository` — реальная EF6-реализация
+  поверх неё (не заглушка); anti-repeat роли (§4) и кулдаун проекта (§4) работают на реальных
+  данных. Таблиц `AdvertisementChannels`/`AdvertisementSchedules` по-прежнему нет — канал и
+  расписание захардкожены (`HardcodedAdvertisementChannelRepository`,
+  `HardcodedAdvertisementScheduleRepository`).
 - ⚠️ **§3 Слои и проекты** — частично. Проект `JoinRpg.Services.Advertisement` создан и
   зарегистрирован через `AddJoinAdvertisement(this IJoinServiceCollection)` (не Autofac), но без
   выделенных `IAdvertisementChannelService`/`IAdvertisementDispatchService` — вся оркестрация в
   `SingleHotRoleAdvertisementJob`. Доставка — через `ISingleHotRoleSender`/`IAdvSenderFactory`
   (аналог `IAdvertisementSender` из ADR, но заточен под один способ) вместо
   `TelegramAdvertisementSender`.
-- ⚠️ **§4 Выборка контента** — реализованы только шаги 1, 3, 4, 5 (частично) для
+- ⚠️ **§4 Выборка контента** — реализованы шаги 1, 2 (кулдаун проекта), 3, 4, 5 (частично) для
   `SingleHotRole`: кандидаты — `IProjectRepository.GetPublicProjectsOpenForHotRoleAdvertisement()`,
   ранжирование игр — `AdvertisementGameRanking` (та же формула
-  `ActiveClaimsCount / (AdvertisementCount + 1)`), выбор наименее рекламированной роли —
-  `HotRoleSelector`. `HotRolesDigest`/`OpenVacanciesDigest` не реализованы. Anti-repeat (шаг 2) не
-  работает — см. §2.
+  `ActiveClaimsCount / (AdvertisementCount + 1)`), кулдаун повторной рекламы проекта в канале —
+  `IAdvertisementLogRepository.WasProjectAdvertisedAmongLastN` (проект пропускается, если он входит
+  в последние `MinOtherAdvertisementsBetweenRepeats = 3` отправленные рекламы этого расписания —
+  эквивалент «меньше 3 реклам других игр с прошлого раза»), выбор наименее рекламированной роли —
+  `HotRoleSelector` (среди наименее рекламированных берётся персонаж с наибольшим `CharacterId`,
+  т.е. созданный последним; выбор детерминированный, без `Random`). `HotRolesDigest`/
+  `OpenVacanciesDigest` не реализованы. Anti-repeat роли (шаг «не повторять роль в канале») —
+  реализован и работает: `AlreadySentForSchedule` считается по реальному логу.
 - ❌ **§5 Секрет бота и безопасность** — не реализовано. Канал использует общего бота из
   конфигурации приложения (`TelegramLoginOptions`/`TelegramBotClient`, тот же, что и для личных
   уведомлений), захардкоженный `chatId`; отдельного хранения/шифрования секрета в БД нет. Джоба
@@ -49,9 +54,9 @@ MVP (`JoinRpg.Services.Advertisement` + `JoinRpg.Services.Advertisement.Test`) �
   `small` сознательно не используются — телеграм-санитайзер вырезает их вместе с содержимым), даты
   игры и регион/МГ — из `KogdaIgraGameData` (через `IProjectMetadataRepository.GetProjectDetails`,
   без обращения к `IKogdaIgraSyncClient`).
-- ⚠️ **§7 Обработка ошибок доставки** — модель есть (`SendingResult`,
-  `AdvertisementLogEntryInfo.Status`), но т.к. лог не пишется (см. §2), различие
-  `Sent`/`Failed` сейчас ни на что не влияет.
+- ✅ **§7 Обработка ошибок доставки** — реализовано: `AdvertisementLogEntryInfo.Status`
+  (`Sent`/`Failed`) пишется в реальный лог, anti-repeat (§4) учитывает только `Sent`-записи —
+  провал доставки не блокирует повторную попытку в следующий запуск.
 - ❌ **§8 UI** — не реализовано. CRUD каналов/расписаний отсутствует; единственный канал и
   единственное расписание заведены в коде.
 

--- a/src/JoinRpg.Dal.Impl/Repositories/AdvertisementLogRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/AdvertisementLogRepository.cs
@@ -45,6 +45,14 @@ internal class AdvertisementLogRepository(MyDbContext ctx) : IAdvertisementLogRe
                 c.AlreadySentForSchedule))];
     }
 
+    public async Task<bool> WasProjectAdvertisedAmongLastN(
+        AdvertisementScheduleIdentification scheduleId, ProjectIdentification projectId, int n) =>
+        await ctx.AdvertisementLogEntriesSet
+            .Where(e => e.ScheduleId == scheduleId.Value && e.Status == (int)AdvertisementLogStatus.Sent)
+            .OrderByDescending(e => e.AdvertisementLogEntryId)
+            .Take(n)
+            .AnyAsync(e => e.ProjectId == projectId.Value);
+
     public async Task RecordAdvertisement(AdvertisementLogEntryInfo entry)
     {
         _ = ctx.AdvertisementLogEntriesSet.Add(new AdvertisementLogEntryEntity

--- a/src/JoinRpg.Data.Interfaces/IAdvertisementLogRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IAdvertisementLogRepository.cs
@@ -8,6 +8,13 @@ public interface IAdvertisementLogRepository
     Task<IReadOnlyCollection<CharacterAdvertisementInfo>> GetHotCharactersAdvertisementInfo(
         AdvertisementScheduleIdentification scheduleId, ProjectIdentification projectId);
 
+    /// <summary>
+    /// true, если проект встречается среди последних <paramref name="n"/> отправленных реклам
+    /// в рамках расписания — используется для кулдауна повторной рекламы одного проекта в канале.
+    /// </summary>
+    Task<bool> WasProjectAdvertisedAmongLastN(
+        AdvertisementScheduleIdentification scheduleId, ProjectIdentification projectId, int n);
+
     Task RecordAdvertisement(AdvertisementLogEntryInfo entry);
 }
 

--- a/src/JoinRpg.IntegrationTests/Scenarios/AdvertisementLogScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/AdvertisementLogScenario.cs
@@ -72,4 +72,68 @@ public class AdvertisementLogScenario(JoinApplicationFactory factory) : IClassFi
             afterOtherInfo.AlreadySentForSchedule.ShouldBeFalse();
         });
     }
+
+    [Fact]
+    public async Task WasProjectAdvertisedAmongLastN_ExpiresAfterEnoughOtherAdvertisements()
+    {
+        UserIdentification masterId;
+        ProjectIdentification projectA;
+        ProjectIdentification projectB;
+        using (var scope = factory.Services.CreateScope())
+        {
+            masterId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+            projectA = await TestUserProjectHelpers.CreateProjectAsync(scope.ServiceProvider, masterId, "Проект A для кулдауна");
+            projectB = await TestUserProjectHelpers.CreateProjectAsync(scope.ServiceProvider, masterId, "Проект B для кулдауна");
+        }
+
+        var scheduleId = new AdvertisementScheduleIdentification(1);
+
+        async Task<CharacterIdentification> AddHotCharacter(ProjectIdentification projectId) =>
+            await factory.Services.RunAsAsync(masterId, async sp =>
+            {
+                var projectService = sp.GetRequiredService<IProjectService>();
+                var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+                var projectInfo = await metadataRepository.GetProjectMetadata(projectId);
+                await projectService.SetClaimSettings(
+                    projectId,
+                    projectInfo.ClaimSettings with { IsAcceptingClaims = true });
+
+                var characterService = sp.GetRequiredService<ICharacterService>();
+                return await characterService.AddCharacter(new AddCharacterRequest(
+                    projectId,
+                    ParentCharacterGroupIds: [],
+                    new CharacterTypeInfo(CharacterType.Player, IsHot: true, SlotLimit: null, SlotName: null, CharacterVisibility.Public),
+                    FieldValues: FieldLayerContainer.Empty(projectInfo)));
+            });
+
+        var characterA = await AddHotCharacter(projectA);
+        var characterB = await AddHotCharacter(projectB);
+
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var logRepository = sp.GetRequiredService<IAdvertisementLogRepository>();
+
+            // 1. Ни один из проектов ещё не рекламировался — кулдаун не действует
+            (await logRepository.WasProjectAdvertisedAmongLastN(scheduleId, projectA, 3)).ShouldBeFalse();
+
+            // 2. Рекламируем проект A — он на кулдауне (последняя реклама — его собственная)
+            await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                scheduleId, AdvertisementMethod.SingleHotRole, projectA, characterA, AdvertisementLogStatus.Sent, DateTimeOffset.UtcNow));
+            (await logRepository.WasProjectAdvertisedAmongLastN(scheduleId, projectA, 3)).ShouldBeTrue();
+
+            // 3. Ещё две рекламы проекта B — с прошлого раза для A было 2 чужих рекламы, кулдаун ещё действует
+            for (var i = 0; i < 2; i++)
+            {
+                await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                    scheduleId, AdvertisementMethod.SingleHotRole, projectB, characterB, AdvertisementLogStatus.Sent, DateTimeOffset.UtcNow));
+            }
+            (await logRepository.WasProjectAdvertisedAmongLastN(scheduleId, projectA, 3)).ShouldBeTrue();
+
+            // 4. Третья реклама проекта B — с прошлого раза для A было уже 3 чужих рекламы, кулдаун снят
+            await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                scheduleId, AdvertisementMethod.SingleHotRole, projectB, characterB, AdvertisementLogStatus.Sent, DateTimeOffset.UtcNow));
+            (await logRepository.WasProjectAdvertisedAmongLastN(scheduleId, projectA, 3)).ShouldBeFalse();
+            (await logRepository.WasProjectAdvertisedAmongLastN(scheduleId, projectB, 3)).ShouldBeTrue();
+        });
+    }
 }

--- a/src/JoinRpg.Services.Advertisement.Test/HotRoleSelectorTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/HotRoleSelectorTests.cs
@@ -7,7 +7,7 @@ public class HotRoleSelectorTests
     [Fact]
     public void SelectLeastAdvertised_EmptyCandidates_ReturnsNull()
     {
-        var result = HotRoleSelector.SelectLeastAdvertised([], new Random(1));
+        var result = HotRoleSelector.SelectLeastAdvertised([]);
 
         result.ShouldBeNull();
     }
@@ -18,23 +18,21 @@ public class HotRoleSelectorTests
         var leastAdvertised = MakeInfo(1, advertisementCount: 0);
         var mostAdvertised = MakeInfo(2, advertisementCount: 5);
 
-        var result = HotRoleSelector.SelectLeastAdvertised([mostAdvertised, leastAdvertised], new Random(1));
+        var result = HotRoleSelector.SelectLeastAdvertised([mostAdvertised, leastAdvertised]);
 
         result.ShouldBe(leastAdvertised);
     }
 
     [Fact]
-    public void SelectLeastAdvertised_WhenTied_PicksFromTiedCandidatesOnly()
+    public void SelectLeastAdvertised_WhenTied_PicksMostRecentlyCreatedCandidate()
     {
-        var tiedA = MakeInfo(1, advertisementCount: 0);
-        var tiedB = MakeInfo(2, advertisementCount: 0);
+        var older = MakeInfo(1, advertisementCount: 0);
+        var newer = MakeInfo(2, advertisementCount: 0);
         var notTied = MakeInfo(3, advertisementCount: 3);
 
-        for (var seed = 0; seed < 20; seed++)
-        {
-            var result = HotRoleSelector.SelectLeastAdvertised([tiedA, tiedB, notTied], new Random(seed));
-            result.ShouldBeOneOf(tiedA, tiedB);
-        }
+        var result = HotRoleSelector.SelectLeastAdvertised([older, notTied, newer]);
+
+        result.ShouldBe(newer);
     }
 
     private static CharacterAdvertisementInfo MakeInfo(int characterId, int advertisementCount) =>

--- a/src/JoinRpg.Services.Advertisement/HotRoleSelector.cs
+++ b/src/JoinRpg.Services.Advertisement/HotRoleSelector.cs
@@ -3,7 +3,7 @@ namespace JoinRpg.Services.Advertisement;
 internal static class HotRoleSelector
 {
     public static CharacterAdvertisementInfo? SelectLeastAdvertised(
-        IReadOnlyCollection<CharacterAdvertisementInfo> candidates, Random random)
+        IReadOnlyCollection<CharacterAdvertisementInfo> candidates)
     {
         if (candidates.Count == 0)
         {
@@ -11,7 +11,9 @@ internal static class HotRoleSelector
         }
 
         var minCount = candidates.Min(c => c.AdvertisementCount);
-        var leastAdvertised = candidates.Where(c => c.AdvertisementCount == minCount).ToList();
-        return leastAdvertised[random.Next(leastAdvertised.Count)];
+        return candidates
+            .Where(c => c.AdvertisementCount == minCount)
+            .OrderByDescending(c => c.Character.CharacterId.CharacterId)
+            .First();
     }
 }

--- a/src/JoinRpg.Services.Advertisement/SingleHotRoleAdvertisementJob.cs
+++ b/src/JoinRpg.Services.Advertisement/SingleHotRoleAdvertisementJob.cs
@@ -15,6 +15,8 @@ internal class SingleHotRoleAdvertisementJob(
     ICharacterUriLocator characterUriLocator,
     ILogger<SingleHotRoleAdvertisementJob> logger) : IDailyJob
 {
+    private const int MinOtherAdvertisementsBetweenRepeats = 3;
+
     public async Task RunOnce(CancellationToken cancellationToken)
     {
         var schedules = await scheduleRepository.GetActiveSchedules();
@@ -113,6 +115,14 @@ internal class SingleHotRoleAdvertisementJob(
             return false;
         }
 
+        if (await logRepository.WasProjectAdvertisedAmongLastN(schedule.ScheduleId, projectId, MinOtherAdvertisementsBetweenRepeats))
+        {
+            logger.LogInformation(
+                "Расписание {scheduleId}: проект {projectId} на кулдауне (рекламировался среди последних {n} реклам в канале), пропускаем",
+                schedule.ScheduleId, projectId, MinOtherAdvertisementsBetweenRepeats);
+            return false;
+        }
+
         var details = await projectMetadataRepository.GetProjectDetails(projectId);
         if (details.NearestFutureKogdaIgraCard is null)
         {
@@ -148,7 +158,7 @@ internal class SingleHotRoleAdvertisementJob(
             "Проект {projectId}: {totalCount} горячих ролей, {candidateCount} ещё не рекламировались по расписанию {scheduleId}",
             projectId, roles.Count, candidates.Count, schedule.ScheduleId);
 
-        return HotRoleSelector.SelectLeastAdvertised(candidates, Random.Shared)?.Character.CharacterId;
+        return HotRoleSelector.SelectLeastAdvertised(candidates)?.Character.CharacterId;
     }
 
     private async Task SendSingleHotRole(


### PR DESCRIPTION
## Что сделано

- Добавлен кулдаун проекта в канале рекламы: если проект встречается среди последних 3 отправленных реклам в этом канале, он пропускается при выборе (переходим к следующему проекту по скору), даже если у него остались нерекламированные горячие роли. Реализовано одним EF-запросом — `IAdvertisementLogRepository.WasProjectAdvertisedAmongLastN`.
- Выбор роли среди наименее рекламированных сделан детерминированным: вместо случайной роли (`Random`) теперь выбирается персонаж с наибольшим `CharacterId` (созданный последним).
- Поправлен устаревший раздел «Статус реализации» ADR010: anti-repeat роли и лог рекламы (`AdvertisementLog`) давно переведены на реальное хранение в БД (#4653), документ ошибочно описывал их как нерабочую заглушку.

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet test src/JoinRpg.Services.Advertisement.Test` — 13/13 зелёных
- [x] `dotnet format --verify-no-changes --severity error` — без замечаний
- [ ] `dotnet test src/JoinRpg.IntegrationTests` (новый сценарий `WasProjectAdvertisedAmongLastN_ExpiresAfterEnoughOtherAdvertisements`) — не прогонялся локально (нет Docker), но проект собирается без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)