### PR TITLE
fix: пробел после запятой в тексте о персональных данных

### DIFF
--- a/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
@@ -48,7 +48,7 @@ public class AddClaimViewModel : IProjectIdAware
 
     [Display(Name = "Предоставить доступ к паспортным данным",
      Description = "Мастера игры просят вас предоставить доступ к паспортным данным. Вероятно, это нужно для поселения. Вы все равно сможете отправить заявку," +
-        "даже если не предоставите доступ, но возможно, мастера отклонят вашу заявку. ")]
+        " даже если не предоставите доступ, но возможно, мастера отклонят вашу заявку. ")]
     public bool SensitiveDataAllowed { get; set; }
 
     public AddClaimViewModel Fill(Character claimSource, UserInfo userInfo, ProjectInfo projectInfo, Dictionary<int, string?>? overrideValues = null)


### PR DESCRIPTION
## Что сделано
- Исправлена опечатка: отсутствовал пробел после запятой в тексте предупреждения о персональных данных ("...отправить заявку,даже если...").

Generated with [Claude Code](https://claude.ai/code)