### PR TITLE
fix: блокировать отвязку ВК администратором, если это единственный способ входа

### DIFF
--- a/src/JoinRpg.Web.AdminTools/AdminUserActionsPanel.razor
+++ b/src/JoinRpg.Web.AdminTools/AdminUserActionsPanel.razor
@@ -39,6 +39,8 @@
             Label="Отвязать ВК"
             AutoConfirm="true"
             AutoConfirmMessage="Действительно отвязать ВК у этого пользователя?"
+            Disabled="@panel.IsVkOnlyLoginMethod"
+            DisabledTitle="Невозможно удалить единственный способ входа"
             OnClick="RemoveVkLinkAsync" />
     }
 

--- a/src/JoinRpg.Web.AdminTools/UserAdminPanelViewModel.cs
+++ b/src/JoinRpg.Web.AdminTools/UserAdminPanelViewModel.cs
@@ -1,3 +1,3 @@
 namespace JoinRpg.Web.AdminTools;
 
-public record UserAdminPanelViewModel(bool IsAdmin, bool IsVerifiedUser, bool HasVkLink);
+public record UserAdminPanelViewModel(bool IsAdmin, bool IsVerifiedUser, bool HasVkLink, bool IsVkOnlyLoginMethod);

--- a/src/Joinrpg.Web.Identity/UserAdminViewService.cs
+++ b/src/Joinrpg.Web.Identity/UserAdminViewService.cs
@@ -1,5 +1,6 @@
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel;
+using JoinRpg.DomainTypes.Users;
 using JoinRpg.Services.Interfaces;
 using JoinRpg.Web.AdminTools;
 
@@ -15,7 +16,7 @@ public class UserAdminViewService(
     {
         var userInfo = await userRepository.GetRequiredUserInfo(userId);
         var hasVkLink = userInfo.Social.Vk is not null;
-        var isVkOnlyLoginMethod = hasVkLink && userInfo.HasSingleLoginMethod;
+        var isVkOnlyLoginMethod = IsVkOnlyLoginMethod(userInfo);
 
         return new UserAdminPanelViewModel(userInfo.IsAdmin, userInfo.VerifiedProfileFlag, hasVkLink, isVkOnlyLoginMethod);
     }
@@ -23,7 +24,7 @@ public class UserAdminViewService(
     public async Task RemoveVkLink(UserIdentification userId)
     {
         var userInfo = await userRepository.GetRequiredUserInfo(userId);
-        if (userInfo.HasSingleLoginMethod)
+        if (IsVkOnlyLoginMethod(userInfo))
         {
             throw new InvalidOperationException("Невозможно удалить единственный способ входа");
         }
@@ -42,6 +43,9 @@ public class UserAdminViewService(
             await userService.RemoveVkFromProfile(userId);
         }
     }
+
+    private static bool IsVkOnlyLoginMethod(UserInfo userInfo)
+        => userInfo.Social.Vk?.CanLogin == true && userInfo.HasSingleLoginMethod;
 
     public async Task SetAdminFlag(UserIdentification userId, bool value)
     {

--- a/src/Joinrpg.Web.Identity/UserAdminViewService.cs
+++ b/src/Joinrpg.Web.Identity/UserAdminViewService.cs
@@ -13,14 +13,29 @@ public class UserAdminViewService(
 {
     public async Task<UserAdminPanelViewModel> GetAdminPanel(UserIdentification userId)
     {
-        var user = await userRepository.GetRequiredUserInfo(userId);
-        return new UserAdminPanelViewModel(user.IsAdmin, user.VerifiedProfileFlag, user.Social.Vk is not null);
+        var userInfo = await userRepository.GetRequiredUserInfo(userId);
+        var hasVkLink = userInfo.Social.Vk is not null;
+
+        var isVkOnlyLoginMethod = false;
+        if (hasVkLink)
+        {
+            var identityUser = await userManager.FindByIdAsync(userId.Value.ToString());
+            var logins = await userManager.GetLoginsAsync(identityUser);
+            isVkOnlyLoginMethod = await IsVkOnlyLoginMethod(identityUser, logins);
+        }
+
+        return new UserAdminPanelViewModel(userInfo.IsAdmin, userInfo.VerifiedProfileFlag, hasVkLink, isVkOnlyLoginMethod);
     }
 
     public async Task RemoveVkLink(UserIdentification userId)
     {
         var user = await userManager.FindByIdAsync(userId.Value.ToString());
         var logins = await userManager.GetLoginsAsync(user);
+        if (await IsVkOnlyLoginMethod(user, logins))
+        {
+            throw new InvalidOperationException("Невозможно удалить единственный способ входа");
+        }
+
         var vkLogin = logins.FirstOrDefault(l =>
             string.Equals(l.LoginProvider, UserExternalLogin.VkProvider, StringComparison.OrdinalIgnoreCase));
         if (vkLogin is not null)
@@ -32,6 +47,12 @@ public class UserAdminViewService(
             // ВК мог быть привязан без записи в AspNetUserLogins (легаси-данные) — чистим профиль напрямую.
             await userService.RemoveVkFromProfile(userId);
         }
+    }
+
+    private async Task<bool> IsVkOnlyLoginMethod(JoinIdentityUser user, IList<UserLoginInfo> logins)
+    {
+        var hasPassword = await userManager.HasPasswordAsync(user);
+        return !hasPassword && logins.Count <= 1;
     }
 
     public async Task SetAdminFlag(UserIdentification userId, bool value)

--- a/src/Joinrpg.Web.Identity/UserAdminViewService.cs
+++ b/src/Joinrpg.Web.Identity/UserAdminViewService.cs
@@ -15,27 +15,21 @@ public class UserAdminViewService(
     {
         var userInfo = await userRepository.GetRequiredUserInfo(userId);
         var hasVkLink = userInfo.Social.Vk is not null;
-
-        var isVkOnlyLoginMethod = false;
-        if (hasVkLink)
-        {
-            var identityUser = await userManager.FindByIdAsync(userId.Value.ToString());
-            var logins = await userManager.GetLoginsAsync(identityUser);
-            isVkOnlyLoginMethod = await IsVkOnlyLoginMethod(identityUser, logins);
-        }
+        var isVkOnlyLoginMethod = hasVkLink && userInfo.HasSingleLoginMethod;
 
         return new UserAdminPanelViewModel(userInfo.IsAdmin, userInfo.VerifiedProfileFlag, hasVkLink, isVkOnlyLoginMethod);
     }
 
     public async Task RemoveVkLink(UserIdentification userId)
     {
-        var user = await userManager.FindByIdAsync(userId.Value.ToString());
-        var logins = await userManager.GetLoginsAsync(user);
-        if (await IsVkOnlyLoginMethod(user, logins))
+        var userInfo = await userRepository.GetRequiredUserInfo(userId);
+        if (userInfo.HasSingleLoginMethod)
         {
             throw new InvalidOperationException("Невозможно удалить единственный способ входа");
         }
 
+        var user = await userManager.FindByIdAsync(userId.Value.ToString());
+        var logins = await userManager.GetLoginsAsync(user);
         var vkLogin = logins.FirstOrDefault(l =>
             string.Equals(l.LoginProvider, UserExternalLogin.VkProvider, StringComparison.OrdinalIgnoreCase));
         if (vkLogin is not null)
@@ -47,12 +41,6 @@ public class UserAdminViewService(
             // ВК мог быть привязан без записи в AspNetUserLogins (легаси-данные) — чистим профиль напрямую.
             await userService.RemoveVkFromProfile(userId);
         }
-    }
-
-    private async Task<bool> IsVkOnlyLoginMethod(JoinIdentityUser user, IList<UserLoginInfo> logins)
-    {
-        var hasPassword = await userManager.HasPasswordAsync(user);
-        return !hasPassword && logins.Count <= 1;
     }
 
     public async Task SetAdminFlag(UserIdentification userId, bool value)


### PR DESCRIPTION
## Что сделано
- Кнопка «Отвязать ВК» на панели администратора теперь дизейблится с подсказкой «Невозможно удалить единственный способ входа», если у пользователя нет пароля и других внешних логинов, кроме ВК.
- На уровне сервиса (`UserAdminViewService.RemoveVkLink`) добавлена та же проверка — при попытке отвязать единственный способ входа выбрасывается исключение, чтобы защититься от прямых запросов к API в обход UI.

## Почему
Раньше кнопка отвязки ВК работала безусловно, даже если ВК был единственным способом входа пользователя — это могло привести к полной блокировке его учётной записи.

Generated with [Claude Code](https://claude.ai/code)