### PR TITLE
build: повысить строгость dotnet format с error до warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -229,3 +229,7 @@ dotnet_style_qualification_for_method = false:warning
 dotnet_style_qualification_for_event = false:warning
 dotnet_diagnostic.CA1835.severity = warning
 dotnet_diagnostic.CA1862.severity = warning
+# Identification-структуры (ClaimIdentification, CharacterIdentification и т.п.) биндятся через
+# кастомный ProjectEntityIdModelBinder, а не по имени свойства — совпадение имени параметра и
+# свойства безопасно.
+dotnet_diagnostic.MVC1004.severity = none

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,7 +57,7 @@ jobs:
       run: dotnet restore
 
     - name: Format
-      run: dotnet format --no-restore --verify-no-changes --severity error
+      run: dotnet format --no-restore --verify-no-changes --severity warn
 
     - name: Build portal
       run: dotnet build --no-restore -c Release  --property:Version=${{ env.CALCULATED_VERSION }} 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Email в dev-режиме не отправляется — логируется
 ```bash
 dotnet build
 dotnet format                                             # Применить стиль кода (обязательно перед коммитом)
-dotnet format --verify-no-changes --severity error        # Проверка (CI)
+dotnet format --verify-no-changes --severity warn         # Проверка (CI)
 ```
 
 ### Коммиты

--- a/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/EntityIdConversionExtensionsTest.cs
+++ b/src/Common/JoinRpg.Common.EntityFrameworkCore.Test/EntityIdConversionExtensionsTest.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.EntityFrameworkCore;
 using JoinRpg.Common.PrimitiveTypes;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/GlobalUsings.cs
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Client/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using JoinRpg.Common.WebComponents;

--- a/src/JoinRpg.Blazor.Client/ApiClients/HttpClientRegistration.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/HttpClientRegistration.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.WebComponents;
 using JoinRpg.Web.Accommodation;
 using JoinRpg.Web.AdminTools;
 using JoinRpg.Web.CharacterGroups.GroupReport;

--- a/src/JoinRpg.Blazor.Client/ApiClients/KogdaIgraClient.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/KogdaIgraClient.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.Blazor.Client.ApiClients;

--- a/src/JoinRpg.Blazor.Client/ApiClients/MoveClientImpl.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/MoveClientImpl.cs
@@ -1,5 +1,3 @@
-using JoinRpg.Common.WebComponents;
-
 namespace JoinRpg.Blazor.Client.ApiClients;
 
 internal class MoveClientImpl(

--- a/src/JoinRpg.Blazor.Client/UriLocatorExtensions.cs
+++ b/src/JoinRpg.Blazor.Client/UriLocatorExtensions.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.WebComponents;
 using JoinRpg.Web.ProjectCommon;
 
 namespace JoinRpg.Blazor.Client;

--- a/src/JoinRpg.Dal.Impl.Tests/CharacterGroupDictionaryBuilderTest.cs
+++ b/src/JoinRpg.Dal.Impl.Tests/CharacterGroupDictionaryBuilderTest.cs
@@ -9,7 +9,6 @@ namespace JoinRpg.Dal.Impl.Tests;
 public class CharacterGroupDictionaryBuilderTest
 {
     private readonly MockedProject _mock = new MockedProject();
-    private readonly ProjectIdentification _projectId = new(1);
 
     [Fact]
     public void Build_ShouldReturnAllGroups()

--- a/src/JoinRpg.Dal.Notifications/Migrations/20260821145114_SkipSignature.cs
+++ b/src/JoinRpg.Dal.Notifications/Migrations/20260821145114_SkipSignature.cs
@@ -2,28 +2,27 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace JoinRpg.Dal.Notifications.Migrations
+namespace JoinRpg.Dal.Notifications.Migrations;
+
+/// <inheritdoc />
+public partial class SkipSignature : Migration
 {
     /// <inheritdoc />
-    public partial class SkipSignature : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<bool>(
-                name: "SkipSignature",
-                table: "Notifications",
-                type: "boolean",
-                nullable: false,
-                defaultValue: false);
-        }
+        migrationBuilder.AddColumn<bool>(
+            name: "SkipSignature",
+            table: "Notifications",
+            type: "boolean",
+            nullable: false,
+            defaultValue: false);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "SkipSignature",
-                table: "Notifications");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "SkipSignature",
+            table: "Notifications");
     }
 }

--- a/src/JoinRpg.Domain.Test/ClaimBalanceOverCharacterInfoTest.cs
+++ b/src/JoinRpg.Domain.Test/ClaimBalanceOverCharacterInfoTest.cs
@@ -1,10 +1,8 @@
 using JoinRpg.DataModel;
-using JoinRpg.DataModel.Finances;
 using JoinRpg.DataModel.Mocks;
 using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
-using JoinRpg.DomainTypes.ProjectMetadata.Payments;
 
 namespace JoinRpg.Domain.Test;
 

--- a/src/JoinRpg.Domain/FinanceExtensions.cs
+++ b/src/JoinRpg.Domain/FinanceExtensions.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.DomainTypes.Characters;

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal/GlobalUsings.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Joinrpg.Web.Identity;
 global using JoinRpg.Common.PrimitiveTypes;
-global using JoinRpg.Common.WebComponents;

--- a/src/JoinRpg.IntegrationTests/Scenarios/XApi/XApiCharacterPlayerTests.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/XApi/XApiCharacterPlayerTests.cs
@@ -2,7 +2,6 @@ using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.Characters;
-using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.IntegrationTest.TestInfrastructure;
 using JoinRpg.IntegrationTests.TestInfrastructure;
 using JoinRpg.Services.Interfaces;

--- a/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
+++ b/src/JoinRpg.Portal.Test/Infrastructure/CaptureNoAccessExceptionFilterTest.cs
@@ -6,7 +6,6 @@ using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.Portal.Infrastructure;
 using JoinRpg.Portal.Infrastructure.DiscoverFilters;
-using JoinRpg.Web.Models;
 using JoinRpg.Web.ProjectCommon;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -1,4 +1,3 @@
-using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.DomainTypes.ProjectMetadata.Payments;

--- a/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
@@ -4,7 +4,6 @@ using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.Domain;
 using JoinRpg.Domain.Access;
 using JoinRpg.DomainTypes.Characters;
-using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Interfaces;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using JoinRpg.Services.Interfaces.Characters;

--- a/src/JoinRpg.Portal/Helpers/FormCollectionHelpers.cs
+++ b/src/JoinRpg.Portal/Helpers/FormCollectionHelpers.cs
@@ -1,5 +1,4 @@
 using JoinRpg.DomainTypes.Characters;
-using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.Helpers;
 
 namespace Joinrpg.AspNetCore.Helpers;

--- a/src/JoinRpg.Portal/Infrastructure/UriServiceImpl.cs
+++ b/src/JoinRpg.Portal/Infrastructure/UriServiceImpl.cs
@@ -1,5 +1,4 @@
 using JoinRpg.Common.WebComponents;
-using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
 using JoinRpg.DomainTypes.Claims;
 using JoinRpg.DomainTypes.Forums;
 using JoinRpg.DomainTypes.Interfaces;

--- a/src/JoinRpg.Portal/Pages/Admin/AdminHotRolesList.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/Admin/AdminHotRolesList.cshtml.cs
@@ -3,7 +3,6 @@ using JoinRpg.Data.Interfaces;
 using JoinRpg.Markdown;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using JoinRpg.Web.AdminTools;
-using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon;
 using JoinRpg.Web.ProjectCommon.KogdaIgra;
 using JoinRpg.Web.ProjectCommon.Projects;

--- a/src/JoinRpg.Services.Advertisement.Test/GlobalUsings.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/GlobalUsings.cs
@@ -4,7 +4,6 @@ global using JoinRpg.Data.Interfaces;
 global using JoinRpg.DomainTypes;
 global using JoinRpg.DomainTypes.Advertisement;
 global using JoinRpg.DomainTypes.ProjectMetadata;
-global using JoinRpg.Interfaces;
 global using JoinRpg.Services.Advertisement.Sending;
 global using JoinRpg.Services.Interfaces.Notification;
 global using Microsoft.Extensions.Options;

--- a/src/JoinRpg.Services.Impl.Test/AccommodationInviteRulesTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/AccommodationInviteRulesTest.cs
@@ -1,5 +1,4 @@
 using JoinRpg.DataModel;
-using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
 
 namespace JoinRpg.Services.Impl.Test;

--- a/src/JoinRpg.Services.Impl/AccommodationInviteServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/AccommodationInviteServiceImpl.cs
@@ -4,7 +4,6 @@ using JoinRpg.DataModel;
 using JoinRpg.DataModel.Extensions;
 using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters.Claims;
-using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
 using JoinRpg.DomainTypes.Interfaces;
 using JoinRpg.Services.Interfaces.Notification;
 

--- a/src/JoinRpg.Services.Interfaces/IAccommodationInviteService.cs
+++ b/src/JoinRpg.Services.Interfaces/IAccommodationInviteService.cs
@@ -1,5 +1,4 @@
 using JoinRpg.DataModel;
-using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
 
 namespace JoinRpg.Services.Interfaces;
 

--- a/src/JoinRpg.Web.Accommodation/GlobalUsings.cs
+++ b/src/JoinRpg.Web.Accommodation/GlobalUsings.cs
@@ -2,4 +2,3 @@ global using JoinRpg.Common.PrimitiveTypes;
 global using JoinRpg.Common.WebComponents;
 global using JoinRpg.DomainTypes;
 global using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
-global using JoinRpg.DomainTypes.ProjectMetadata;

--- a/src/JoinRpg.Web.AdminTools/GlobalUsings.cs
+++ b/src/JoinRpg.Web.AdminTools/GlobalUsings.cs
@@ -1,4 +1,3 @@
 global using JoinRpg.Common.PrimitiveTypes;
-global using JoinRpg.Common.WebComponents;
 global using JoinRpg.DomainTypes;
 global using JoinRpg.DomainTypes.ProjectMetadata;

--- a/src/JoinRpg.Web.CharacterGroups/ProjectRoleGrid/ViewModels.cs
+++ b/src/JoinRpg.Web.CharacterGroups/ProjectRoleGrid/ViewModels.cs
@@ -1,6 +1,5 @@
 using System.Text.Json.Serialization;
 using JoinRpg.Common.PrimitiveTypes;
-using JoinRpg.Common.WebComponents;
 using JoinRpg.DomainTypes;
 using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.Web.ProjectCommon;

--- a/src/JoinRpg.Web.CheckIn/GlobalUsings.cs
+++ b/src/JoinRpg.Web.CheckIn/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using JoinRpg.Common.WebComponents;

--- a/src/JoinRpg.Web.Claims/UnifiedGrid/ListViewModels.cs
+++ b/src/JoinRpg.Web.Claims/UnifiedGrid/ListViewModels.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using JoinRpg.Common.WebComponents;
 using JoinRpg.DomainTypes.Characters.Claims.Finances;
 using JoinRpg.DomainTypes.Interfaces;
 using JoinRpg.Web.ProjectCommon;

--- a/src/JoinRpg.Web.Plots/PlotElementMoveItem.cs
+++ b/src/JoinRpg.Web.Plots/PlotElementMoveItem.cs
@@ -1,5 +1,3 @@
-using JoinRpg.Common.WebComponents;
-
 namespace JoinRpg.Web.Plots;
 
 internal sealed class PlotElementMoveItem(PlotRenderedTextViewModel plot, CharacterIdentification characterId) : IMoveableListItem

--- a/src/JoinRpg.Web.ProjectCommon/KogdaIgra/ViewModels.cs
+++ b/src/JoinRpg.Web.ProjectCommon/KogdaIgra/ViewModels.cs
@@ -1,5 +1,3 @@
-using JoinRpg.Common.WebComponents;
-
 namespace JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 public record class JoinRpgSyncCandidateViewModel(

--- a/src/JoinRpg.WebPortal.Managers/Accommodation/AccommodationTypeViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Accommodation/AccommodationTypeViewService.cs
@@ -1,8 +1,5 @@
-using JoinRpg.Common.PrimitiveTypes;
-using JoinRpg.Common.WebComponents;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.Data.Interfaces.Claims;
-using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters.Claims.Accommodation;
 using JoinRpg.DomainTypes.Interfaces;

--- a/src/JoinRpg.WebPortal.Managers/AdminTools/KogdaIgraSyncManager.cs
+++ b/src/JoinRpg.WebPortal.Managers/AdminTools/KogdaIgraSyncManager.cs
@@ -1,7 +1,6 @@
 using JoinRpg.Common.KogdaIgraClient;
 using JoinRpg.Data.Interfaces.AdminTools;
 using JoinRpg.Services.Interfaces.Integrations.KogdaIgra;
-using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.WebPortal.Managers.AdminTools;

--- a/src/JoinRpg.WebPortal.Managers/AdminTools/ViewModelBuilders.cs
+++ b/src/JoinRpg.WebPortal.Managers/AdminTools/ViewModelBuilders.cs
@@ -1,6 +1,5 @@
 using JoinRpg.Common.KogdaIgraClient;
 using JoinRpg.Services.Interfaces.Integrations.KogdaIgra;
-using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.ProjectCommon.KogdaIgra;
 
 namespace JoinRpg.WebPortal.Managers.AdminTools;

--- a/src/JoinRpg.WebPortal.Models/Exporters/CustomExporter.cs
+++ b/src/JoinRpg.WebPortal.Models/Exporters/CustomExporter.cs
@@ -6,7 +6,6 @@ using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Interfaces;
-using JoinRpg.DomainTypes.Users;
 using JoinRpg.Helpers;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.UserProfile;

--- a/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MasterBalanceBuilder.cs
@@ -1,7 +1,5 @@
-using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
-using JoinRpg.DomainTypes.Users;
 using JoinRpg.Helpers;
 
 namespace JoinRpg.Web.Models;

--- a/src/JoinRpg.WebPortal.Models/Money/MasterBalanceViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MasterBalanceViewModel.cs
@@ -1,7 +1,6 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.Domain;
-using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Web.Models;
 

--- a/src/JoinRpg.WebPortal.Models/Money/MoneyInfoForUserViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MoneyInfoForUserViewModel.cs
@@ -1,6 +1,5 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
-using JoinRpg.DomainTypes.Users;
 using JoinRpg.Interfaces;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.Money;

--- a/src/JoinRpg.WebPortal.Models/Money/MoneyInfoTotalViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Money/MoneyInfoTotalViewModel.cs
@@ -1,6 +1,5 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
-using JoinRpg.DomainTypes.Users;
 using JoinRpg.Interfaces;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.Models.Money;


### PR DESCRIPTION
## Что сделано
- `dotnet format --verify-no-changes --severity error` -> `--severity warn` в CI (`.github/workflows/build_and_publish.yml`) и в `CLAUDE.md`.
- Исправлены накопившиеся предупреждения уровня warning, чтобы CI проходил при новом пороге:
  - неиспользуемые `using` (IDE0005) в нескольких проектах;
  - неиспользуемое приватное поле `_projectId` в `CharacterGroupDictionaryBuilderTest` (IDE0052);
  - форматирование file-scoped namespace в миграции `20260821145114_SkipSignature.cs` (IDE0161).
- В `.editorconfig` подавлен `MVC1004`: свойства `*Identification`-структур (`ClaimIdentification`, `CharacterIdentification` и т.п.) намеренно совпадают по имени с параметрами экшенов — биндинг идёт через кастомный `ProjectEntityIdModelBinder`, а не по имени свойства, так что предупреждение — ложное срабатывание по всему кодовому пути.

## Test plan
- [x] `dotnet format --no-restore --verify-no-changes --severity warn` — чисто
- [x] `dotnet build`
- [x] `dotnet test`