### PR TITLE
Remove trailing whitespace in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,6 @@ updates:
           - "AWSSDK.*"
 
   - package-ecosystem: "github-actions"
-    directory: "/" 
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary
- Minor formatting cleanup: removed trailing whitespace after `directory: "/"` in the github-actions ecosystem entry.

Done while aligning dependabot.yml across joinrpg-net, bastilia-rating and TwilightRandom — no functional change.

## Test plan
- [ ] N/A, cosmetic whitespace-only change