### PR TITLE
feat: флаг активности у каналов и расписаний рекламы

### DIFF
--- a/src/JoinRpg.Data.Interfaces/IAdvertisementScheduleRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IAdvertisementScheduleRepository.cs
@@ -2,5 +2,9 @@ namespace JoinRpg.Data.Interfaces;
 
 public interface IAdvertisementScheduleRepository
 {
+    /// <summary>Расписания, которые фактически активны (см. <see cref="AdvertisementScheduleInfo.IsEffectivelyActive"/>) — для рассылки.</summary>
     Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetActiveSchedules();
+
+    /// <summary>Все расписания независимо от активности — для админского UI.</summary>
+    Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetAllSchedules();
 }

--- a/src/JoinRpg.DomainTypes/Advertisement/AdvertisementInfo.cs
+++ b/src/JoinRpg.DomainTypes/Advertisement/AdvertisementInfo.cs
@@ -10,7 +10,8 @@ public record AdvertisementChannelInfo(
     AdvertisementChannelIdentification ChannelId,
     string Name,
     ProjectIdentification? BoundProjectId, // null = глобальный канал
-    AdvertisementChannelSettings Settings);
+    AdvertisementChannelSettings Settings,
+    bool IsActive = true);
 
 [method: JsonConstructor]
 [TypedEntityId(ShortName = "AdvSchedule")]
@@ -25,7 +26,14 @@ public record AdvertisementScheduleInfo(
     AdvertisementScheduleIdentification ScheduleId,
     AdvertisementChannelInfo Channel,
     AdvertisementMethod Method,
-    IReadOnlySet<DayOfWeek> Days);
+    IReadOnlySet<DayOfWeek> Days,
+    bool IsActive = true)
+{
+    /// <summary>
+    /// Расписание фактически активно, только если активно и оно само, и его канал.
+    /// </summary>
+    public bool IsEffectivelyActive => IsActive && Channel.IsActive;
+}
 
 public enum AdvertisementLogStatus
 {

--- a/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/Admin/AdvertisementDashboard.cshtml.cs
@@ -16,6 +16,6 @@ public class AdvertisementDashboardModel(
     public async Task OnGetAsync()
     {
         Channels = [.. await channelRepository.GetAllChannels()];
-        Schedules = [.. await scheduleRepository.GetActiveSchedules()];
+        Schedules = [.. await scheduleRepository.GetAllSchedules()];
     }
 }

--- a/src/JoinRpg.Services.Advertisement.Test/AdvertisementScheduleInfoTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/AdvertisementScheduleInfoTests.cs
@@ -1,0 +1,22 @@
+namespace JoinRpg.Services.Advertisement.Test;
+
+public class AdvertisementScheduleInfoTests
+{
+    private static AdvertisementChannelInfo Channel(bool isActive) =>
+        new(new AdvertisementChannelIdentification(1), Name: "Test", BoundProjectId: null, new TelegramChannelSettings(new TelegramChatId(-100)), IsActive: isActive);
+
+    private static AdvertisementScheduleInfo Schedule(bool scheduleActive, bool channelActive) =>
+        new(new AdvertisementScheduleIdentification(1), Channel(channelActive), AdvertisementMethod.SingleHotRole, Enum.GetValues<DayOfWeek>().ToHashSet(), IsActive: scheduleActive);
+
+    [Fact]
+    public void IsEffectivelyActive_ActiveScheduleAndActiveChannel_ReturnsTrue() =>
+        Schedule(scheduleActive: true, channelActive: true).IsEffectivelyActive.ShouldBeTrue();
+
+    [Fact]
+    public void IsEffectivelyActive_InactiveSchedule_ReturnsFalse() =>
+        Schedule(scheduleActive: false, channelActive: true).IsEffectivelyActive.ShouldBeFalse();
+
+    [Fact]
+    public void IsEffectivelyActive_InactiveChannel_ReturnsFalse() =>
+        Schedule(scheduleActive: true, channelActive: false).IsEffectivelyActive.ShouldBeFalse();
+}

--- a/src/JoinRpg.Services.Advertisement.Test/HardcodedAdvertisementScheduleRepositoryTests.cs
+++ b/src/JoinRpg.Services.Advertisement.Test/HardcodedAdvertisementScheduleRepositoryTests.cs
@@ -28,4 +28,14 @@ public class HardcodedAdvertisementScheduleRepositoryTests
         schedule.Method.ShouldBe(AdvertisementMethod.SingleHotRole);
         schedule.Days.ShouldBe([DayOfWeek.Wednesday], ignoreOrder: true);
     }
+
+    [Fact]
+    public async Task GetAllSchedules_ReturnsBothChannelsRegardlessOfActivity()
+    {
+        var repository = new HardcodedAdvertisementScheduleRepository(new HardcodedAdvertisementChannelRepository());
+
+        var schedules = await repository.GetAllSchedules();
+
+        schedules.Count.ShouldBe(2);
+    }
 }

--- a/src/JoinRpg.Services.Advertisement/Schedules/HardcodedAdvertisementScheduleRepository.cs
+++ b/src/JoinRpg.Services.Advertisement/Schedules/HardcodedAdvertisementScheduleRepository.cs
@@ -6,7 +6,10 @@ internal class HardcodedAdvertisementScheduleRepository(IAdvertisementChannelRep
     private static readonly IReadOnlySet<DayOfWeek> EveryDay = Enum.GetValues<DayOfWeek>().ToHashSet();
     private static readonly IReadOnlySet<DayOfWeek> Wednesdays = new HashSet<DayOfWeek> { DayOfWeek.Wednesday };
 
-    public async Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetActiveSchedules()
+    public async Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetActiveSchedules() =>
+        [.. (await GetAllSchedules()).Where(s => s.IsEffectivelyActive)];
+
+    public async Task<IReadOnlyCollection<AdvertisementScheduleInfo>> GetAllSchedules()
     {
         var schedules = new List<AdvertisementScheduleInfo>();
 

--- a/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementChannelsGrid.razor
+++ b/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementChannelsGrid.razor
@@ -9,6 +9,7 @@
             <th>Название</th>
             <th>Игра</th>
             <th>Настройки</th>
+            <th>Активен</th>
         </tr>
     </HeadContent>
     <ItemTemplate>
@@ -26,6 +27,7 @@
                 }
             </td>
             <td>@DescribeSettings(channel.Settings)</td>
+            <td>@(channel.IsActive ? "Да" : "Нет")</td>
         </tr>
     </ItemTemplate>
 </JoinBorderedTable>

--- a/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementSchedulesGrid.razor
+++ b/src/JoinRpg.Web.AdminTools/Advertisement/AdvertisementSchedulesGrid.razor
@@ -7,6 +7,7 @@
             <th>Канал</th>
             <th>Способ</th>
             <th>Дни</th>
+            <th>Активно</th>
         </tr>
     </HeadContent>
     <ItemTemplate>
@@ -15,6 +16,7 @@
             <td>@schedule.Channel.Name</td>
             <td>@schedule.Method</td>
             <td>@DescribeDays(schedule.Days)</td>
+            <td>@DescribeActivity(schedule)</td>
         </tr>
     </ItemTemplate>
 </JoinBorderedTable>
@@ -39,4 +41,12 @@
         days.Count == 7
             ? "Каждый день"
             : string.Join(", ", Enum.GetValues<DayOfWeek>().Where(days.Contains).Select(d => DayNames[d]));
+
+    private static string DescribeActivity(AdvertisementScheduleInfo schedule) =>
+        (schedule.IsActive, schedule.Channel.IsActive) switch
+        {
+            (true, true) => "Да",
+            (false, _) => "Нет",
+            (true, false) => "Нет (канал неактивен)",
+        };
 }


### PR DESCRIPTION
## Что сделано

Развитие #4713 (админ-страница каналов/расписаний рекламы): добавлен флаг активности.

- `AdvertisementChannelInfo` и `AdvertisementScheduleInfo` получили `bool IsActive = true`.
- У расписания добавлено вычисляемое `IsEffectivelyActive` — активно само расписание и активен его канал.
- `IAdvertisementScheduleRepository.GetActiveSchedules()` теперь фильтрует по `IsEffectivelyActive` — неактивные расписания (сами по себе или из-за неактивного канала) не попадают в рассылку `SingleHotRoleAdvertisementJob` без изменений в самой джобе.
- Добавлен `GetAllSchedules()` (без фильтра) — использует админская страница, чтобы показывать в том числе неактивные расписания.
- В гриды `AdvertisementChannelsGrid`/`AdvertisementSchedulesGrid` добавлены колонки активности; для расписания отдельно показывается причина неактивности («Нет (канал неактивен)»).

## Test plan

- [x] `dotnet build src/JoinRpg.Portal/JoinRpg.Portal.csproj`
- [x] `dotnet test src/JoinRpg.Services.Advertisement.Test` (18/18)
- [x] `dotnet format --verify-no-changes --severity error`
- [ ] Ручная проверка страницы `/Admin/AdvertisementDashboard` в браузере

Generated with [Claude Code](https://claude.ai/code)