### PR TITLE
fix: невалидный код подтверждения email не должен падать 500

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using Joinrpg.Web.Identity;
 using JoinRpg.Data.Interfaces;
-using JoinRpg.Domain;
 using JoinRpg.Portal.Infrastructure.Authentication;
 using JoinRpg.Services.Interfaces.Avatars;
 using JoinRpg.Services.Interfaces.Notification;
@@ -215,7 +214,7 @@ public class AccountController(
             {
                 logger.LogWarning("Ошибка при подтверждении email (Code={accountErrorCode}: {description}", err.Code, err.Description);
             }
-            throw new JoinRpgAccountOperationFailedException($"Не удалось подтвердить email ({string.Join(", ", result.Errors.Select(e => e.Code.ToString()))})");
+            return View("ConfirmEmailFailed");
         }
     }
 

--- a/src/JoinRpg.Portal/Views/Account/ConfirmEmailFailed.cshtml
+++ b/src/JoinRpg.Portal/Views/Account/ConfirmEmailFailed.cshtml
@@ -1,0 +1,12 @@
+@{
+    ViewBag.Title = "Не удалось подтвердить Email";
+}
+
+<h2>@ViewBag.Title</h2>
+<div>
+    <p>
+        Ссылка для подтверждения email недействительна: она уже была использована или срок её действия истёк.
+        <br />
+        Попробуйте @(Html.ActionLink("войти", "Login", "Account", routeValues: null, htmlAttributes: new { id = "loginLink" })) — если email всё ещё не подтверждён, мы вышлем новое письмо.
+    </p>
+</div>


### PR DESCRIPTION
## Что сделано
- `AccountController.ConfirmEmail` больше не бросает `JoinRpgAccountOperationFailedException` при неуспехе `userManager.ConfirmEmailAsync` (истёкший/уже использованный код) — вместо необработанного исключения (500, ERROR в логах) показывается дружелюбная страница `ConfirmEmailFailed` с предложением войти заново.
- Ошибки подтверждения по-прежнему логируются, но как `Warning`, а не как необработанное исключение.

Closes #4714

## Test plan
- [x] `dotnet build` без новых ошибок
- [x] `dotnet format --verify-no-changes` чисто на изменённых файлах
- [ ] Ручная проверка: перейти по `/account/confirmemail` с невалидным `code` — должна открыться страница с понятным сообщением, а не generic-ошибка

Generated with [Claude Code](https://claude.ai/code)