### PR TITLE
fix: ссылка на группу вела на сетку ролей вместо /details

### DIFF
--- a/src/JoinRpg.Blazor.Client/UriLocatorExtensions.cs
+++ b/src/JoinRpg.Blazor.Client/UriLocatorExtensions.cs
@@ -5,8 +5,9 @@ namespace JoinRpg.Blazor.Client;
 public static class UriLocatorExtensions
 {
     private class UriLocator :
-        IUriLocator<UserLinkViewModel>, IUriLocator<CharacterGroupLinkSlimViewModel>, IUriLocator<CharacterLinkSlimViewModel>,
+        IUriLocator<UserLinkViewModel>, IUriLocator<CharacterLinkSlimViewModel>,
         IUriLocator<ProjectIdentification>, IUriLocator<ClaimIdentification>, IUriLocator<CharacterIdentification>,
+        IUriLocator<CharacterGroupIdentification>,
         ICharacterUriLocator, ICharacterGroupUriLocator, IProjectFieldUriLocator
     {
         public Uri GetUri(ClaimIdentification target) => new Uri($"/{target.ProjectId.Value}/claim/{target.ClaimId}/edit", UriKind.Relative);
@@ -26,9 +27,10 @@ public static class UriLocatorExtensions
             return new($"/user/{target.UserId}", UriKind.Relative);
         }
 
-        Uri IUriLocator<CharacterGroupLinkSlimViewModel>.GetUri(CharacterGroupLinkSlimViewModel target)
-            => new($"/{target.CharacterGroupId.ProjectId.Value}/roles/{target.CharacterGroupId.CharacterGroupId}", UriKind.Relative);
         Uri IUriLocator<CharacterLinkSlimViewModel>.GetUri(CharacterLinkSlimViewModel target) => GetUri(target.CharacterId);
+
+        Uri IUriLocator<CharacterGroupIdentification>.GetUri(CharacterGroupIdentification target)
+            => new($"/{target.ProjectId.Value}/roles/{target.CharacterGroupId}/details", UriKind.Relative);
 
         Uri IUriLocator<ProjectIdentification>.GetUri(ProjectIdentification target) => new($"/{target.Value}/home", UriKind.Relative);
 
@@ -74,9 +76,9 @@ public static class UriLocatorExtensions
         return serviceCollection
             .AddSingleton<IUriLocator<UserLinkViewModel>>(locator)
             .AddSingleton<IUriLocator<ProjectIdentification>>(locator)
-            .AddSingleton<IUriLocator<CharacterGroupLinkSlimViewModel>>(locator)
             .AddSingleton<IUriLocator<ClaimIdentification>>(locator)
             .AddSingleton<IUriLocator<CharacterLinkSlimViewModel>>(locator)
+            .AddSingleton<IUriLocator<CharacterGroupIdentification>>(locator)
             .AddSingleton<ICharacterUriLocator>(locator)
             .AddSingleton<ICharacterGroupUriLocator>(locator)
             .AddSingleton<IProjectFieldUriLocator>(locator)

--- a/src/JoinRpg.DomainTypes/LinkType.cs
+++ b/src/JoinRpg.DomainTypes/LinkType.cs
@@ -5,7 +5,6 @@ public enum LinkType
 {
     ResultUser,
     ResultCharacterGroup,
-    CharacterGroupRoles,
     ResultCharacter,
     Claim,
     Plot,

--- a/src/JoinRpg.Portal.Test/UriLocatorConsistencyTests.cs
+++ b/src/JoinRpg.Portal.Test/UriLocatorConsistencyTests.cs
@@ -1,4 +1,5 @@
 using JoinRpg.Blazor.Client;
+using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.DomainTypes;
 using JoinRpg.Web.ProjectCommon;
 using Microsoft.Extensions.DependencyInjection;
@@ -76,6 +77,16 @@ public class UriLocatorConsistencyTests(IntegrationTestPortalFactory factory)
         var server = call(factory.Services.GetRequiredService<IProjectFieldUriLocator>());
         var client = call(_clientServices.GetRequiredService<IProjectFieldUriLocator>());
         NormalizePathAndQuery(client).ShouldBe(NormalizePathAndQuery(server), StringCompareShould.IgnoreCase);
+    }
+
+    [Fact]
+    public void CharacterGroupLinkShouldPointToDetails()
+    {
+        var server = factory.Services.GetRequiredService<IUriLocator<CharacterGroupIdentification>>().GetUri(GroupId);
+        var client = _clientServices.GetRequiredService<IUriLocator<CharacterGroupIdentification>>().GetUri(GroupId);
+
+        NormalizePathAndQuery(client).ShouldBe(NormalizePathAndQuery(server), StringCompareShould.IgnoreCase);
+        NormalizePathAndQuery(server).ShouldEndWith("/details", Case.Insensitive);
     }
 
     private static string NormalizePathAndQuery(Uri uri) =>

--- a/src/JoinRpg.Portal/Infrastructure/UriServiceImpl.cs
+++ b/src/JoinRpg.Portal/Infrastructure/UriServiceImpl.cs
@@ -18,7 +18,6 @@ internal class UriServiceImpl(
     LinkGenerator linkGenerator,
     IOptions<NotificationsOptions> notificationOptions) : IUriService,
     IUriLocator<UserLinkViewModel>,
-    IUriLocator<CharacterGroupLinkSlimViewModel>,
     IUriLocator<CharacterLinkSlimViewModel>,
     IUriLocator<ProjectIdentification>,
     IProjectUriLocator,
@@ -59,9 +58,6 @@ internal class UriServiceImpl(
                                 "User",
                                 new { UserId = identification }),
             LinkType.ResultCharacterGroup => linkGenerator.GetPathByAction("Details",
-                                "GameGroups",
-                                new { CharacterGroupId = identification, ProjectId = projectId }),
-            LinkType.CharacterGroupRoles => linkGenerator.GetPathByAction("Index",
                                 "GameGroups",
                                 new { CharacterGroupId = identification, ProjectId = projectId }),
             LinkType.ResultCharacter => linkGenerator.GetPathByAction("Details",
@@ -122,8 +118,6 @@ internal class UriServiceImpl(
 
     Uri IUriLocator<UserLinkViewModel>.GetUri(UserLinkViewModel target) =>
         GetUri(new Linkable(LinkType.ResultUser, ProjectId: null, Identification: target.UserId.ToString()));
-    Uri IUriLocator<CharacterGroupLinkSlimViewModel>.GetUri(CharacterGroupLinkSlimViewModel target) =>
-         GetUri(new Linkable(target.CharacterGroupId));
     Uri IUriLocator<CharacterLinkSlimViewModel>.GetUri(CharacterLinkSlimViewModel target)
         => GetUri(new Linkable(target.CharacterId));
     public Uri GetUri(ProjectIdentification target) => GetUri(new Linkable(target));
@@ -269,7 +263,7 @@ internal class UriServiceImpl(
 
         public Linkable(ProjectIdentification id) : this(LinkType.Project, id.Value, Identification: null) { }
 
-        public Linkable(CharacterGroupIdentification id) : this(LinkType.CharacterGroupRoles, id) { }
+        public Linkable(CharacterGroupIdentification id) : this(LinkType.ResultCharacterGroup, id) { }
 
         public Linkable(PlotFolderIdentification id) : this(LinkType.Plot, id) { }
     }

--- a/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/CharacterGroupDetailsViewModel.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/CharacterGroupDetailsViewModel.cshtml
@@ -19,13 +19,6 @@
                 asp-route-charactergroupid="@Model.CharacterGroupId">
                 Группа
             </nav-link>
-            <nav-link
-                asp-controller="GameGroups"
-                asp-action="Index"
-                asp-route-projectid="@Model.ProjectId"
-                asp-route-charactergroupid="@Model.CharacterGroupId">
-                Сетка ролей
-            </nav-link>
         }
         @if (Model.HasMasterAccess)
         {

--- a/src/JoinRpg.Web.ProjectCommon/CharacterGroupLink.razor
+++ b/src/JoinRpg.Web.ProjectCommon/CharacterGroupLink.razor
@@ -1,4 +1,4 @@
-﻿@inject IUriLocator<CharacterGroupLinkSlimViewModel> linkLocator
+﻿@inject IUriLocator<CharacterGroupIdentification> linkLocator
 <a href="@TargetUri" class="@(Model.IsPublic ? "" : "world-object-hidden")">@Model.Name</a>
 
 @code {
@@ -6,5 +6,5 @@
     [Parameter] [EditorRequired]
     public CharacterGroupLinkSlimViewModel Model { get; set; } = null!;
 
-    public Uri TargetUri => linkLocator.GetUri(Model);
+    public Uri TargetUri => linkLocator.GetUri(Model.CharacterGroupId);
 }


### PR DESCRIPTION
## Что сделано
- Убран пункт «Сетка ролей» из меню группы — стандартная ссылка на группу ведёт на `/details`.
- Исправлен баг: `CharacterGroupLink.razor` (Blazor-остров) вёл на сетку ролей (`GameGroups/Index`) вместо `GameGroups/Details`, в отличие от классической MVC-модели `CharacterGroupLinkViewModel`.
- Удалён дублирующий `IUriLocator<CharacterGroupLinkSlimViewModel>` — компонент теперь использует уже существующий `IUriLocator<CharacterGroupIdentification>` (реализован и на сервере, и в Blazor.Client).
- Убран неиспользуемый `LinkType.CharacterGroupRoles`.
- Добавлен регрессионный тест `CharacterGroupLinkShouldPointToDetails` в `UriLocatorConsistencyTests`.

## Test plan
- [x] `dotnet build` без ошибок (Portal, Portal.Test, Blazor.Client)
- [x] `dotnet test src/JoinRpg.Portal.Test` — `UriLocatorConsistencyTests` 16/16 зелёные

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01G5yVoPWbwLP1bQSHx9ZZ7C