### PR TITLE
feat: описание «горячей роли» упоминает рекламу в канале «Зовем на игру»

### DIFF
--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents.Test/FormRowTest.cs
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents.Test/FormRowTest.cs
@@ -1,0 +1,24 @@
+namespace JoinRpg.Common.WebComponents.Test;
+
+public class FormRowTest
+{
+    [Fact]
+    public void Description_RendersDescriptionText()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<FormRow>(p => p
+            .Add(x => x.Label, "Label")
+            .Add(x => x.Description, "Some description"));
+        cut.Markup.ShouldContain("Some description");
+    }
+
+    [Fact]
+    public void DescriptionFragment_RendersFragmentContent()
+    {
+        using var ctx = new BunitContext();
+        var cut = ctx.Render<FormRow>(p => p
+            .Add(x => x.Label, "Label")
+            .Add(x => x.DescriptionFragment, builder => builder.AddContent(0, "Fragment description")));
+        cut.Markup.ShouldContain("Fragment description");
+    }
+}

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponents/FormRow.razor
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponents/FormRow.razor
@@ -8,7 +8,7 @@
     }
     else if (DescriptionFragment is not null)
     {
-      <div class="help-block">@Description</div>
+      <div class="help-block">@DescriptionFragment</div>
     }
   </div>
 </div>

--- a/src/JoinRpg.Web.CharacterGroups/CharacterTypeSelector.razor
+++ b/src/JoinRpg.Web.CharacterGroups/CharacterTypeSelector.razor
@@ -43,8 +43,13 @@
 
 @if (!HasApprovedClaim && (characterType == CharacterTypeView.Player || characterType == CharacterTypeView.Slot))
 {
-  <FormRow Label="Горячая роль" Description="Горячая роль специальным образом выделяется в ролевке">
-    <CheckboxInput @bind-Value="@isHot" Name="@(Name + ".IsHot")" />
+  <FormRow Label="Горячая роль">
+    <ChildContent>
+      <CheckboxInput @bind-Value="@isHot" Name="@(Name + ".IsHot")" />
+    </ChildContent>
+    <DescriptionFragment>
+      Горячая роль специальным образом выделяется в ролевке. Если ваш проект публичный, горячая роль будет автоматически рекламироваться в канале «Зовем на игру» <a href="https://t.me/zovem_joinrpg" target="_blank" rel="noopener">https://t.me/zovem_joinrpg</a>
+    </DescriptionFragment>
   </FormRow>
 }
 

--- a/src/JoinRpg.Web.CharacterGroups/CharacterTypeSelector.razor
+++ b/src/JoinRpg.Web.CharacterGroups/CharacterTypeSelector.razor
@@ -48,7 +48,7 @@
       <CheckboxInput @bind-Value="@isHot" Name="@(Name + ".IsHot")" />
     </ChildContent>
     <DescriptionFragment>
-      Горячая роль специальным образом выделяется в ролевке. Если ваш проект публичный, горячая роль будет автоматически рекламироваться в канале «Зовем на игру» <a href="https://t.me/zovem_joinrpg" target="_blank" rel="noopener">https://t.me/zovem_joinrpg</a>
+      Горячая роль специальным образом выделяется в ролевке. Если ваш проект публичный, горячая роль будет автоматически рекламироваться в канале <TelegramLink Link="zovem_joinrpg">«Зовем на игру»</TelegramLink>
     </DescriptionFragment>
   </FormRow>
 }


### PR DESCRIPTION
## Что сделано
- В описании чекбокса «Горячая роль» добавлено упоминание о том, что для публичных проектов горячая роль автоматически рекламируется в канале «Зовем на игру» (https://t.me/zovem_joinrpg), со ссылкой.
- Попутно исправлен баг в `FormRow`: `DescriptionFragment` рендерился как `@Description` (пустая строка), из-за чего фрагмент с описанием не показывался.

## Тест-план
- [ ] Открыть страницу редактирования шаблона/роли персонажа, включить тип «Персонаж» или «Шаблон», убедиться, что под чекбоксом «Горячая роль» отображается новый текст со ссылкой на канал

Generated with [Claude Code](https://claude.ai/code)