### PR TITLE
feat: добавить ссылку на ВК игры в рекламное сообщение горячей роли

### DIFF
--- a/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.BuildMessage_WhenVkClubIsSet_IncludesVkLink.verified.txt
+++ b/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.BuildMessage_WhenVkClubIsSet_IncludesVkLink.verified.txt
@@ -1,0 +1,14 @@
+﻿<strong>Горячая роль «Тёмный властелин» на игре «Зимний путь»</strong>
+
+Зимний путь 2026, Московская область
+1–5 марта 2026
+https://kogda-igra.ru/game/1/
+<a href="https://vk.com/club219947794">ВК игры</a>
+
+<strong>Тёмный властелин</strong>
+
+<p>Описание персонажа</p>
+
+<a href="https://joinrpg.ru/character/1/claim">Подать заявку</a>
+
+<em>Сообщение от joinrpg</em>

--- a/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.BuildMessage_WhenVkClubIsSet_IncludesVkLink.verified.txt
+++ b/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.BuildMessage_WhenVkClubIsSet_IncludesVkLink.verified.txt
@@ -3,7 +3,7 @@
 Зимний путь 2026, Московская область
 1–5 марта 2026
 https://kogda-igra.ru/game/1/
-<a href="https://vk.com/club219947794">ВК игры</a>
+ВК: <a href="https://vk.com/club219947794">club219947794</a>
 
 <strong>Тёмный властелин</strong>
 

--- a/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/HotRoleAdvertisementMessageBuilderTests.cs
@@ -57,4 +57,33 @@ public class HotRoleAdvertisementMessageBuilderTests
 
         return Verify(message.Contents);
     }
+
+    [Fact]
+    public Task BuildMessage_WhenVkClubIsSet_IncludesVkLink()
+    {
+        var uri = new Uri("https://joinrpg.ru/character/1/claim");
+
+        var kogdaIgraGame = new KogdaIgraGameData(
+            new KogdaIgraIdentification(1),
+            "Зимний путь 2026",
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 3, 5),
+            "Московская область",
+            "",
+            SiteUri: null,
+            IsActive: true,
+            VkClub: new VkId("club219947794"));
+
+        var kogdaIgraCardUri = new Uri("https://kogda-igra.ru/game/1/");
+
+        var message = TelegramSingleHotRoleSender.BuildMessage(
+            "Тёмный властелин",
+            "Зимний путь",
+            new MarkdownString("Описание персонажа"),
+            kogdaIgraGame,
+            kogdaIgraCardUri,
+            uri);
+
+        return Verify(message.Contents);
+    }
 }

--- a/src/JoinRpg.Services.Advertisement/Sending/TelegramSingleHotRoleSender.cs
+++ b/src/JoinRpg.Services.Advertisement/Sending/TelegramSingleHotRoleSender.cs
@@ -47,7 +47,7 @@ internal class TelegramSingleHotRoleSender(
         var dateRangeString = DateRangeFormatter.FormatDisplay(dateRange, CultureInfo.GetCultureInfo("ru-RU"));
 
         var vkLine = kogdaIgraGame.VkClub is { } vk
-            ? $"<a href=\"https://vk.com/{vk.Value}\">ВК игры</a>\n"
+            ? $"ВК: <a href=\"https://vk.com/{vk.Value}\">{WebUtility.HtmlEncode(vk.Value)}</a>\n"
             : string.Empty;
 
         var text =

--- a/src/JoinRpg.Services.Advertisement/Sending/TelegramSingleHotRoleSender.cs
+++ b/src/JoinRpg.Services.Advertisement/Sending/TelegramSingleHotRoleSender.cs
@@ -46,11 +46,17 @@ internal class TelegramSingleHotRoleSender(
         var dateRange = new DateRange(kogdaIgraGame.Begin, kogdaIgraGame.End);
         var dateRangeString = DateRangeFormatter.FormatDisplay(dateRange, CultureInfo.GetCultureInfo("ru-RU"));
 
+        var vkLine = kogdaIgraGame.VkClub is { } vk
+            ? $"<a href=\"https://vk.com/{vk.Value}\">ВК игры</a>\n"
+            : string.Empty;
+
         var text =
             $"<strong>Горячая роль «{WebUtility.HtmlEncode(characterName)}» на игре «{WebUtility.HtmlEncode(projectName)}»</strong>\n\n" +
             $"{WebUtility.HtmlEncode(kogdaIgraGame.Name)}, {WebUtility.HtmlEncode(kogdaIgraGame.RegionName)}{masterGroupSuffix}\n" +
             $"{dateRangeString}\n" +
-            $"{kogdaIgraCardUri}\n\n" +
+            $"{kogdaIgraCardUri}\n" +
+            vkLine +
+            "\n" +
             $"<strong>{WebUtility.HtmlEncode(characterName)}</strong>\n\n" +
             $"{characterDescription.ToHtmlString().Value}\n\n" +
             $"<a href=\"{addClaimUri}\">Подать заявку</a>\n\n" +


### PR DESCRIPTION
## Что сделано
- В текст объявления горячей роли (`TelegramSingleHotRoleSender.BuildMessage`) добавлена ссылка на группу ВК игры, если она заполнена в карточке КогдаИгры (`KogdaIgraGameData.VkClub`).
- Добавлен юнит-тест `BuildMessage_WhenVkClubIsSet_IncludesVkLink`, проверяющий появление ссылки.

## Test plan
- [x] `dotnet test src/JoinRpg.Services.Advertisement.Test` — все тесты проходят
- [x] `dotnet build` без ошибок

Generated with [Claude Code](https://claude.ai/code)