### PR TITLE
fix: отключить попытку GSSAPI-шифрования Npgsql к Postgres

### DIFF
--- a/src/Common/JoinRpg.Common.WebInfrastructure/DbContextRegisterHelper.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/DbContextRegisterHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace JoinRpg.Common.WebInfrastructure;
 
@@ -22,6 +23,16 @@ public static class DbContextRegisterHelper
         {
             return false;
         }
+
+        // Мы не используем Kerberos-аутентификацию к Postgres, а krb5-библиотек в контейнере нет
+        // (см. https://github.com/npgsql/npgsql/issues/6360). Без явного отключения Npgsql 10
+        // всё равно пытается их найти при каждом подключении и пишет в лог не влияющую ни на что ошибку.
+        // В .NET 11 сам рантайм перестанет логировать эту ошибку (https://github.com/dotnet/runtime/issues/126251),
+        // но это отключение можно будет убрать не раньше перехода проекта на .NET 11.
+        connectionString = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            GssEncryptionMode = GssEncryptionMode.Disable,
+        }.ConnectionString;
 
         services.AddDbContext<TContext>(
         options =>


### PR DESCRIPTION
## Что сделано
- В `DbContextRegisterHelper.AddJoinEfCoreDbContext` connection string для всех Postgres-подключений (DataProtection, DailyJob, Notifications, IdPortal) дополняется `GssEncryptionMode=Disable`.

## Почему
Npgsql 10 по умолчанию включил `GssEncryptionMode.Prefer` — при каждом подключении драйвер сначала пытается согласовать GSSAPI/Kerberos-шифрование, для чего пытается загрузить `libgssapi_krb5.so.2`. В официальных .NET-образах (начиная с .NET 8) этой библиотеки нет, поэтому в логе при старте появляется пугающая, но безобидная ошибка:

```
Cannot load library libgssapi_krb5.so.2
Error: libgssapi_krb5.so.2: cannot open shared object file: No such file or directory
```

Соединение при этом всё равно откатывается на обычный TLS и работает нормально — Kerberos для Postgres в проекте не используется. Централизованный фикс в одном хелпере, а не правка connection strings в secrets по отдельности, т.к. все Postgres EF Core контексты регистрируются через него.

См. https://github.com/npgsql/npgsql/issues/6360 — подтверждённое поведение Npgsql 10.
См. https://github.com/dotnet/runtime/issues/126251 — рантайм перестанет логировать эту ошибку начиная с .NET 11, после чего это отключение можно будет убрать.

## Test plan
- [x] `dotnet build` без новых ошибок/предупреждений
- [x] `dotnet format --verify-no-changes` не находит изменений