### PR TITLE
refactor: убрать мёртвое ProjectInfo.DefaultTemplateCharacter

### DIFF
--- a/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectInfo.cs
+++ b/src/JoinRpg.DomainTypes/ProjectMetadata/ProjectInfo.cs
@@ -26,7 +26,6 @@ public record class ProjectInfo
     public ProjectFinanceSettings ProjectFinanceSettings { get; }
     public bool AccomodationEnabled { get; }
 
-    public CharacterIdentification? DefaultTemplateCharacter { get; }
     public bool AllowToSetGroups { get; }
 
     public CharacterGroupIdentification RootCharacterGroupId { get; }


### PR DESCRIPTION
## Что сделано

Убрано свойство `ProjectInfo.DefaultTemplateCharacter`.

Оно было объявлено, но **никогда не присваивалось в конструкторе** — то есть всегда возвращало `null`. Использований у него не было. Реальное значение живёт в `ClaimSettings.DefaultTemplate` и пишется через `ProjectService.SetClaimSettings`.

Ловушка на будущее: любой, кто им воспользовался бы, получил бы тихий `null`.

Найдено при аудите того, какие свойства `ProjectInfo` меняются мимо `ProjectPropsService` (ADR009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nLrVeiLMRj5JYAohvBiFz