### PR TITLE
feat: админ-страница со списком каналов и расписаний рекламы (ADR010 §8)

### DIFF
--- a/src/JoinRpg.Data.Interfaces/IAdvertisementChannelRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IAdvertisementChannelRepository.cs
@@ -3,4 +3,6 @@ namespace JoinRpg.Data.Interfaces;
 public interface IAdvertisementChannelRepository
 {
     Task<AdvertisementChannelInfo?> GetChannel(AdvertisementChannelIdentification channelId);
+
+    Task<IReadOnlyCollection<AdvertisementChannelInfo>> GetAllChannels();
 }

--- a/src/JoinRpg.DomainTypes/Advertisement/AdvertisementInfo.cs
+++ b/src/JoinRpg.DomainTypes/Advertisement/AdvertisementInfo.cs
@@ -8,6 +8,7 @@ public partial record AdvertisementChannelIdentification(int Value);
 
 public record AdvertisementChannelInfo(
     AdvertisementChannelIdentification ChannelId,
+    string Name,
     ProjectIdentification? BoundProjectId, // null = глобальный канал
     AdvertisementChannelSettings Settings);
 

--- a/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml
+++ b/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml
@@ -1,0 +1,12 @@
+@page "/admin/advertisement"
+@model JoinRpg.Portal.Pages.Admin.AdvertisementDashboardModel
+@{
+    ViewBag.Title = "Реклама горячих вакансий";
+}
+<h3>@ViewBag.Title</h3>
+
+<h4>Каналы</h4>
+<component type="typeof(JoinRpg.Web.AdminTools.Advertisement.AdvertisementChannelsGrid)" param-Model="Model.Channels" render-mode="Static" />
+
+<h4>Расписания</h4>
+<component type="typeof(JoinRpg.Web.AdminTools.Advertisement.AdvertisementSchedulesGrid)" param-Model="Model.Schedules" render-mode="Static" />

--- a/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml.cs
@@ -1,0 +1,21 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DomainTypes.Advertisement;
+using JoinRpg.Portal.Infrastructure.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace JoinRpg.Portal.Pages.Admin;
+
+[AdminAuthorize]
+public class AdvertisementDashboardModel(
+    IAdvertisementChannelRepository channelRepository,
+    IAdvertisementScheduleRepository scheduleRepository) : PageModel
+{
+    public IReadOnlyList<AdvertisementChannelInfo> Channels { get; private set; } = null!;
+    public IReadOnlyList<AdvertisementScheduleInfo> Schedules { get; private set; } = null!;
+
+    public async Task OnGetAsync()
+    {
+        Channels = [.. await channelRepository.GetAllChannels()];
+        Schedules = [.. await scheduleRepository.GetActiveSchedules()];
+    }
+}

--- a/src/JoinRpg.Portal/Pages/Admin/Index.cshtml
+++ b/src/JoinRpg.Portal/Pages/Admin/Index.cshtml
@@ -14,6 +14,7 @@
     <li><a asp-page="/Admin/Jobs">Джобы</a></li>
     <li><a asp-page="/Admin/NotificationDashboard">Статус уведомлений</a></li>
     <li><a asp-page="/Admin/AdminHotRolesList">Горячие роли</a></li>
+    <li><a asp-page="/Admin/AdvertisementDashboard">Реклама горячих вакансий</a></li>
     <li><a asp-page="/Admin/SyncWithKogdaIgra">КогдаИгра</a></li>
     <li><a asp-page="/Admin/TestMessage">Проверка отправки сообщения</a></li>
     @if (environment.IsDevelopment())

--- a/src/JoinRpg.Services.Advertisement.Test/AdvSenderFactoryTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/AdvSenderFactoryTests.cs
@@ -7,7 +7,7 @@ public class AdvSenderFactoryTests
     {
         var factory = new AdvSenderFactory(new FakeTelegramNotificationService(), Options.Create(new KogdaIgraOptions { HostName = new Uri("https://kogda-igra.ru") }));
         var channel = new AdvertisementChannelInfo(
-            new AdvertisementChannelIdentification(1), BoundProjectId: null, new TelegramChannelSettings(new TelegramChatId(-100)));
+            new AdvertisementChannelIdentification(1), Name: "Test", BoundProjectId: null, new TelegramChannelSettings(new TelegramChatId(-100)));
 
         var sender = factory.Create(channel);
 
@@ -20,7 +20,7 @@ public class AdvSenderFactoryTests
     {
         var factory = new AdvSenderFactory(new FakeTelegramNotificationService(), Options.Create(new KogdaIgraOptions { HostName = new Uri("https://kogda-igra.ru") }));
         var channel = new AdvertisementChannelInfo(
-            new AdvertisementChannelIdentification(1), BoundProjectId: null, new TelegramChannelSettings(new TelegramChatId(0)));
+            new AdvertisementChannelIdentification(1), Name: "Test", BoundProjectId: null, new TelegramChannelSettings(new TelegramChatId(0)));
 
         factory.Create(channel).ShouldBeNull();
     }
@@ -30,7 +30,7 @@ public class AdvSenderFactoryTests
     {
         var factory = new AdvSenderFactory(new FakeTelegramNotificationService(), Options.Create(new KogdaIgraOptions { HostName = new Uri("https://kogda-igra.ru") }));
         var channel = new AdvertisementChannelInfo(
-            new AdvertisementChannelIdentification(1), BoundProjectId: null, new UnsupportedChannelSettings());
+            new AdvertisementChannelIdentification(1), Name: "Test", BoundProjectId: null, new UnsupportedChannelSettings());
 
         factory.Create(channel).ShouldBeNull();
     }

--- a/src/JoinRpg.Services.Advertisement.Test/HardcodedAdvertisementScheduleRepositoryTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/HardcodedAdvertisementScheduleRepositoryTests.cs
@@ -6,15 +6,26 @@ namespace JoinRpg.Services.Advertisement.Test;
 public class HardcodedAdvertisementScheduleRepositoryTests
 {
     [Fact]
-    public async Task GetActiveSchedules_ReturnsSingleHotRoleScheduleForHardcodedChannel()
+    public async Task GetActiveSchedules_ReturnsScheduleForHotRoleChannelEveryDay()
     {
         var repository = new HardcodedAdvertisementScheduleRepository(new HardcodedAdvertisementChannelRepository());
 
         var schedules = await repository.GetActiveSchedules();
 
-        var schedule = schedules.ShouldHaveSingleItem();
-        schedule.Channel.ChannelId.ShouldBe(HardcodedAdvertisementChannelRepository.HotRoleChannelId);
+        var schedule = schedules.Single(s => s.Channel.ChannelId == HardcodedAdvertisementChannelRepository.HotRoleChannelId);
         schedule.Method.ShouldBe(AdvertisementMethod.SingleHotRole);
         schedule.Days.ShouldBe(Enum.GetValues<DayOfWeek>(), ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task GetActiveSchedules_ReturnsScheduleForZovemChannelOnWednesdays()
+    {
+        var repository = new HardcodedAdvertisementScheduleRepository(new HardcodedAdvertisementChannelRepository());
+
+        var schedules = await repository.GetActiveSchedules();
+
+        var schedule = schedules.Single(s => s.Channel.ChannelId == HardcodedAdvertisementChannelRepository.ZovemChannelId);
+        schedule.Method.ShouldBe(AdvertisementMethod.SingleHotRole);
+        schedule.Days.ShouldBe([DayOfWeek.Wednesday], ignoreOrder: true);
     }
 }

--- a/src/JoinRpg.Services.Advertisement/Channels/HardcodedAdvertisementChannelRepository.cs
+++ b/src/JoinRpg.Services.Advertisement/Channels/HardcodedAdvertisementChannelRepository.cs
@@ -4,12 +4,25 @@ namespace JoinRpg.Services.Advertisement.Channels;
 internal class HardcodedAdvertisementChannelRepository : IAdvertisementChannelRepository
 {
     public static readonly AdvertisementChannelIdentification HotRoleChannelId = new(1);
+    public static readonly AdvertisementChannelIdentification ZovemChannelId = new(2);
 
     private static readonly AdvertisementChannelInfo HotRoleChannel = new(
         HotRoleChannelId,
+        Name: "test_zovem_na_igru",
         BoundProjectId: null,
         new TelegramChannelSettings(new TelegramChatId(-1004315256401)));
 
+    private static readonly AdvertisementChannelInfo ZovemChannel = new(
+        ZovemChannelId,
+        Name: "t.me/zovem_joinrpg",
+        BoundProjectId: null,
+        new TelegramChannelSettings(new TelegramChatId(-1002544815071)));
+
+    private static readonly IReadOnlyList<AdvertisementChannelInfo> AllChannels = [HotRoleChannel, ZovemChannel];
+
     public Task<AdvertisementChannelInfo?> GetChannel(AdvertisementChannelIdentification channelId) =>
-        Task.FromResult(channelId == HotRoleChannelId ? HotRoleChannel : null);
+        Task.FromResult(AllChannels.FirstOrDefault(c => c.ChannelId == channelId));
+
+    public Task<IReadOnlyCollection<AdvertisementChannelInfo>> GetAllChannels() =>
+        Task.FromResult<IReadOnlyCollection<AdvertisementChannelInfo>>(AllChannels);
 }

--- a/src/JoinRpg.Services.Advertisement/Schedules/HardcodedAdvertisementScheduleRepository.cs
+++ b/src/JoinRpg.Services.Advertisement/Schedules/HardcodedAdvertisementScheduleRepository.cs
@@ -4,15 +4,22 @@ namespace JoinRpg.Services.Advertisement.Schedules;
 internal class HardcodedAdvertisementScheduleRepository(IAdvertisementChannelRepository channelRepository) : IAdvertisementScheduleRepository
 {
     private static readonly IReadOnlySet<DayOfWeek> EveryDay = Enum.GetValues<DayOfWeek>().ToHashSet();
+    private static readonly IReadOnlySet<DayOfWeek> Wednesdays = new HashSet<DayOfWeek> { DayOfWeek.Wednesday };
 
     public async Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetActiveSchedules()
     {
-        var channel = await channelRepository.GetChannel(HardcodedAdvertisementChannelRepository.HotRoleChannelId);
-        if (channel is null)
+        var schedules = new List<AdvertisementScheduleInfo>();
+
+        if (await channelRepository.GetChannel(HardcodedAdvertisementChannelRepository.HotRoleChannelId) is { } hotRoleChannel)
         {
-            return [];
+            schedules.Add(new(new AdvertisementScheduleIdentification(1), hotRoleChannel, AdvertisementMethod.SingleHotRole, EveryDay));
         }
 
-        return [new(new AdvertisementScheduleIdentification(1), channel, AdvertisementMethod.SingleHotRole, EveryDay)];
+        if (await channelRepository.GetChannel(HardcodedAdvertisementChannelRepository.ZovemChannelId) is { } zovemChannel)
+        {
+            schedules.Add(new(new AdvertisementScheduleIdentification(2), zovemChannel, AdvertisementMethod.SingleHotRole, Wednesdays));
+        }
+
+        return schedules;
     }
 }

--- a/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementChannelsGrid.razor
+++ b/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementChannelsGrid.razor
@@ -1,0 +1,44 @@
+@using JoinRpg.DomainTypes.Advertisement
+@using JoinRpg.Web.ProjectCommon.Projects
+@inject IProjectUriLocator ProjectUriLocator
+
+<JoinBorderedTable Items="Model" Context="channel">
+    <HeadContent>
+        <tr>
+            <th>Id</th>
+            <th>Название</th>
+            <th>Игра</th>
+            <th>Настройки</th>
+        </tr>
+    </HeadContent>
+    <ItemTemplate>
+        <tr>
+            <td>@channel.ChannelId.Value</td>
+            <td>@channel.Name</td>
+            <td>
+                @if (channel.BoundProjectId is { } projectId)
+                {
+                    <a href="@ProjectUriLocator.GetRolesListUri(projectId)">Проект #@projectId.Value</a>
+                }
+                else
+                {
+                    @:Общий
+                }
+            </td>
+            <td>@DescribeSettings(channel.Settings)</td>
+        </tr>
+    </ItemTemplate>
+</JoinBorderedTable>
+
+@code {
+    [Parameter]
+    [EditorRequired]
+    public IReadOnlyList<AdvertisementChannelInfo> Model { get; set; } = default!;
+
+    private static string DescribeSettings(AdvertisementChannelSettings settings) =>
+        settings switch
+        {
+            TelegramChannelSettings telegram => $"Telegram, chat {telegram.ChatId}",
+            _ => settings.GetType().Name,
+        };
+}

--- a/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementSchedulesGrid.razor
+++ b/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementSchedulesGrid.razor
@@ -1,0 +1,42 @@
+@using JoinRpg.DomainTypes.Advertisement
+
+<JoinBorderedTable Items="Model" Context="schedule">
+    <HeadContent>
+        <tr>
+            <th>Id</th>
+            <th>Канал</th>
+            <th>Способ</th>
+            <th>Дни</th>
+        </tr>
+    </HeadContent>
+    <ItemTemplate>
+        <tr>
+            <td>@schedule.ScheduleId.Value</td>
+            <td>@schedule.Channel.Name</td>
+            <td>@schedule.Method</td>
+            <td>@DescribeDays(schedule.Days)</td>
+        </tr>
+    </ItemTemplate>
+</JoinBorderedTable>
+
+@code {
+    [Parameter]
+    [EditorRequired]
+    public IReadOnlyList<AdvertisementScheduleInfo> Model { get; set; } = default!;
+
+    private static readonly Dictionary<DayOfWeek, string> DayNames = new()
+    {
+        [DayOfWeek.Monday] = "Пн",
+        [DayOfWeek.Tuesday] = "Вт",
+        [DayOfWeek.Wednesday] = "Ср",
+        [DayOfWeek.Thursday] = "Чт",
+        [DayOfWeek.Friday] = "Пт",
+        [DayOfWeek.Saturday] = "Сб",
+        [DayOfWeek.Sunday] = "Вс",
+    };
+
+    private static string DescribeDays(IReadOnlySet<DayOfWeek> days) =>
+        days.Count == 7
+            ? "Каждый день"
+            : string.Join(", ", Enum.GetValues<DayOfWeek>().Where(days.Contains).Select(d => DayNames[d]));
+}


### PR DESCRIPTION
## Что сделано
- Новая read-only страница `/Admin/AdvertisementDashboard` с двумя гридами — каналы и расписания рекламы горячих вакансий (ADR010 §8, продолжение ADR010).
- Гриды вынесены в отдельные Blazor-компоненты `AdvertisementChannelsGrid`/`AdvertisementSchedulesGrid` (`JoinRpg.Web.AdminTools/Advertisement/`) по образцу существующих админ-компонентов, поверх `JoinBorderedTable`.
- У `AdvertisementChannelInfo` появилось читаемое `Name`.
- Привязка канала к игре (`BoundProjectId`) — кликабельная ссылка на список ролей проекта (`IProjectUriLocator.GetRolesListUri`).
- Заведён второй захардкоженный канал `t.me/zovem_joinrpg` с расписанием по средам.
- Ссылка на страницу добавлена в `/Admin`.

## Test plan
- [x] `dotnet build` — 0 ошибок
- [x] `dotnet test src/JoinRpg.Services.Advertisement.Test` — все тесты зелёные (обновлены под второй канал)
- [x] `dotnet format --verify-no-changes --severity error` — чисто
- [ ] Ручная проверка страницы в браузере не выполнялась в этой сессии

Generated with [Claude Code](https://claude.ai/code)