### PR TITLE
feat: реорганизация списка проектов в профиле пользователя

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
@@ -277,7 +277,8 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
                         IAmMaster = masterPredicate.Compile()(project),
                         HasMyClaims = claimPredicate.Compile()(project),
                         ActiveClaimsCount = project.Claims.Count(claim => activeClaimPredicate.Invoke(claim)),
-                        LastKogdaIgraId = (int?)project.KogdaIgraGames.Where(x => x.Active).OrderByDescending(x => x.KogdaIgraGameId).FirstOrDefault()!.KogdaIgraGameId
+                        LastKogdaIgraId = (int?)project.KogdaIgraGames.Where(x => x.Active).OrderByDescending(x => x.KogdaIgraGameId).FirstOrDefault()!.KogdaIgraGameId,
+                        project.Details.IsPublicProject
                     };
 
         var result = await query.ToListAsync();
@@ -290,7 +291,8 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
             x.ActiveClaimsCount,
             x.HasMyClaims,
             x.IAmMaster,
-            KogdaIgraIdentification.FromOptional(x.LastKogdaIgraId)
+            KogdaIgraIdentification.FromOptional(x.LastKogdaIgraId),
+            x.IsPublicProject
             ))];
     }
 

--- a/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectPersonalizedInfo.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectPersonalizedInfo.cs
@@ -11,7 +11,8 @@ public record ProjectPersonalizedInfo(
     int ActiveClaimsCount,
     bool HasMyClaims,
     bool HasMyMasterAccess,
-    KogdaIgraIdentification? LastKogdaIgraId)
+    KogdaIgraIdentification? LastKogdaIgraId,
+    bool IsPublicProject)
 {
     public bool Active => ProjectLifecycleStatus != ProjectLifecycleStatus.Archived;
 

--- a/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
@@ -3,6 +3,7 @@ using JoinRpg.Data.Interfaces.Claims;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Interfaces;
 using JoinRpg.Portal.Infrastructure.Logging;
+using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.Models;
 using JoinRpg.Web.Models.ClaimList;
 using Microsoft.AspNetCore.Authorization;
@@ -29,13 +30,19 @@ public class UserController(IUserRepository userRepository, ICurrentUserAccessor
         }
 
         var userProjects = await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.AllProjectsWithMasterAccess(userId));
+        var activeUserProjects = userProjects.Where(p => p.Active).ToList();
+
+        // Непубличные проекты в профиле видны только администраторам сайта
+        var visibleUserProjects = currentUserAccessor.IsAdmin ? userProjects : userProjects.Where(p => p.IsPublicProject).ToArray();
 
         var currentUser = User.Identity?.IsAuthenticated == true ? await userRepository.GetUserInfo(currentUserAccessor.UserIdentification) : null;
 
         var userProfileViewModel = new UserProfileViewModel()
         {
             DisplayName = user.DisplayName.DisplayName,
-            ThisUserProjects = userProjects.ToLinkViewModels().ToList(),
+            ThisUserProjects = activeUserProjects.ToLinkViewModels().ToList(),
+            ActiveMasterProjects = [.. visibleUserProjects.Where(p => p.Active).Select(p => new ProjectListItemViewModel(p))],
+            ArchivedProjects = visibleUserProjects.Where(p => !p.Active).ToLinkViewModels().ToList(),
             UserId = user.UserId,
             Details = new UserProfileDetailsViewModel(user, currentUser),
             Admin = currentUserAccessor.IsAdmin ? new UserAdminOperationsViewModel(yandexLogLink.GetLinkForUser(user.Email)) : null,

--- a/src/JoinRpg.Portal/Views/User/Details.cshtml
+++ b/src/JoinRpg.Portal/Views/User/Details.cshtml
@@ -12,35 +12,43 @@
     
   <partial  name="_UserDetailsPanel" model="@Model.Details"/>
 
-    @if (Model.ThisUserProjects.Any())
+    @if (Model.HasAdminAccess)
     {
-        <div class="col-md-4">
-            <h4>Проекты этого пользователя </h4>
-            <ul>
-                @foreach (var master in Model.ThisUserProjects)
-                {
-                    <li>
-                        @Html.ActionLink(@master.ProjectName, "Details", "Game", new {ProjectId = master.ProjectId.Value}, null)
-                    </li>
-                }
-
-            </ul>
-        </div>
+        <component type="typeof(AdminUserActionsPanel)"
+                   render-mode="WebAssemblyPrerendered"
+                   param-UserId="new UserIdentification(Model.UserId)"
+                   param-LogLink="Model.Admin!.LogLink" />
     }
-           @if (Model.HasAdminAccess)
-           {
-               <component type="typeof(AdminUserActionsPanel)"
-                          render-mode="WebAssemblyPrerendered"
-                          param-UserId="new UserIdentification(Model.UserId)"
-                          param-LogLink="Model.Admin!.LogLink" />
-           }
+
+    <div class="clearfix"></div>
+
+    <component type="typeof(JoinRpg.Web.Games.Projects.ProjectCards)"
+               param-Projects="@Model.ActiveMasterProjects"
+               param-Header="@("Текущие проекты")"
+               render-mode="Static" />
+
+
 
         
     @if (Model.Claims != null && Model.Claims.Items.Any())
     {
         @await Html.PartialAsync("..\\ClaimList\\_MyClaimsList", Model.Claims)
     }
-    
+
+    @if (Model.ArchivedProjects.Any())
+    {
+        <div class="col-md-4">
+            <h4>Архивные проекты пользователя</h4>
+            <ul>
+                @foreach (var project in Model.ArchivedProjects)
+                {
+                    <li>
+                        @Html.ActionLink(@project.ProjectName, "Details", "Game", new { ProjectId = project.ProjectId.Value }, null)
+                    </li>
+                }
+            </ul>
+        </div>
+    }
 
     @if (Model.ProjectsToAdd.Any())
     {

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -1,6 +1,7 @@
 using JoinRpg.Common.PrimitiveTypes.Users;
 using JoinRpg.Common.WebComponents;
 using JoinRpg.Interfaces;
+using JoinRpg.Web.Games.Projects;
 using JoinRpg.Web.Models.ClaimList;
 using JoinRpg.Web.Models.UserProfile;
 using JoinRpg.Web.ProjectCommon.Projects;
@@ -11,7 +12,16 @@ public class UserProfileViewModel
 {
     public required string DisplayName { get; set; }
 
-    public required IEnumerable<ProjectLinkViewModel> ThisUserProjects { get; set; }
+    /// <summary>
+    /// Активные проекты, где у пользователя есть доступ мастера — используется, чтобы не предлагать
+    /// повторно выдать доступ в <see cref="ProjectsToAdd"/>. Архивные проекты сюда не входят: их и так
+    /// нет в <see cref="CanGrantAccessProjects"/> (доступ выдаётся только в активные проекты).
+    /// </summary>
+    public required IReadOnlyCollection<ProjectLinkViewModel> ThisUserProjects { get; set; }
+
+    public required IReadOnlyCollection<ProjectListItemViewModel> ActiveMasterProjects { get; set; }
+
+    public required IReadOnlyCollection<ProjectLinkViewModel> ArchivedProjects { get; set; }
 
     [ReadOnly(true)]
     public IEnumerable<ProjectLinkViewModel> CanGrantAccessProjects { get; set; } = [];


### PR DESCRIPTION
## Что сделано
- Текущие проекты (где пользователь мастер) в профиле `/user/{id}` показываются карточками, как на главной странице
- Общий список проектов перенесён под список заявок пользователя, оставлены только архивные проекты, заголовок — «Архивные проекты пользователя»
- Непубличные проекты (без галочки «публичный проект») в профиле видны только администраторам сайта

## Test plan
- [x] `dotnet build` без ошибок
- [ ] Проверить профиль пользователя-мастера: карточки текущих проектов сверху, архивный список снизу
- [ ] Проверить, что непубличный проект мастера не виден обычному посетителю профиля, но виден админу

Generated with [Claude Code](https://claude.ai/code)