### PR TITLE
fix: синхронизировать порядок спецгрупп при перемещении/сортировке полей и вариантов

### DIFF
--- a/src/JoinRpg.Services.Impl.Test/CharacterGroupServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/CharacterGroupServiceTest.cs
@@ -209,4 +209,42 @@ public class CharacterGroupServiceTest
         root.ChildGroupsOrdering.ShouldNotBeNullOrEmpty();
         unitOfWork.SaveChangesCallCount.ShouldBe(1);
     }
+
+    [Fact]
+    public async Task MoveCharacterGroupAfter_SpecialGroup_Throws_AndDoesNotSave()
+    {
+        var root = mock.Project.CharacterGroups.Single(g => g.IsRoot);
+        var special = mock.CreateCharacterGroup();
+        special.IsSpecial = true;
+        special.ParentCharacterGroupIds = [root.CharacterGroupId];
+        var regular = mock.CreateCharacterGroup();
+        regular.ParentCharacterGroupIds = [root.CharacterGroupId];
+        mock.ReInitProjectInfo();
+
+        var service = CreateService(mock.Master.UserId);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => service.MoveCharacterGroupAfter(
+            RootGroupId, GroupId(special), GroupId(regular)));
+
+        unitOfWork.SaveChangesCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task MoveCharacterGroupAfter_AfterSpecialGroup_Throws_AndDoesNotSave()
+    {
+        var root = mock.Project.CharacterGroups.Single(g => g.IsRoot);
+        var special = mock.CreateCharacterGroup();
+        special.IsSpecial = true;
+        special.ParentCharacterGroupIds = [root.CharacterGroupId];
+        var regular = mock.CreateCharacterGroup();
+        regular.ParentCharacterGroupIds = [root.CharacterGroupId];
+        mock.ReInitProjectInfo();
+
+        var service = CreateService(mock.Master.UserId);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => service.MoveCharacterGroupAfter(
+            RootGroupId, GroupId(regular), GroupId(special)));
+
+        unitOfWork.SaveChangesCallCount.ShouldBe(0);
+    }
 }

--- a/src/JoinRpg.Services.Impl.Test/Projects/FieldSetupServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/Projects/FieldSetupServiceTest.cs
@@ -128,4 +128,169 @@ public class FieldSetupServiceTest : ProjectMetadataServiceTestBase
         newOrder.Select(id => id.ProjectFieldVariantId).ShouldBe([100, 102, 101]);
         unitOfWork.SaveChangesCallCount.ShouldBe(1);
     }
+
+    private CharacterGroup AddSpecialGroup(ProjectField field, string name)
+    {
+        var group = mock.CreateCharacterGroup();
+        group.IsSpecial = true;
+        group.CharacterGroupName = name;
+        group.ParentCharacterGroupIds = [mock.Project.RootGroup.CharacterGroupId];
+        field.CharacterGroup = group;
+        return group;
+    }
+
+    private CharacterGroup AddSpecialGroup(ProjectFieldDropdownValue variant, CharacterGroup parentGroup, string name)
+    {
+        var group = mock.CreateCharacterGroup();
+        group.IsSpecial = true;
+        group.CharacterGroupName = name;
+        group.ParentCharacterGroupIds = [parentGroup.CharacterGroupId];
+        variant.CharacterGroup = group;
+        return group;
+    }
+
+    [Fact]
+    public async Task MoveField_WithSpecialGroup_SyncsRootGroupOrdering()
+    {
+        var field1 = mock.AddField(f => f.FieldType = ProjectFieldType.Dropdown);
+        var group1 = AddSpecialGroup(mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field1.Id.ProjectFieldId), "Поле 1");
+        var field2 = mock.AddField(f => f.FieldType = ProjectFieldType.Dropdown);
+        var group2 = AddSpecialGroup(mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field2.Id.ProjectFieldId), "Поле 2");
+
+        mock.Project.Details.FieldsOrdering = $"{field1.Id.ProjectFieldId},{field2.Id.ProjectFieldId}";
+        mock.Project.RootGroup.ChildGroupsOrdering = $"{group1.CharacterGroupId},{group2.CharacterGroupId}";
+
+        var service = CreateService(mock.Master.UserId);
+
+        await service.MoveField(ProjectId.Value, field1.Id.ProjectFieldId, direction: 1);
+
+        mock.Project.RootGroup.GetCharacterGroupsContainer().OrderedItems
+            .Select(g => g.CharacterGroupId)
+            .ShouldBe([group2.CharacterGroupId, group1.CharacterGroupId]);
+    }
+
+    [Fact]
+    public async Task MoveFieldAfter_WithSpecialGroup_SyncsRootGroupOrdering()
+    {
+        var field1 = mock.AddField(f => f.FieldType = ProjectFieldType.Dropdown);
+        var group1 = AddSpecialGroup(mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field1.Id.ProjectFieldId), "Поле 1");
+        var field2 = mock.AddField(f => f.FieldType = ProjectFieldType.Dropdown);
+        var group2 = AddSpecialGroup(mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field2.Id.ProjectFieldId), "Поле 2");
+        var field3 = mock.AddField(f => f.FieldType = ProjectFieldType.Dropdown);
+        var group3 = AddSpecialGroup(mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field3.Id.ProjectFieldId), "Поле 3");
+
+        mock.Project.Details.FieldsOrdering = $"{field1.Id.ProjectFieldId},{field2.Id.ProjectFieldId},{field3.Id.ProjectFieldId}";
+        mock.Project.RootGroup.ChildGroupsOrdering = $"{group1.CharacterGroupId},{group2.CharacterGroupId},{group3.CharacterGroupId}";
+
+        var service = CreateService(mock.Master.UserId);
+
+        await service.MoveFieldAfter(ProjectId.Value, field3.Id.ProjectFieldId, afterFieldId: field1.Id.ProjectFieldId);
+
+        mock.Project.RootGroup.GetCharacterGroupsContainer().OrderedItems
+            .Select(g => g.CharacterGroupId)
+            .ShouldBe([group1.CharacterGroupId, group3.CharacterGroupId, group2.CharacterGroupId]);
+    }
+
+    [Fact]
+    public async Task MoveFieldVariantAfter_WithSpecialGroup_SyncsFieldGroupOrdering()
+    {
+        var fieldInfo = mock.AddField(f =>
+        {
+            f.FieldType = ProjectFieldType.Dropdown;
+            f.DropdownValues =
+            [
+                new ProjectFieldDropdownValue
+                {
+                    ProjectFieldDropdownValueId = 100,
+                    Label = "Вариант 1",
+                    IsActive = true,
+                    Description = new MarkdownDbValue(),
+                    MasterDescription = new MarkdownDbValue(),
+                },
+                new ProjectFieldDropdownValue
+                {
+                    ProjectFieldDropdownValueId = 101,
+                    Label = "Вариант 2",
+                    IsActive = true,
+                    Description = new MarkdownDbValue(),
+                    MasterDescription = new MarkdownDbValue(),
+                },
+            ];
+        });
+        var field = mock.Project.ProjectFields.Single(f => f.ProjectFieldId == fieldInfo.Id.ProjectFieldId);
+        var fieldGroup = AddSpecialGroup(field, "Поле");
+        var variant1 = field.DropdownValues.Single(v => v.ProjectFieldDropdownValueId == 100);
+        var variant2 = field.DropdownValues.Single(v => v.ProjectFieldDropdownValueId == 101);
+        var variantGroup1 = AddSpecialGroup(variant1, fieldGroup, "Вариант 1");
+        var variantGroup2 = AddSpecialGroup(variant2, fieldGroup, "Вариант 2");
+
+        fieldGroup.ChildGroupsOrdering = $"{variantGroup1.CharacterGroupId},{variantGroup2.CharacterGroupId}";
+
+        var service = CreateService(mock.Master.UserId);
+
+        _ = await service.MoveFieldVariantAfter(
+            new ProjectFieldVariantIdentification(fieldInfo.Id, 100),
+            new ProjectFieldVariantIdentification(fieldInfo.Id, 101));
+
+        fieldGroup.GetCharacterGroupsContainer().OrderedItems
+            .Select(g => g.CharacterGroupId)
+            .ShouldBe([variantGroup2.CharacterGroupId, variantGroup1.CharacterGroupId]);
+    }
+
+    [Fact]
+    public async Task SortFieldVariants_WithSpecialGroups_SortsGroupsByName()
+    {
+        var fieldInfo = mock.AddField(f =>
+        {
+            f.FieldType = ProjectFieldType.Dropdown;
+            f.DropdownValues =
+            [
+                new ProjectFieldDropdownValue
+                {
+                    ProjectFieldDropdownValueId = 100,
+                    Label = "Zebra",
+                    IsActive = true,
+                    Description = new MarkdownDbValue(),
+                    MasterDescription = new MarkdownDbValue(),
+                },
+                new ProjectFieldDropdownValue
+                {
+                    ProjectFieldDropdownValueId = 101,
+                    Label = "Alpha",
+                    IsActive = true,
+                    Description = new MarkdownDbValue(),
+                    MasterDescription = new MarkdownDbValue(),
+                },
+            ];
+        });
+        var field = mock.Project.ProjectFields.Single(f => f.ProjectFieldId == fieldInfo.Id.ProjectFieldId);
+        var fieldGroup = AddSpecialGroup(field, "Поле");
+        var variantZebra = field.DropdownValues.Single(v => v.ProjectFieldDropdownValueId == 100);
+        var variantAlpha = field.DropdownValues.Single(v => v.ProjectFieldDropdownValueId == 101);
+        var groupZebra = AddSpecialGroup(variantZebra, fieldGroup, "Zebra");
+        var groupAlpha = AddSpecialGroup(variantAlpha, fieldGroup, "Alpha");
+
+        field.ValuesOrdering = $"{variantZebra.ProjectFieldDropdownValueId},{variantAlpha.ProjectFieldDropdownValueId}";
+        fieldGroup.ChildGroupsOrdering = $"{groupZebra.CharacterGroupId},{groupAlpha.CharacterGroupId}";
+
+        var service = CreateService(mock.Master.UserId);
+
+        await service.SortFieldVariants(ProjectId.Value, fieldInfo.Id.ProjectFieldId);
+
+        fieldGroup.GetCharacterGroupsContainer().OrderedItems
+            .Select(g => g.CharacterGroupId)
+            .ShouldBe([groupAlpha.CharacterGroupId, groupZebra.CharacterGroupId]);
+    }
+
+    [Fact]
+    public async Task MoveField_WithoutSpecialGroup_DoesNotThrow()
+    {
+        var field1 = mock.AddField(f => f.FieldType = ProjectFieldType.String);
+        var field2 = mock.AddField(f => f.FieldType = ProjectFieldType.String);
+        mock.Project.Details.FieldsOrdering = $"{field1.Id.ProjectFieldId},{field2.Id.ProjectFieldId}";
+
+        var service = CreateService(mock.Master.UserId);
+
+        await Should.NotThrowAsync(() => service.MoveField(ProjectId.Value, field1.Id.ProjectFieldId, direction: 1));
+    }
 }

--- a/src/JoinRpg.Services.Impl/Projects/Metadata/CharacterGroupService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Metadata/CharacterGroupService.cs
@@ -174,6 +174,15 @@ internal class CharacterGroupService(IProjectPropsService projectPropsService) :
             {
                 var (parentCharacterGroup, _) = ctx.GetCharacterGroupForChange(ctx.Request.parentCharacterGroupId, allowRoot: true);
 
+                if (ctx.ProjectInfo.Groups[ctx.Request.characterGroupId].IsSpecial
+                    || (ctx.Request.afterCharacterGroupId is { } afterId && ctx.ProjectInfo.Groups[afterId].IsSpecial))
+                {
+                    // Специальные группы (привязанные к полям/вариантам) сортируются автоматически
+                    // сервисом FieldSetupServiceImpl вслед за полем/вариантом — вручную их порядок
+                    // менять нельзя.
+                    throw new InvalidOperationException("Нельзя вручную менять порядок специальных групп.");
+                }
+
                 var container = parentCharacterGroup.GetCharacterGroupsContainer()
                     .MoveAfter(ctx.Request.characterGroupId.CharacterGroupId, ctx.Request.afterCharacterGroupId?.CharacterGroupId);
                 parentCharacterGroup.ChildGroupsOrdering = container.GetStoredOrder();

--- a/src/JoinRpg.Services.Impl/Projects/Metadata/FieldSetupServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Metadata/FieldSetupServiceImpl.cs
@@ -171,6 +171,13 @@ internal class FieldSetupServiceImpl(
                 var field = GetField(ctx.Project, ctx.Request.projectcharacterfieldid);
                 ctx.Project.Details.FieldsOrdering
                     = ctx.Project.GetFieldsContainer().Move(field, ctx.Request.direction).GetStoredOrder();
+
+                if (field.CharacterGroup != null)
+                {
+                    var rootGroup = ctx.Project.RootGroup;
+                    rootGroup.ChildGroupsOrdering = rootGroup.GetCharacterGroupsContainer()
+                        .Move(field.CharacterGroup, ctx.Request.direction).GetStoredOrder();
+                }
             });
     }
 
@@ -191,6 +198,14 @@ internal class FieldSetupServiceImpl(
 
                 var container = field.GetFieldValuesContainer().MoveAfter(variant, afterVariant);
                 field.ValuesOrdering = container.GetStoredOrder();
+
+                if (field.CharacterGroup != null && variant.CharacterGroup != null)
+                {
+                    var afterGroup = afterVariant?.CharacterGroup;
+                    field.CharacterGroup.ChildGroupsOrdering = field.CharacterGroup.GetCharacterGroupsContainer()
+                        .MoveAfter(variant.CharacterGroup, afterGroup).GetStoredOrder();
+                }
+
                 return container.OrderedItems
                     .Select(v => v.GetId())
                     .ToList();
@@ -240,6 +255,15 @@ internal class FieldSetupServiceImpl(
 
                 var container = ctx.Project.GetFieldsContainer().MoveAfter(field, afterField);
                 ctx.Project.Details.FieldsOrdering = container.GetStoredOrder();
+
+                if (field.CharacterGroup != null)
+                {
+                    var rootGroup = ctx.Project.RootGroup;
+                    var afterGroup = afterField?.CharacterGroup;
+                    rootGroup.ChildGroupsOrdering = rootGroup.GetCharacterGroupsContainer()
+                        .MoveAfter(field.CharacterGroup, afterGroup).GetStoredOrder();
+                }
+
                 var pid = new ProjectIdentification(ctx.Project.ProjectId);
                 return container.OrderedItems
                     .Select(f => f.GetId())
@@ -274,6 +298,13 @@ internal class FieldSetupServiceImpl(
                 var container = field.GetFieldValuesContainer();
                 container.SortBy(x => x.Label);
                 field.ValuesOrdering = container.GetStoredOrder();
+
+                if (field.CharacterGroup != null)
+                {
+                    var groupContainer = field.CharacterGroup.GetCharacterGroupsContainer();
+                    groupContainer.SortBy(g => g.CharacterGroupName);
+                    field.CharacterGroup.ChildGroupsOrdering = groupContainer.GetStoredOrder();
+                }
             });
     }
 


### PR DESCRIPTION
## Что сделано
- При перемещении поля (`MoveField`/`MoveFieldAfter`) и варианта дропдауна (`MoveFieldVariantAfter`), а также при сортировке вариантов по алфавиту (`SortFieldVariants`) теперь синхронно обновляется `ChildGroupsOrdering` соответствующей спецгруппы — чтобы порядок в сетке ролей совпадал с порядком полей/вариантов в настройках.
- Портировано на актуальную реализацию `FieldSetupServiceImpl` поверх `IProjectPropsService` (после #4393); часть исходной логики из #4266 (веб он тогда был написан ещё против старой реализации).
- Дополнительно: `MoveCharacterGroupAfter` теперь запрещает вручную менять порядок спецгрупп (саму перемещаемую группу и `afterGroup`) — раньше это было защищено только на уровне UI (скрытие кнопки в `ProjectRoleGridTreeNode`), но не на сервере: `GetCharacterGroupForChange` проверяет тип только родительской группы, а спецгруппы полей висят прямо под Root, поэтому их можно было передать как перемещаемую группу в обход UI.
- Добавлены юнит-тесты на все сценарии, включая защиту от ручного перемещения спецгрупп.

Продолжение #4266 (веб перевязан на актуальный код после рефакторинга `FieldSetupServiceImpl` в #4393; закрываю #4266, открываю новый PR, так как история сильно разошлась).

Closes #4141

Generated with [Claude Code](https://claude.ai/code)