### PR TITLE
feat: редактирование OAuth-клиентов в IdPortal

### DIFF
--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/IOAuthClientService.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/IOAuthClientService.cs
@@ -61,4 +61,39 @@ public interface IOAuthClientService
     /// <param name="ct">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">Thrown when the client is not found.</exception>
     Task DeleteClientAsync(string clientId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing OAuth client's metadata (display name, redirect URIs, client type,
+    /// scopes, refresh token support) while leaving its client secret untouched. Use
+    /// <see cref="RegenerateSecretAsync"/> to rotate the secret separately.
+    /// </summary>
+    /// <param name="clientId">Unique client identifier of the client to update.</param>
+    /// <param name="displayName">Human-readable name shown in consent screens. Can be <c>null</c>.</param>
+    /// <param name="redirectUris">Allowed redirect URIs for the authorization code flow. Must contain at least one entry.</param>
+    /// <param name="clientType">Whether the client can hold a secret securely.</param>
+    /// <param name="scopes">Scopes the client is allowed to request — see <see cref="CreateClientAsync"/>.</param>
+    /// <param name="allowRefreshToken">Whether the client may use the refresh token grant (<c>offline_access</c>).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The newly generated secret when the client is confidential and did not previously have one
+    /// (e.g. it is being switched from public to confidential); otherwise <c>null</c>.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown when the client is not found.</exception>
+    Task<string?> UpdateClientAsync(
+        string clientId,
+        string? displayName,
+        IReadOnlyList<Uri> redirectUris,
+        OAuthClientType clientType,
+        IReadOnlyList<string> scopes,
+        bool allowRefreshToken,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates a new client secret for an existing confidential OAuth client, invalidating the old one.
+    /// </summary>
+    /// <param name="clientId">Unique client identifier of the client to rotate the secret for.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The newly generated secret. Shown only once — it is stored hashed and cannot be retrieved later.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the client is not found or is not confidential.</exception>
+    Task<string> RegenerateSecretAsync(string clientId, CancellationToken ct = default);
 }

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthClientService.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthClientService.cs
@@ -57,6 +57,64 @@ internal class OAuthClientService(IOpenIddictApplicationManager manager) : IOAut
         await manager.DeleteAsync(application, ct);
     }
 
+    public async Task<string?> UpdateClientAsync(
+        string clientId,
+        string? displayName,
+        IReadOnlyList<Uri> redirectUris,
+        OAuthClientType clientType,
+        IReadOnlyList<string> scopes,
+        bool allowRefreshToken,
+        CancellationToken ct = default)
+    {
+        var existing = await manager.FindByClientIdAsync(clientId, ct)
+            ?? throw new InvalidOperationException($"OAuth client with ClientId={clientId} not found.");
+
+        string? newSecret = null;
+        string? secretForDescriptor = null;
+
+        if (clientType == OAuthClientType.Confidential)
+        {
+            // Preserve the existing (already-hashed) secret: UpdateAsync only re-hashes when the
+            // descriptor's ClientSecret differs from what's currently stored, so feeding it back
+            // unchanged leaves the secret untouched instead of wiping it.
+            var current = new OpenIddictApplicationDescriptor();
+            await manager.PopulateAsync(current, existing, ct);
+            secretForDescriptor = current.ClientSecret;
+
+            // The client never had a secret (e.g. it was public before) — it needs one now.
+            if (string.IsNullOrEmpty(secretForDescriptor))
+            {
+                var secretBytes = new byte[32];
+                RandomNumberGenerator.Fill(secretBytes);
+                newSecret = Convert.ToBase64String(secretBytes);
+                secretForDescriptor = newSecret;
+            }
+        }
+
+        var descriptor = BuildDescriptor(clientId, secretForDescriptor, displayName, redirectUris, clientType, scopes, allowRefreshToken);
+        await manager.UpdateAsync(existing, descriptor, ct);
+        return newSecret;
+    }
+
+    public async Task<string> RegenerateSecretAsync(string clientId, CancellationToken ct = default)
+    {
+        var existing = await manager.FindByClientIdAsync(clientId, ct)
+            ?? throw new InvalidOperationException($"OAuth client with ClientId={clientId} not found.");
+
+        var clientType = await manager.GetClientTypeAsync(existing, ct);
+        if (!string.Equals(clientType, ClientTypes.Confidential, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"OAuth client with ClientId={clientId} is public and has no secret to regenerate.");
+        }
+
+        var secretBytes = new byte[32];
+        RandomNumberGenerator.Fill(secretBytes);
+        var secret = Convert.ToBase64String(secretBytes);
+
+        await manager.UpdateAsync(existing, secret, ct);
+        return secret;
+    }
+
     private static OpenIddictApplicationDescriptor BuildDescriptor(
         string clientId,
         string? clientSecret,

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthClientEditScenario.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthClientEditScenario.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using JoinRpg.IdPortal.OAuthServer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using OpenIddict.Abstractions;
+
+namespace JoinRpg.IdPortal.Test.Scenarios;
+
+[Collection("IdPortal")]
+public class OAuthClientEditScenario(IdPortalApplicationFactory factory)
+{
+    [Fact]
+    public async Task EditOAuthClient_GetForm_UnauthenticatedRedirectsToLogin()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var response = await client.GetAsync("/admin/oauthclients/some-client/edit");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location?.ToString().ShouldContain("Login");
+    }
+
+    // Service-level integration tests
+    // Form submission for InteractiveServer pages goes through SignalR, not HTTP POST,
+    // so update logic is tested directly via IOAuthClientService.
+
+    [Fact]
+    public async Task UpdateClient_ExistingConfidentialClient_KeepsOldSecretValid()
+    {
+        var clientId = $"test-edit-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+        var manager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+
+        var originalSecret = await clientService.CreateClientAsync(
+            clientId,
+            "Исходное название",
+            [new Uri("https://example.com/v1")],
+            OAuthClientType.Confidential,
+            [OpenIddictConstants.Scopes.OpenId],
+            allowRefreshToken: false);
+        originalSecret.ShouldNotBeNullOrEmpty();
+
+        var newSecret = await clientService.UpdateClientAsync(
+            clientId,
+            "Новое название",
+            [new Uri("https://example.com/v2")],
+            OAuthClientType.Confidential,
+            [OpenIddictConstants.Scopes.OpenId, OpenIddictConstants.Scopes.Email],
+            allowRefreshToken: true);
+
+        newSecret.ShouldBeNull();
+
+        var updated = await manager.FindByClientIdAsync(clientId);
+        updated.ShouldNotBeNull();
+        (await manager.GetDisplayNameAsync(updated)).ShouldBe("Новое название");
+        (await manager.GetRedirectUrisAsync(updated)).ShouldBe(["https://example.com/v2"]);
+        (await manager.ValidateClientSecretAsync(updated, originalSecret!)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateClient_SwitchedFromPublicToConfidential_GeneratesNewSecret()
+    {
+        var clientId = $"test-edit-switch-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+        var manager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+
+        await clientService.CreateClientAsync(
+            clientId,
+            null,
+            [new Uri("https://example.com/callback")],
+            OAuthClientType.Public,
+            [JoinRpgScopes.Read],
+            allowRefreshToken: false);
+
+        var newSecret = await clientService.UpdateClientAsync(
+            clientId,
+            null,
+            [new Uri("https://example.com/callback")],
+            OAuthClientType.Confidential,
+            [JoinRpgScopes.Read],
+            allowRefreshToken: false);
+
+        newSecret.ShouldNotBeNullOrEmpty();
+
+        var updated = await manager.FindByClientIdAsync(clientId);
+        updated.ShouldNotBeNull();
+        (await manager.ValidateClientSecretAsync(updated, newSecret!)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateClient_NonExistingClient_ThrowsInvalidOperationException()
+    {
+        var clientId = $"test-edit-missing-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+
+        await Should.ThrowAsync<InvalidOperationException>(() => clientService.UpdateClientAsync(
+            clientId,
+            null,
+            [new Uri("https://example.com/callback")],
+            OAuthClientType.Confidential,
+            [OpenIddictConstants.Scopes.OpenId],
+            allowRefreshToken: false));
+    }
+
+    [Fact]
+    public async Task RegenerateSecret_ExistingConfidentialClient_InvalidatesOldSecret()
+    {
+        var clientId = $"test-regen-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+        var manager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+
+        var originalSecret = await clientService.CreateClientAsync(
+            clientId,
+            null,
+            [new Uri("https://example.com/callback")],
+            OAuthClientType.Confidential,
+            [OpenIddictConstants.Scopes.OpenId],
+            allowRefreshToken: false);
+
+        var newSecret = await clientService.RegenerateSecretAsync(clientId);
+
+        newSecret.ShouldNotBeNullOrEmpty();
+        newSecret.ShouldNotBe(originalSecret);
+
+        var updated = await manager.FindByClientIdAsync(clientId);
+        updated.ShouldNotBeNull();
+        (await manager.ValidateClientSecretAsync(updated, originalSecret!)).ShouldBeFalse();
+        (await manager.ValidateClientSecretAsync(updated, newSecret)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task RegenerateSecret_PublicClient_ThrowsInvalidOperationException()
+    {
+        var clientId = $"test-regen-public-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+
+        await clientService.CreateClientAsync(
+            clientId,
+            null,
+            [new Uri("https://example.com/callback")],
+            OAuthClientType.Public,
+            [JoinRpgScopes.Read],
+            allowRefreshToken: false);
+
+        await Should.ThrowAsync<InvalidOperationException>(() => clientService.RegenerateSecretAsync(clientId));
+    }
+
+    [Fact]
+    public async Task RegenerateSecret_NonExistingClient_ThrowsInvalidOperationException()
+    {
+        var clientId = $"test-regen-missing-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+
+        await Should.ThrowAsync<InvalidOperationException>(() => clientService.RegenerateSecretAsync(clientId));
+    }
+}

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/Admin/OAuthClientEdit.razor
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/Admin/OAuthClientEdit.razor
@@ -1,0 +1,255 @@
+@page "/admin/oauthclients/{ClientId}/edit"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using System.ComponentModel.DataAnnotations
+@using JoinRpg.IdPortal.OAuthServer
+@using OpenIddict.Abstractions
+@inject IOAuthClientService OAuthClientService
+@inject IOpenIddictApplicationManager OpenIddictApplicationManager
+
+<PageTitle>Редактировать OAuth-клиент — id.joinrpg.ru</PageTitle>
+
+<JoinAdminAuthorizeView Roles="@Security.AdminRoleName">
+    <h3>Редактировать OAuth-клиент «@ClientId»</h3>
+
+    @if (notFound)
+    {
+        <JoinAlert Variation="VariationStyleEnum.Danger">Клиент «@ClientId» не найден.</JoinAlert>
+        <JoinButton Link="/admin/oauthclients" Label="К списку клиентов" />
+    }
+    else if (Input is null)
+    {
+        <JoinLoadingMessage />
+    }
+    else if (updated)
+    {
+        @if (newSecret is not null)
+        {
+            <JoinAlert Variation="VariationStyleEnum.Warning">
+                Сохраните секрет — после закрытия страницы он недоступен.
+            </JoinAlert>
+            <FormHorizontal>
+                <FormRow Label="Client Secret">
+                    <JoinTextArea Value="@newSecret" ReadOnly="true" HasCopyButton="true" Rows="2" />
+                </FormRow>
+            </FormHorizontal>
+        }
+        else
+        {
+            <JoinAlert Variation="VariationStyleEnum.Info">Клиент «@ClientId» обновлён.</JoinAlert>
+        }
+        <JoinButton Link="/admin/oauthclients" Label="К списку клиентов" />
+    }
+    else
+    {
+        <EditForm Model="Input" OnValidSubmit="OnValidSubmitAsync">
+            <DataAnnotationsValidator />
+
+            @if (errorMessage is not null)
+            {
+                <JoinAlert Variation="VariationStyleEnum.Danger">@errorMessage</JoinAlert>
+            }
+
+            <FormHorizontal>
+                <FormRow Label="Client ID">
+                    <JoinTextInput Value="@ClientId" readonly />
+                </FormRow>
+                <FormRowFor For="() => Input.DisplayName">
+                    <JoinTextInput @bind-Value="Input.DisplayName" />
+                </FormRowFor>
+                <FormRowFor For="() => Input.RedirectUris">
+                    <JoinTextArea @bind-Value="Input.RedirectUris" Placeholder="https://example.com/callback" />
+                </FormRowFor>
+
+                <FormRowFor For="() => Input.ClientTypeChoice">
+                    <EnumRadioButtonGroup @bind-SelectedValue="Input.ClientTypeChoice" />
+                </FormRowFor>
+
+                <FormRow Label="Scope: вход на сайт (OIDC)">
+                    <label><CheckboxInput @bind-Value="Input.IncludeOpenId" /> openid</label><br />
+                    <label><CheckboxInput @bind-Value="Input.IncludeEmail" /> email</label><br />
+                    <label><CheckboxInput @bind-Value="Input.IncludePhone" /> phone</label><br />
+                    <label><CheckboxInput @bind-Value="Input.IncludeProfile" /> profile</label>
+                </FormRow>
+
+                <FormRow Label="Scope: доступ к данным проектов (MCP)">
+                    <label><CheckboxInput @bind-Value="Input.IncludeJoinRpgRead" /> joinrpg.read — чтение данных проектов</label><br />
+                    <label><CheckboxInput @bind-Value="Input.IncludeJoinRpgCharactersWrite" /> joinrpg.characters.write — создание и правка персонажей</label>
+                </FormRow>
+
+                <FormRow Label="Refresh token">
+                    <label><CheckboxInput @bind-Value="Input.AllowRefreshToken" /> разрешить обновление токена без повторного входа</label>
+                </FormRow>
+
+                @if (wasConfidentialBefore)
+                {
+                    <FormRow Label="Client Secret">
+                        <JoinButton Label="Перегенерировать секрет"
+                                    Style="VariationStyleEnum.Warning"
+                                    AutoConfirm="true"
+                                    AutoConfirmMessage="Старый секрет перестанет работать. Продолжить?"
+                                    OnClick="RegenerateSecretAsync" />
+                        @if (regeneratedSecret is not null)
+                        {
+                            <JoinAlert Variation="VariationStyleEnum.Warning">
+                                Сохраните секрет — после закрытия страницы он недоступен.
+                            </JoinAlert>
+                            <JoinTextArea Value="@regeneratedSecret" ReadOnly="true" HasCopyButton="true" Rows="2" />
+                        }
+                    </FormRow>
+                }
+                else if (Input.ClientTypeChoice == ClientTypeChoice.Confidential)
+                {
+                    <FormRow Label="Client Secret">
+                        <JoinAlert Variation="VariationStyleEnum.Info">
+                            У клиента ещё нет секрета — при сохранении будет сгенерирован новый.
+                        </JoinAlert>
+                    </FormRow>
+                }
+            </FormHorizontal>
+
+            <JoinButton Submit="true" Preset="ButtonPreset.Save" />
+            <JoinButton Link="/admin/oauthclients" Preset="ButtonPreset.Cancel" />
+        </EditForm>
+    }
+</JoinAdminAuthorizeView>
+
+@code {
+    [Parameter]
+    public string ClientId { get; set; } = "";
+
+    private bool notFound;
+    private bool updated;
+    private bool wasConfidentialBefore;
+    private string? newSecret;
+    private string? regeneratedSecret;
+    private string? errorMessage;
+
+    private InputModel? Input { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var application = await OpenIddictApplicationManager.FindByClientIdAsync(ClientId);
+        if (application is null)
+        {
+            notFound = true;
+            return;
+        }
+
+        var displayName = await OpenIddictApplicationManager.GetDisplayNameAsync(application);
+        var redirectUris = await OpenIddictApplicationManager.GetRedirectUrisAsync(application);
+        var clientType = await OpenIddictApplicationManager.GetClientTypeAsync(application);
+        var permissions = await OpenIddictApplicationManager.GetPermissionsAsync(application);
+
+        wasConfidentialBefore = !string.Equals(clientType, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase);
+
+        Input = new InputModel
+        {
+            DisplayName = displayName ?? "",
+            RedirectUris = string.Join('\n', redirectUris),
+            ClientTypeChoice = wasConfidentialBefore ? ClientTypeChoice.Confidential : ClientTypeChoice.Public,
+            IncludeOpenId = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + OpenIddictConstants.Scopes.OpenId),
+            IncludeEmail = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + OpenIddictConstants.Scopes.Email),
+            IncludePhone = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + OpenIddictConstants.Scopes.Phone),
+            IncludeProfile = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + OpenIddictConstants.Scopes.Profile),
+            IncludeJoinRpgRead = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + JoinRpgScopes.Read),
+            IncludeJoinRpgCharactersWrite = permissions.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + JoinRpgScopes.CharactersWrite),
+            AllowRefreshToken = permissions.Contains(OpenIddictConstants.Permissions.GrantTypes.RefreshToken),
+        };
+    }
+
+    private async Task OnValidSubmitAsync()
+    {
+        if (Input is null)
+        {
+            return;
+        }
+
+        var parsedUris = new List<Uri>();
+        foreach (var line in Input.RedirectUris.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!Uri.TryCreate(line, UriKind.Absolute, out var uri))
+            {
+                errorMessage = $"Некорректный URI: {line}";
+                return;
+            }
+            parsedUris.Add(uri);
+        }
+
+        if (parsedUris.Count == 0)
+        {
+            errorMessage = "Необходимо указать хотя бы один Redirect URI.";
+            return;
+        }
+
+        var oidcScopes = new List<string>();
+        if (Input.IncludeOpenId) { oidcScopes.Add(OpenIddictConstants.Scopes.OpenId); }
+        if (Input.IncludeEmail) { oidcScopes.Add(OpenIddictConstants.Scopes.Email); }
+        if (Input.IncludePhone) { oidcScopes.Add(OpenIddictConstants.Scopes.Phone); }
+        if (Input.IncludeProfile) { oidcScopes.Add(OpenIddictConstants.Scopes.Profile); }
+
+        var joinRpgScopes = new List<string>();
+        if (Input.IncludeJoinRpgRead) { joinRpgScopes.Add(JoinRpgScopes.Read); }
+        if (Input.IncludeJoinRpgCharactersWrite) { joinRpgScopes.Add(JoinRpgScopes.CharactersWrite); }
+
+        if (oidcScopes.Count == 0 && joinRpgScopes.Count == 0)
+        {
+            errorMessage = "Выберите хотя бы один scope.";
+            return;
+        }
+
+        if (oidcScopes.Count > 0 && joinRpgScopes.Count > 0)
+        {
+            errorMessage = "Нельзя одновременно выдавать scope для входа на сайт (OIDC) и scope для доступа к данным проектов (joinrpg.*) — это разные категории клиентов.";
+            return;
+        }
+
+        var displayName = string.IsNullOrWhiteSpace(Input.DisplayName) ? null : Input.DisplayName;
+        var scopes = oidcScopes.Count > 0 ? oidcScopes : joinRpgScopes;
+        var clientType = Input.ClientTypeChoice == ClientTypeChoice.Public ? OAuthClientType.Public : OAuthClientType.Confidential;
+
+        newSecret = await OAuthClientService.UpdateClientAsync(
+            ClientId, displayName, parsedUris, clientType, scopes, Input.AllowRefreshToken);
+        updated = true;
+    }
+
+    private async Task RegenerateSecretAsync()
+    {
+        regeneratedSecret = await OAuthClientService.RegenerateSecretAsync(ClientId);
+    }
+
+    // Presentation-only mirror of OAuthClientType: JoinRpg.IdPortal.OAuthServer stays
+    // locale-neutral, so the Russian labels/descriptions live here instead.
+    private enum ClientTypeChoice
+    {
+        [Display(Name = "Confidential", Description = "Клиент может безопасно хранить секрет (веб-сервер)")]
+        Confidential,
+
+        [Display(Name = "Public", Description = "Нативное приложение/CLI без надёжного хранилища секрета — защита PKCE")]
+        Public,
+    }
+
+    private sealed class InputModel
+    {
+        [MaxLength(200)]
+        [Display(Name = "Название")]
+        public string DisplayName { get; set; } = "";
+
+        [Required(ErrorMessage = "Укажите хотя бы один Redirect URI")]
+        [Display(Name = "Redirect URIs (по одному на строку)")]
+        public string RedirectUris { get; set; } = "";
+
+        [Display(Name = "Тип клиента")]
+        public ClientTypeChoice ClientTypeChoice { get; set; } = ClientTypeChoice.Confidential;
+
+        public bool IncludeOpenId { get; set; }
+        public bool IncludeEmail { get; set; }
+        public bool IncludePhone { get; set; }
+        public bool IncludeProfile { get; set; }
+
+        public bool IncludeJoinRpgRead { get; set; }
+        public bool IncludeJoinRpgCharactersWrite { get; set; }
+
+        public bool AllowRefreshToken { get; set; } = true;
+    }
+}

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/Admin/OAuthClients.razor
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/Admin/OAuthClients.razor
@@ -48,6 +48,7 @@
                         </ul>
                     </td>
                     <td>
+                        <JoinButton Link="@($"/admin/oauthclients/{client.ClientId}/edit")" Preset="ButtonPreset.Edit" />
                         <JoinButton Preset="ButtonPreset.Delete"
                                    AutoConfirm="true"
                                    AutoConfirmMessage="@($"Вы уверены, что хотите удалить OAuth-клиента «{client.DisplayName}»?")"


### PR DESCRIPTION
## Что сделано
- Добавлена страница `/admin/oauthclients/{ClientId}/edit` по аналогии со страницей создания OAuth-клиента: можно менять название, redirect URI, тип клиента, scope и refresh token.
- `IOAuthClientService.UpdateClientAsync` сохраняет существующий (захешированный) секрет клиента без изменений при обычном сохранении формы — секрет создаётся заново только если у клиента его ещё не было (например, при переключении public → confidential).
- Добавлен отдельный метод `RegenerateSecretAsync` и кнопка «Перегенерировать секрет» с подтверждением на странице редактирования — ротация секрета вынесена из формы сохранения в отдельное явное действие.
- На странице списка клиентов добавлена кнопка перехода к редактированию.

## Test plan
- [x] `dotnet build` — 0 ошибок
- [x] `dotnet test src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test` — все тесты (включая новый `OAuthClientEditScenario`) проходят
- [x] `dotnet format --verify-no-changes` на изменённых файлах — без замечаний

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QNjAUTo4Tpu37jzL6DdEvc