### PR TITLE
feat: общая инфраструктура OIDC-логина через id.joinrpg.ru

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,8 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.1" />
+        <PackageVersion Include="OpenIddict.Client.AspNetCore" Version="7.6.1" />
+        <PackageVersion Include="OpenIddict.Client.SystemNetHttp" Version="7.6.1" />
         <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />
         <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
         <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@
 - `JoinRpg.Markdown` — обработка Markdown (Markdig)
 - `JoinRpg.PrimitiveTypes` — доменные типы-значения: идентификаторы и Value Objects
 - `JoinRpg.Common.EntityFrameworkCore` — generic EF Core ValueConverter для `[TypedEntityId]`-типов, реализующих `IEntityId<TSelf,TValue>` (не составные id)
-- `JoinRpg.Common.WebInfrastructure` — веб-инфраструктура: логирование (Serilog), кеш, DataProtection, фоновые задачи
+- `JoinRpg.Common.WebInfrastructure` — веб-инфраструктура: логирование (Serilog), кеш, DataProtection, фоновые задачи, общий OIDC-логин через id.joinrpg.ru для сателлитных сайтов (`AddJoinRpgAuthentication`, приложение-специфичная часть — через `IJoinUserLoginHandler`)
 - `JoinRpg.Common.Telegram` — интеграция с Telegram Bot
 - `JoinRpg.Common.BastiliaRatingClient` — HTTP-клиент к сайту клуба #Бастилия
 - `JoinRpg.Common.KogdaIgraClient` — HTTP-клиент к сервису KogdaIgra (сырые вызовы API)

--- a/src/Common/JoinRpg.Common.WebInfrastructure/Auth/AuthEndpoints.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/Auth/AuthEndpoints.cs
@@ -1,0 +1,78 @@
+using System.Security.Claims;
+using JoinRpg.Common.PrimitiveTypes;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Client.AspNetCore;
+
+namespace JoinRpg.Common.WebInfrastructure.Auth;
+
+/// <summary>
+/// Общая часть логина через id.joinrpg.ru (OpenIddict): маппинг /login, /signin-joinrpg, /logout.
+/// Приложение-специфичное сохранение пользователя и claims — в <see cref="IJoinUserLoginHandler"/>.
+/// </summary>
+public static class AuthEndpoints
+{
+    public static void MapAuthEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/login", (HttpContext context) =>
+        {
+            var properties = new AuthenticationProperties
+            {
+                RedirectUri = "/signin-joinrpg",
+            };
+            return Results.Challenge(properties, [OpenIddictClientAspNetCoreDefaults.AuthenticationScheme]);
+        });
+
+        endpoints.MapGet("/signin-joinrpg", async (
+            HttpContext context,
+            IJoinUserLoginHandler loginHandler,
+            ILoggerFactory loggerFactory,
+            CancellationToken cancellationToken) =>
+        {
+            var logger = loggerFactory.CreateLogger("Auth");
+
+            var result = await context.AuthenticateAsync(OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+            if (!result.Succeeded)
+            {
+                logger.LogWarning("OIDC authentication failed: {Error}", result.Failure?.Message);
+                return Results.Problem(
+                    detail: result.Failure?.Message ?? "Authentication callback failed",
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            var externalPrincipal = result.Principal!;
+
+            var sub = externalPrincipal.FindFirstValue("sub");
+            if (sub is null || !UserIdentification.TryParse(sub, provider: null, out var userId))
+            {
+                logger.LogWarning("Failed to extract user ID from claims. sub={Sub}, claims=[{Claims}]",
+                    sub, string.Join(", ", externalPrincipal.Claims.Select(c => $"{c.Type}={c.Value}")));
+                return Results.Problem(
+                    detail: $"Could not extract numeric user ID from 'sub' claim (got: {sub})",
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId.Value.ToString()),
+            };
+
+            await loginHandler.HandleLoginAsync(userId, externalPrincipal, claims, cancellationToken);
+
+            var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+            await context.SignInAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                new ClaimsPrincipal(identity));
+
+            return Results.Redirect("/");
+        });
+
+        endpoints.MapGet("/logout", async (HttpContext context) =>
+        {
+            await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return Results.Redirect("/");
+        });
+    }
+}

--- a/src/Common/JoinRpg.Common.WebInfrastructure/Auth/AuthRegistration.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/Auth/AuthRegistration.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.EntityFrameworkCore;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace JoinRpg.Common.WebInfrastructure.Auth;
+
+public static class AuthRegistration
+{
+    /// <summary>
+    /// Регистрирует cookie-схему аутентификации и OpenIddict-клиент для логина через id.joinrpg.ru.
+    /// Состояние OpenIddict (authorization/token records) хранится в <typeparamref name="TContext"/> —
+    /// вызывающая сторона должна вызвать <c>modelBuilder.UseOpenIddict()</c> в <c>OnModelCreating</c> этого контекста.
+    /// Реализацию <see cref="IJoinUserLoginHandler"/> для приложение-специфичной части логина
+    /// нужно зарегистрировать отдельно.
+    /// </summary>
+    public static void AddJoinRpgAuthentication<TContext>(this IServiceCollection services, IConfiguration configuration)
+        where TContext : DbContext
+    {
+        services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultSignOutScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            })
+            .AddCookie(options =>
+            {
+                options.LoginPath = "/login";
+            });
+
+        var oidcOptions = configuration.GetSection("JoinRpgOidc").Get<JoinRpgOidcOptions>()
+            ?? throw new InvalidOperationException("JoinRpgOidc configuration section is required");
+
+        services.AddOpenIddict()
+            .AddCore(options =>
+            {
+                options.UseEntityFrameworkCore()
+                    .UseDbContext<TContext>();
+            })
+            .AddClient(options =>
+            {
+                options.AllowAuthorizationCodeFlow();
+
+                options.AddDevelopmentEncryptionCertificate()
+                    .AddDevelopmentSigningCertificate();
+
+                options.UseAspNetCore()
+                    .EnableRedirectionEndpointPassthrough();
+
+                options.UseSystemNetHttp();
+
+                options.AddRegistration(new OpenIddict.Client.OpenIddictClientRegistration
+                {
+                    Issuer = oidcOptions.Issuer,
+                    ClientId = oidcOptions.ClientId,
+                    ClientSecret = oidcOptions.ClientSecret,
+                    Scopes = { Scopes.OpenId, Scopes.Profile },
+                    RedirectUri = new Uri("/signin-joinrpg", UriKind.Relative),
+                });
+            });
+
+        services.AddAuthorization();
+    }
+}

--- a/src/Common/JoinRpg.Common.WebInfrastructure/Auth/ClaimsPrincipalExtensions.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/Auth/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+using JoinRpg.Common.PrimitiveTypes;
+
+namespace JoinRpg.Common.WebInfrastructure.Auth;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static UserIdentification GetJoinrpgUserId(this ClaimsPrincipal user)
+    {
+        return user.TryGetJoinrpgUserId() ?? throw new InvalidOperationException("User has no valid JoinrpgUserId claim");
+    }
+
+    public static UserIdentification? TryGetJoinrpgUserId(this ClaimsPrincipal user)
+    {
+        var value = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        return UserIdentification.TryParse(value, provider: null, out var userId) ? userId : null;
+    }
+}

--- a/src/Common/JoinRpg.Common.WebInfrastructure/Auth/IJoinUserLoginHandler.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/Auth/IJoinUserLoginHandler.cs
@@ -1,0 +1,13 @@
+using System.Security.Claims;
+using JoinRpg.Common.PrimitiveTypes;
+
+namespace JoinRpg.Common.WebInfrastructure.Auth;
+
+/// <summary>
+/// Приложение-специфичная часть логина через id.joinrpg.ru: сохраняет/обновляет пользователя
+/// и дополняет claims, с которыми он будет залогинен по cookie-схеме.
+/// </summary>
+public interface IJoinUserLoginHandler
+{
+    Task HandleLoginAsync(UserIdentification userId, ClaimsPrincipal externalPrincipal, List<Claim> claims, CancellationToken cancellationToken);
+}

--- a/src/Common/JoinRpg.Common.WebInfrastructure/Auth/JoinRpgOidcOptions.cs
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/Auth/JoinRpgOidcOptions.cs
@@ -1,0 +1,11 @@
+namespace JoinRpg.Common.WebInfrastructure.Auth;
+
+/// <summary>
+/// Настройки OIDC-клиента для логина через id.joinrpg.ru. Читаются из секции конфигурации <c>JoinRpgOidc</c>.
+/// </summary>
+public class JoinRpgOidcOptions
+{
+    public Uri Issuer { get; set; } = new("https://id.joinrpg.ru/");
+    public required string ClientId { get; set; }
+    public string? ClientSecret { get; set; }
+}

--- a/src/Common/JoinRpg.Common.WebInfrastructure/JoinRpg.Common.WebInfrastructure.csproj
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/JoinRpg.Common.WebInfrastructure.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <PackageId>JoinRpg.Common.WebInfrastructure</PackageId>
-        <Description>ASP.NET Core web infrastructure: Serilog logging, OpenTelemetry, EF Core PostgreSQL, health checks, data protection, background tasks.</Description>
+        <Description>ASP.NET Core web infrastructure: Serilog logging, OpenTelemetry, EF Core PostgreSQL, health checks, data protection, background tasks, OIDC login against id.joinrpg.ru.</Description>
         <PackageProjectUrl>https://github.com/joinrpg/joinrpg-net</PackageProjectUrl>
         <RepositoryUrl>https://github.com/joinrpg/joinrpg-net</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -33,6 +33,13 @@
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
         <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" />
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+        <PackageReference Include="OpenIddict.Client.AspNetCore" />
+        <PackageReference Include="OpenIddict.Client.SystemNetHttp" />
+        <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JoinRpg.Common.PrimitiveTypes\JoinRpg.Common.PrimitiveTypes.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Common/JoinRpg.Common.WebInfrastructure/README.MD
+++ b/src/Common/JoinRpg.Common.WebInfrastructure/README.MD
@@ -1,6 +1,6 @@
 # JoinRpg.Common.WebInfrastructure
 
-Общая веб-инфраструктура для ASP.NET Core приложений JoinRpg: логирование (Serilog), OpenTelemetry, Data Protection, кеширование, health checks, поддержка PostgreSQL.
+Общая веб-инфраструктура для ASP.NET Core приложений JoinRpg: логирование (Serilog), OpenTelemetry, Data Protection, кеширование, health checks, поддержка PostgreSQL, логин через id.joinrpg.ru.
 
 ## Подключение
 
@@ -52,7 +52,49 @@ services.RegisterMigrator<MyDbContext>(
 );
 ```
 
-### 4. Middleware pipeline
+### 4. Логин через id.joinrpg.ru (OpenIddict client)
+
+Для сателлитных сайтов, авторизующих пользователей через id.joinrpg.ru (authorization code flow):
+
+```csharp
+services.AddJoinRpgAuthentication<MyDbContext>(Configuration);
+services.AddScoped<IJoinUserLoginHandler, MyUserLoginHandler>();
+```
+
+`MyDbContext` — контекст, в котором OpenIddict хранит своё состояние (authorization/token records). В его `OnModelCreating` нужно вызвать `modelBuilder.UseOpenIddict()` (пакет `OpenIddict.EntityFrameworkCore`).
+
+`IJoinUserLoginHandler` — приложение-специфичная часть логина: получив `UserIdentification` и внешний `ClaimsPrincipal` от id.joinrpg.ru, реализация должна создать/обновить локального пользователя и дополнить список `claims`, с которыми он будет залогинен по cookie-схеме:
+
+```csharp
+internal class MyUserLoginHandler(MyDbContext dbContext) : IJoinUserLoginHandler
+{
+    public async Task HandleLoginAsync(UserIdentification userId, ClaimsPrincipal externalPrincipal, List<Claim> claims, CancellationToken cancellationToken)
+    {
+        // найти/создать локального пользователя по userId, дополнить claims
+    }
+}
+```
+
+В pipeline замаппить эндпойнты `/login`, `/signin-joinrpg`, `/logout`:
+
+```csharp
+app.MapAuthEndpoints();
+```
+
+Конфигурация (секция `JoinRpgOidc`). `Issuer` по умолчанию — `https://id.joinrpg.ru/`, указывать нужно только для отличного от прода окружения (dev/staging):
+
+```json
+{
+  "JoinRpgOidc": {
+    "ClientId": "my-app",
+    "ClientSecret": "..."
+  }
+}
+```
+
+Получить id пользователя из текущего `ClaimsPrincipal`: `user.GetJoinrpgUserId()`.
+
+### 5. Middleware pipeline
 
 ```csharp
 app.UseForwardedHeaders();           // Должен быть первым — обрабатывает X-Forwarded-* заголовки
@@ -64,7 +106,7 @@ app.UseJoinRequestLogging();         // Логирование HTTP-запрос
 app.MapJoinHealthChecks();           // Эндпойнты /health, /health/ready, /health/live
 ```
 
-### 5. MVC/Razor Pages фильтры (опционально)
+### 6. MVC/Razor Pages фильтры (опционально)
 
 Для обогащения логов данными из MVC/Razor Pages контекста:
 
@@ -87,6 +129,7 @@ options.Filters.Add<SerilogRazorPagesFilter>();
 | **Forwarded Headers** | `UseForwardedHeaders()` / `ConfigureForwardedHeaders()` | Обработка X-Forwarded-Proto и X-Forwarded-For от reverse proxy |
 | **DbContext** | `AddJoinEfCoreDbContext<T>()` | PostgreSQL + EntityFramework.Exceptions + health check для каждого контекста |
 | **Миграции** | `RegisterMigrator<T>()` | Регистрация DbContext + `IMigratorService` для применения миграций |
+| **Логин через id.joinrpg.ru** | `AddJoinRpgAuthentication<T>()`, `MapAuthEndpoints()`, `IJoinUserLoginHandler` | OpenIddict client (authorization code flow), cookie-схема, эндпойнты `/login`, `/signin-joinrpg`, `/logout` |
 | **Конфигурация хостов** | `JoinRpgHostNamesOptions` | Имена хостов всех сервисов JoinRpg (основной сайт, IdPortal, KogdaIgra, рейтинг) |
 | **MVC фильтры** | `SerilogMvcFilter`, `SerilogRazorPagesFilter` | Обогащение логов данными из HTTP-контекста для MVC и Razor Pages |
 


### PR DESCRIPTION
## Что сделано

Переносит в `JoinRpg.Common.WebInfrastructure` (новая папка `Auth/`) общую инфраструктурную часть логина через id.joinrpg.ru (OpenIddict client, authorization code flow), которая сейчас независимо и почти дословно продублирована в двух сателлитных сайтах — [bastilia-rating](https://github.com/bastilia-ru/bastilia-rating/tree/master/Bastilia.Rating.Portal/Auth) и [TwilightRandom](https://github.com/leotsarev/TwilightRandom/tree/master/Twilight.Web/Auth):

- `JoinRpgOidcOptions` — настройки OIDC-клиента (секция конфигурации `JoinRpgOidc`), `Issuer` по умолчанию `https://id.joinrpg.ru/`.
- `IJoinUserLoginHandler` — контракт для приложение-специфичной части логина (импорт/обновление пользователя, дополнительные claims, роли).
- `AuthEndpoints.MapAuthEndpoints()` — маппинг `/login`, `/signin-joinrpg`, `/logout`.
- `AuthRegistration.AddJoinRpgAuthentication<TContext>()` — регистрация cookie-схемы и OpenIddict-клиента; дженерик по `DbContext`, так как оба сайта одинаково хранят состояние OpenIddict через `AddCore().UseEntityFrameworkCore().UseDbContext<TContext>()`.
- `ClaimsPrincipalExtensions.GetJoinrpgUserId()` — извлечение `UserIdentification` текущего пользователя из claims.

Приложение-специфичная логика (импорт пользователя из БД, роли, avatar-claim и т.п.) остаётся в каждом сайте за реализацией `IJoinUserLoginHandler` — перенос самих bastilia-rating/TwilightRandom на этот пакет не входит в этот PR.

## Test plan

- [x] `dotnet build` — весь solution собирается
- [x] `dotnet format --verify-no-changes --severity warn` — без изменений
- [ ] Ручная проверка: подключение пакета в bastilia-rating/TwilightRandom (отдельная задача в тех репозиториях)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01L2Z5Mux1rWo5WeZ51RQdwN