### PR TITLE
fix: кнопка «Заявиться» пропадала для безлимитных шаблонов и обсуждаемых ролей

### DIFF
--- a/src/JoinRpg.Web.ProjectCommon/Characters/ApplyForCharacterButton.razor
+++ b/src/JoinRpg.Web.ProjectCommon/Characters/ApplyForCharacterButton.razor
@@ -25,8 +25,7 @@ else if (Model.IsSlot)
     [Parameter, EditorRequired]
     public CharacterApplyViewModel Model { get; set; } = default!;
 
-    private bool IsAvailable => Model.BusyStatus is CharacterBusyStatusView.Vacancy or CharacterBusyStatusView.HotVacancy
-        || (Model.IsSlot && Model.SlotCount is > 0);
+    private bool IsAvailable => Model.IsAvailable;
 
     private string ButtonLabel => Model.SlotCount is > 1
         ? $"Заявиться ({CountHelper.DisplayCount(Model.SlotCount.Value, "место", "места", "мест")})"

--- a/src/JoinRpg.Web.ProjectCommon/Characters/CharacterApplyViewModel.cs
+++ b/src/JoinRpg.Web.ProjectCommon/Characters/CharacterApplyViewModel.cs
@@ -4,5 +4,12 @@ public record CharacterApplyViewModel(
     CharacterIdentification CharacterId,
     CharacterBusyStatusView BusyStatus,
     int? SlotCount,
-    bool IsHot,
-    bool IsSlot);
+    bool IsHot)
+{
+    public bool IsSlot => BusyStatus is CharacterBusyStatusView.Slot or CharacterBusyStatusView.HotSlot;
+
+    // null SlotCount у слота — не «мест нет», а безлимитный шаблон (см. IsAcceptingClaims в JoinRpg.Domain).
+    // Discussed — есть поданные заявки, но мастер ещё не одобрил ни одну: заявиться ещё можно.
+    public bool IsAvailable => BusyStatus is CharacterBusyStatusView.Vacancy or CharacterBusyStatusView.HotVacancy or CharacterBusyStatusView.Discussed
+        || (IsSlot && SlotCount is null or > 0);
+}

--- a/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/ProjectRoleGridViewModelBuilderTests.cs
@@ -286,6 +286,19 @@ public class ProjectRoleGridViewModelBuilderTests
     }
 
     [Fact]
+    public void Build_DiscussedCharacter_IsAvailable()
+    {
+        var character = _mock.CreateCharacter("Обсуждаемый");
+        _mock.CreateClaim(character, _mock.Player);
+
+        var result = BuildGrid(Config(), [character]);
+
+        var row = result.Rows.ShouldHaveSingleItem().ShouldBeOfType<ProjectRoleGridCharacterRowViewModel>();
+        row.Player!.ApplyStatus.BusyStatus.ShouldBe(CharacterBusyStatusView.Discussed);
+        row.Player.ApplyStatus.IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
     public void Build_SlotCharacter_SlotCountInApplyStatus()
     {
         var character = _mock.CreateCharacter("Шаблон");
@@ -310,6 +323,19 @@ public class ProjectRoleGridViewModelBuilderTests
 
         result.Rows.ShouldHaveSingleItem().ShouldBeOfType<ProjectRoleGridCharacterRowViewModel>()
             .Player!.ApplyStatus.SlotCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Build_UnlimitedSlot_IsAvailable()
+    {
+        var character = _mock.CreateCharacter("Шаблон");
+        character.CharacterType = CharacterType.Slot;
+        character.CharacterSlotLimit = null;
+
+        var result = BuildGrid(Config(), [character]);
+
+        result.Rows.ShouldHaveSingleItem().ShouldBeOfType<ProjectRoleGridCharacterRowViewModel>()
+            .Player!.ApplyStatus.IsAvailable.ShouldBeTrue();
     }
 
     [Fact]

--- a/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
+++ b/src/JoinRpg.WebPortal.Managers/CharacterGroups/ProjectRoleGridViewModelBuilder.cs
@@ -2,7 +2,6 @@ using System.Text.Encodings.Web;
 using JoinRpg.Common.WebComponents;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
-using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.Users;
 using JoinRpg.Markdown;
@@ -219,8 +218,7 @@ internal static class ProjectRoleGridViewModelBuilder
             character.GetId(),
             character.GetBusyStatus(),
             character.CharacterSlotLimit,
-            character.IsHot,
-            character.CharacterType == CharacterType.Slot);
+            character.IsHot);
 
         var player = character.ApprovedClaim?.Player;
         if (player is null)

--- a/src/JoinRpg.WebPortal.Managers/UnifiedGrid/ItemBuilder.cs
+++ b/src/JoinRpg.WebPortal.Managers/UnifiedGrid/ItemBuilder.cs
@@ -31,8 +31,7 @@ public static class ItemBuilder
                ugItem.CharacterId,
                ugItem.GetBusyStatus(),
                ugItem.CharacterTypeInfo.SlotLimit,
-               ugItem.CharacterTypeInfo.IsHot,
-               ugItem.CharacterTypeInfo.CharacterType == CharacterType.Slot),
+               ugItem.CharacterTypeInfo.IsHot),
            [] // TODO
            );
 

--- a/src/JoinRpg.WebPortal.Models.Test/CharacterApplyViewModelTest.cs
+++ b/src/JoinRpg.WebPortal.Models.Test/CharacterApplyViewModelTest.cs
@@ -1,0 +1,50 @@
+using JoinRpg.DomainTypes;
+using JoinRpg.Web.ProjectCommon;
+
+namespace JoinRpg.WebPortal.Models.Test;
+
+public class CharacterApplyViewModelTest
+{
+    private static CharacterApplyViewModel CreateSlot(int? slotCount) => new(
+        new CharacterIdentification(new ProjectIdentification(1), 1),
+        CharacterBusyStatusView.Slot,
+        slotCount,
+        IsHot: false);
+
+    private static CharacterApplyViewModel CreatePlayer(CharacterBusyStatusView busyStatus) => new(
+        new CharacterIdentification(new ProjectIdentification(1), 1),
+        busyStatus,
+        SlotCount: null,
+        IsHot: false);
+
+    [Fact]
+    public void UnlimitedSlot_IsAvailable()
+    {
+        CreateSlot(null).IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SlotWithFreePlaces_IsAvailable()
+    {
+        CreateSlot(3).IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExhaustedSlot_IsNotAvailable()
+    {
+        CreateSlot(0).IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DiscussedCharacter_IsAvailable()
+    {
+        // Есть поданные, но не одобренные заявки — мастер ещё не выбрал игрока, заявиться можно.
+        CreatePlayer(CharacterBusyStatusView.Discussed).IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CharacterWithPlayer_IsNotAvailable()
+    {
+        CreatePlayer(CharacterBusyStatusView.HasPlayer).IsAvailable.ShouldBeFalse();
+    }
+}

--- a/src/JoinRpg.WebPortal.Models/Characters/CharacterGroupListViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Characters/CharacterGroupListViewModel.cs
@@ -1,6 +1,5 @@
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
-using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Helpers;
 using JoinRpg.Markdown;
@@ -109,8 +108,7 @@ public static class CharacterGroupListViewModel
                     arg.GetId(),
                     arg.GetBusyStatus(),
                     arg.CharacterSlotLimit,
-                    arg.IsHot,
-                    arg.CharacterType == CharacterType.Slot),
+                    arg.IsHot),
                 Description = ((MarkdownString?)arg.Description).ToHtmlString(),
                 IsPublic = arg.IsPublic,
                 IsActive = arg.IsActive,

--- a/src/JoinRpg.WebPortal.Models/Characters/CharacterViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Characters/CharacterViewModel.cs
@@ -16,8 +16,7 @@ public class CharacterViewModel :
 
     public required CharacterApplyViewModel ApplyStatus { get; init; }
 
-    public bool IsAvailable => ApplyStatus.BusyStatus is CharacterBusyStatusView.Vacancy or CharacterBusyStatusView.HotVacancy
-        || (ApplyStatus.IsSlot && ApplyStatus.SlotCount is > 0);
+    public bool IsAvailable => ApplyStatus.IsAvailable;
 
     public required JoinHtmlString Description { get; set; }
 


### PR DESCRIPTION
## Что сделано

`CharacterApplyViewModel.IsAvailable` не совпадал с серверной валидацией `IsAcceptingClaims` (`ClaimAcceptOrMoveValidationExtensions`):

- Шаблон (`CharacterType.Slot`) с безлимитным числом мест (`CharacterSlotLimit == null`) не проходил проверку `SlotCount is > 0` — кнопка исчезала полностью, хотя сервер такую заявку разрешает.
- Обычная роль, получившая первую (ещё не одобренную) заявку, переходит в статус `Discussed` и переставала считаться доступной — хотя мастер ещё не выбрал игрока и заявиться может кто угодно ещё (это же подтверждает существующий фильтр `ShowRolesFilter.VacantOnly`, который трактует `Discussed` как вакантный статус).

Заодно убрали дублирование: формула `IsAvailable` была продублирована в `ApplyForCharacterButton.razor` и `CharacterViewModel.cs` — вынесли её в `CharacterApplyViewModel` как единственный источник истины. `IsSlot` тоже был независимым полем, хотя полностью выводится из `BusyStatus` (`Slot`/`HotSlot` производятся только для `CharacterType.Slot`) — заменили на вычисляемое свойство и убрали лишний параметр конструктора на всех трёх точках построения (`ProjectRoleGridViewModelBuilder`, `CharacterGroupListViewModel`, `ItemBuilder`).

## Тесты

- `CharacterApplyViewModelTest` — юнит-тесты на `IsAvailable` для безлимитного/исчерпанного/со свободными местами шаблона и для Discussed/HasPlayer обычной роли.
- `ProjectRoleGridViewModelBuilderTests` — регрессионные тесты `Build_UnlimitedSlot_IsAvailable` и `Build_DiscussedCharacter_IsAvailable`, воспроизводящие баг до фикса.

Closes #4706

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017ARxbFjoLa4dmnTcDhQ8gW