### PR TITLE
refactor: настройки финансов проекта через IProjectPropsService

### DIFF
--- a/src/JoinRpg.DataModel.Mocks/MockedProject.cs
+++ b/src/JoinRpg.DataModel.Mocks/MockedProject.cs
@@ -101,6 +101,12 @@ public class MockedProject
             acl.User ??= new User { UserId = acl.UserId, PrefferedName = $"User{acl.UserId}", Email = $"user{acl.UserId}@example.com", Claims = [] };
         }
 
+        foreach (var paymentType in Project.PaymentTypes)
+        {
+            paymentType.User ??= Project.ProjectAcls.FirstOrDefault(a => a.UserId == paymentType.UserId)?.User
+                ?? new User { UserId = paymentType.UserId, PrefferedName = $"User{paymentType.UserId}", Email = $"user{paymentType.UserId}@example.com", Claims = [] };
+        }
+
         // Имитация relationship fixup EF6: если дефолтная сетка ролей проставлена только
         // навигационным свойством (сущность добавлена в рамках текущей мутации и ещё не имела Id),
         // подтягиваем сгенерированный Id в FK-свойство — как это делает реальный DbContext при SaveChanges.

--- a/src/JoinRpg.DataModel/Finances/PaymentType.cs
+++ b/src/JoinRpg.DataModel/Finances/PaymentType.cs
@@ -36,7 +36,12 @@ public class PaymentType : IProjectEntity, IValidatableObject, IDeletableSubEnti
     public virtual ICollection<FinanceOperation> Operations { get; set; }
 
     #region interface implementations
-    public bool CanBePermanentlyDeleted => !Operations.Any();
+    /// <summary>
+    /// Тип оплаты не удаляется физически никогда — только soft-delete (<see cref="IsActive"/>).
+    /// Иначе пришлось бы всюду, где тип оплаты выключают, тянуть за собой его
+    /// <see cref="Operations"/> только ради этой проверки.
+    /// </summary>
+    public bool CanBePermanentlyDeleted => false;
     int IOrderableEntity.Id => ProjectId;
     #endregion
 

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -6,6 +6,7 @@ using JoinRpg.Portal.Controllers.Common;
 using JoinRpg.Portal.Helpers;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using JoinRpg.Services.Interfaces;
+using JoinRpg.Services.Interfaces.Projects;
 using JoinRpg.Web.Models;
 using JoinRpg.Web.Models.Exporters;
 using JoinRpg.Web.Models.Money;
@@ -20,6 +21,7 @@ public class FinancesController(
     IProjectRepository projectRepository,
     IExportDataService exportDataService,
     IFinanceService financeService,
+    IProjectFinanceSettingsService financeSettingsService,
     IUriService uriService,
     IFinanceReportRepository financeReportRepository,
     IUserRepository userRepository,
@@ -113,11 +115,11 @@ public class FinancesController(
         {
             if (data.PaymentTypeId > 0)
             {
-                await financeService.TogglePaymentActiveness(data.ProjectId, data.PaymentTypeId.Value);
+                await financeSettingsService.TogglePaymentActiveness(new(data.ProjectId), data.PaymentTypeId.Value);
             }
             else
             {
-                await financeService.CreatePaymentType(new CreatePaymentTypeRequest
+                await financeSettingsService.CreatePaymentType(new CreatePaymentTypeRequest
                 {
                     ProjectId = data.ProjectId,
                     TargetMasterId = data.MasterId,
@@ -143,7 +145,7 @@ public class FinancesController(
     {
         try
         {
-            await financeService.CreatePaymentType(new CreatePaymentTypeRequest
+            await financeSettingsService.CreatePaymentType(new CreatePaymentTypeRequest
             {
                 ProjectId = viewModel.ProjectId,
                 TargetMasterId = viewModel.UserId,
@@ -192,7 +194,7 @@ public class FinancesController(
 
         try
         {
-            await financeService.EditCustomPaymentType(viewModel.ProjectId, viewModel.PaymentTypeId, viewModel.Name, viewModel.IsDefault);
+            await financeSettingsService.EditCustomPaymentType(new(viewModel.ProjectId), viewModel.PaymentTypeId, viewModel.Name, viewModel.IsDefault);
             return RedirectToAction("Setup", new { viewModel.ProjectId });
         }
         catch (Exception exc)
@@ -208,7 +210,7 @@ public class FinancesController(
     {
         try
         {
-            await financeService.CreateFeeSetting(new CreateFeeSettingRequest()
+            await financeSettingsService.CreateFeeSetting(new CreateFeeSettingRequest()
             {
                 ProjectId = viewModel.ProjectId,
                 Fee = viewModel.Fee,
@@ -231,7 +233,7 @@ public class FinancesController(
     {
         try
         {
-            await financeService.DeleteFeeSetting(projectid, projectFeeSettingId);
+            await financeSettingsService.DeleteFeeSetting(new(projectid), projectFeeSettingId);
             return RedirectToAction("Setup", new { projectid });
         }
         catch (Exception ex)
@@ -278,7 +280,7 @@ public class FinancesController(
     {
         try
         {
-            await financeService.SaveGlobalSettings(new SetFinanceSettingsRequest
+            await financeSettingsService.SaveGlobalSettings(new SetFinanceSettingsRequest
             {
                 ProjectId = viewModel.ProjectId,
                 WarnOnOverPayment = viewModel.WarnOnOverPayment,

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -121,7 +121,7 @@ public class FinancesController(
             {
                 await financeSettingsService.CreatePaymentType(new CreatePaymentTypeRequest
                 {
-                    ProjectId = data.ProjectId,
+                    ProjectId = new(data.ProjectId),
                     TargetMasterId = data.MasterId,
                     Name = null, // У них специальное имя
                     TypeKind = (PaymentTypeKind)data.TypeKind.GetValueOrDefault(PaymentTypeKindViewModel.Custom),
@@ -147,7 +147,7 @@ public class FinancesController(
         {
             await financeSettingsService.CreatePaymentType(new CreatePaymentTypeRequest
             {
-                ProjectId = viewModel.ProjectId,
+                ProjectId = new(viewModel.ProjectId),
                 TargetMasterId = viewModel.UserId,
                 TypeKind = PaymentTypeKind.Custom,
                 Name = viewModel.Name,
@@ -212,7 +212,7 @@ public class FinancesController(
         {
             await financeSettingsService.CreateFeeSetting(new CreateFeeSettingRequest()
             {
-                ProjectId = viewModel.ProjectId,
+                ProjectId = new(viewModel.ProjectId),
                 Fee = viewModel.Fee,
                 PreferentialFee = viewModel.PreferentialFee,
                 StartDate = viewModel.StartDate.ToDateTime(TimeOnly.MinValue),
@@ -282,7 +282,7 @@ public class FinancesController(
         {
             await financeSettingsService.SaveGlobalSettings(new SetFinanceSettingsRequest
             {
-                ProjectId = viewModel.ProjectId,
+                ProjectId = new(viewModel.ProjectId),
                 WarnOnOverPayment = viewModel.WarnOnOverPayment,
                 PreferentialFeeEnabled = viewModel.PreferentialFeeEnabled,
                 PreferentialFeeConditions = viewModel.PreferentialFeeConditions,

--- a/src/JoinRpg.Portal/Controllers/FinancesController.cs
+++ b/src/JoinRpg.Portal/Controllers/FinancesController.cs
@@ -115,7 +115,7 @@ public class FinancesController(
         {
             if (data.PaymentTypeId > 0)
             {
-                await financeSettingsService.TogglePaymentActiveness(new(data.ProjectId), data.PaymentTypeId.Value);
+                await financeSettingsService.TogglePaymentActiveness(new PaymentTypeIdentification(data.ProjectId, data.PaymentTypeId.Value));
             }
             else
             {
@@ -194,7 +194,7 @@ public class FinancesController(
 
         try
         {
-            await financeSettingsService.EditCustomPaymentType(new(viewModel.ProjectId), viewModel.PaymentTypeId, viewModel.Name, viewModel.IsDefault);
+            await financeSettingsService.EditCustomPaymentType(new PaymentTypeIdentification(viewModel.ProjectId, viewModel.PaymentTypeId), viewModel.Name, viewModel.IsDefault);
             return RedirectToAction("Setup", new { viewModel.ProjectId });
         }
         catch (Exception exc)

--- a/src/JoinRpg.Services.Impl.Test/Projects/Fakes.cs
+++ b/src/JoinRpg.Services.Impl.Test/Projects/Fakes.cs
@@ -63,6 +63,10 @@ internal sealed class FakeProjectMetadataWriteRepository(MockedProject mock) : I
             {
                 _ = mock.Project.ProjectRolesLists.Remove(rolesList);
             }
+            if (entity is ProjectFeeSetting feeSetting)
+            {
+                _ = mock.Project.ProjectFeeSettings.Remove(feeSetting);
+            }
         }
     }
 }
@@ -141,7 +145,7 @@ internal sealed class FakeNotificationService : INotificationService
 
 internal sealed class FakeVirtualUsersService : IVirtualUsersService
 {
-    public User PaymentsUser => throw new NotSupportedException();
+    public User PaymentsUser { get; } = new User { UserId = 1000, PrefferedName = "Payments", Email = "payments@example.com", Claims = [] };
     public User RobotUser => throw new NotSupportedException();
     public UserIdentification RobotUserId => new(int.MaxValue);
 }

--- a/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
@@ -1,0 +1,291 @@
+using JoinRpg.DataModel;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes.ProjectMetadata;
+using JoinRpg.DomainTypes.ProjectMetadata.Payments;
+using JoinRpg.Services.Impl.Projects.Metadata;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.Services.Impl.Test.Projects;
+
+public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
+{
+    private readonly FakeVirtualUsersService vpu = new();
+
+    private ProjectFinanceSettingsService CreateService(int? currentUserId = null, bool isAdmin = false)
+        => new(CreatePropsService(CreateCurrentUser(currentUserId, isAdmin)), vpu);
+
+    private ProjectFinanceSettings FinanceSettings => Result.ProjectFinanceSettings;
+
+    /// <summary>Добавляет тип оплаты прямо в мок, минуя сервис (заготовка состояния для теста).</summary>
+    private PaymentType AddPaymentType(PaymentTypeKind kind, bool isActive = true, int? userId = null)
+    {
+        var paymentType = new PaymentType(kind, mock.Project.ProjectId, userId ?? mock.Master.UserId)
+        {
+            PaymentTypeId = mock.Project.PaymentTypes.Count + 1,
+            IsActive = isActive,
+        };
+        mock.Project.PaymentTypes.Add(paymentType);
+        mock.ReInitProjectInfo();
+        return paymentType;
+    }
+
+    /// <summary>Добавляет строку расписания взносов прямо в мок, минуя сервис.</summary>
+    private ProjectFeeSetting AddFeeSetting(DateTime startDate)
+    {
+        var feeSetting = new ProjectFeeSetting
+        {
+            ProjectFeeSettingId = mock.Project.ProjectFeeSettings.Count + 1,
+            ProjectId = mock.Project.ProjectId,
+            Fee = 1000,
+            StartDate = startDate,
+        };
+        mock.Project.ProjectFeeSettings.Add(feeSetting);
+        mock.ReInitProjectInfo();
+        return feeSetting;
+    }
+
+    private SetFinanceSettingsRequest GlobalSettings(bool preferentialFeeEnabled) => new()
+    {
+        ProjectId = ProjectId.Value,
+        WarnOnOverPayment = true,
+        PreferentialFeeEnabled = preferentialFeeEnabled,
+        PreferentialFeeConditions = "Условия",
+    };
+
+    #region Общие настройки
+
+    [Fact]
+    public async Task SaveGlobalSettingsShouldAppearInProjectInfo()
+    {
+        await CreateService().SaveGlobalSettings(GlobalSettings(preferentialFeeEnabled: true));
+
+        FinanceSettings.PreferentialFeeEnabled.ShouldBeTrue();
+        mock.Project.Details.FinanceWarnOnOverPayment.ShouldBeTrue();
+        mock.Project.Details.PreferentialFeeConditions.Contents.ShouldBe("Условия");
+    }
+
+    [Fact]
+    public async Task CantChangeSettingsWithoutManageMoneyPermission()
+        => _ = await Should.ThrowAsync<NoAccessToProjectException>(
+            () => CreateService(currentUserId: mock.Player.UserId).SaveGlobalSettings(GlobalSettings(preferentialFeeEnabled: true)));
+
+    [Fact]
+    public async Task CantChangeSettingsInArchivedProject()
+    {
+        mock.Project.Active = false;
+        mock.Project.IsAcceptingClaims = false;
+        mock.ReInitProjectInfo();
+
+        _ = await Should.ThrowAsync<ProjectDeactivatedException>(
+            () => CreateService().SaveGlobalSettings(GlobalSettings(preferentialFeeEnabled: true)));
+    }
+
+    #endregion
+
+    #region Расписание взносов
+
+    [Fact]
+    public async Task CreateFeeSettingShouldAppearInProjectInfo()
+    {
+        var startDate = DateTime.UtcNow.Date.AddDays(10);
+
+        await CreateService().CreateFeeSetting(new CreateFeeSettingRequest
+        {
+            ProjectId = ProjectId.Value,
+            Fee = 500,
+            StartDate = startDate,
+        });
+
+        var fee = FinanceSettings.FeeSchedule.ShouldHaveSingleItem();
+        fee.Fee.ShouldBe(500);
+        // Самая ранняя строка расписания всегда сдвигается к дате создания проекта.
+        fee.StartDate.ShouldBe(mock.Project.CreatedDate);
+    }
+
+    [Fact]
+    public async Task SecondFeeSettingKeepsItsOwnStartDate()
+    {
+        var service = CreateService();
+        var startDate = DateTime.UtcNow.Date.AddDays(10);
+
+        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId.Value, Fee = 500, StartDate = DateTime.UtcNow.Date });
+        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId.Value, Fee = 700, StartDate = startDate });
+
+        FinanceSettings.FeeSchedule.Count.ShouldBe(2);
+        FinanceSettings.GetFeeForDate(startDate, preferential: false).ShouldBe(700);
+    }
+
+    [Fact]
+    public async Task CantCreateFeeSettingInPast()
+        => _ = await Should.ThrowAsync<CannotPerformOperationInPast>(
+            () => CreateService().CreateFeeSetting(new CreateFeeSettingRequest
+            {
+                ProjectId = ProjectId.Value,
+                Fee = 500,
+                StartDate = DateTime.UtcNow.Date.AddDays(-10),
+            }));
+
+    [Fact]
+    public async Task CantSetPreferentialFeeWhenItIsDisabled()
+        => _ = await Should.ThrowAsync<PreferentialFeeNotEnabled>(
+            () => CreateService().CreateFeeSetting(new CreateFeeSettingRequest
+            {
+                ProjectId = ProjectId.Value,
+                Fee = 500,
+                PreferentialFee = 100,
+                StartDate = DateTime.UtcNow.Date.AddDays(10),
+            }));
+
+    [Fact]
+    public async Task PreferentialFeeAllowedWhenEnabled()
+    {
+        var service = CreateService();
+        await service.SaveGlobalSettings(GlobalSettings(preferentialFeeEnabled: true));
+
+        await service.CreateFeeSetting(new CreateFeeSettingRequest
+        {
+            ProjectId = ProjectId.Value,
+            Fee = 500,
+            PreferentialFee = 100,
+            StartDate = DateTime.UtcNow.Date.AddDays(10),
+        });
+
+        FinanceSettings.FeeSchedule.ShouldHaveSingleItem().PreferentialFee.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task DeleteFeeSettingShouldDisappearFromProjectInfo()
+    {
+        var feeSetting = AddFeeSetting(DateTime.UtcNow.Date.AddDays(10));
+
+        await CreateService().DeleteFeeSetting(ProjectId, feeSetting.ProjectFeeSettingId);
+
+        FinanceSettings.FeeSchedule.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CantDeleteFeeSettingFromPast()
+    {
+        var feeSetting = AddFeeSetting(DateTime.UtcNow.Date.AddDays(-10));
+
+        _ = await Should.ThrowAsync<CannotPerformOperationInPast>(
+            () => CreateService().DeleteFeeSetting(ProjectId, feeSetting.ProjectFeeSettingId));
+    }
+
+    #endregion
+
+    #region Типы оплаты
+
+    [Fact]
+    public async Task CreateCashPaymentTypeShouldAppearInProjectInfo()
+    {
+        await CreateService().CreatePaymentType(new CreatePaymentTypeRequest
+        {
+            ProjectId = ProjectId.Value,
+            TargetMasterId = new UserIdentification(mock.Master.UserId),
+            TypeKind = PaymentTypeKind.Cash,
+            Name = null,
+        });
+
+        var paymentType = FinanceSettings.PaymentTypes.ShouldHaveSingleItem();
+        paymentType.TypeKind.ShouldBe(PaymentTypeKind.Cash);
+        paymentType.Enabled.ShouldBeTrue();
+        paymentType.User.UserId.ShouldBe(new UserIdentification(mock.Master.UserId));
+    }
+
+    [Fact]
+    public async Task CantCreateSecondCashPaymentTypeForSameMaster()
+    {
+        _ = AddPaymentType(PaymentTypeKind.Cash);
+
+        _ = await Should.ThrowAsync<JoinRpgInvalidUserException>(
+            () => CreateService().CreatePaymentType(new CreatePaymentTypeRequest
+            {
+                ProjectId = ProjectId.Value,
+                TargetMasterId = new UserIdentification(mock.Master.UserId),
+                TypeKind = PaymentTypeKind.Cash,
+                Name = null,
+            }));
+    }
+
+    [Fact]
+    public async Task CantCreatePaymentTypeForNonMaster()
+        => _ = await Should.ThrowAsync<NoAccessToProjectException>(
+            () => CreateService().CreatePaymentType(new CreatePaymentTypeRequest
+            {
+                ProjectId = ProjectId.Value,
+                TargetMasterId = new UserIdentification(mock.Player.UserId),
+                TypeKind = PaymentTypeKind.Cash,
+                Name = null,
+            }));
+
+    [Fact]
+    public async Task EditCustomPaymentTypeShouldAppearInProjectInfo()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Custom);
+
+        await CreateService().EditCustomPaymentType(ProjectId, paymentType.PaymentTypeId, "Перевод на карту", isDefault: true);
+
+        var result = FinanceSettings.PaymentTypes.ShouldHaveSingleItem();
+        result.Name.ShouldBe("Перевод на карту");
+        result.IsDefault.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Выключение типа оплаты — всегда soft-delete: физически он не удаляется, иначе потерялась бы
+    /// связь с уже проведёнными операциями (см. PaymentType.CanBePermanentlyDeleted).
+    /// </summary>
+    [Fact]
+    public async Task DisablingPaymentTypeIsSoftDelete()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Custom);
+
+        await CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+
+        paymentType.IsActive.ShouldBeFalse();
+        mock.Project.PaymentTypes.ShouldContain(paymentType);
+        FinanceSettings.PaymentTypes.ShouldHaveSingleItem().Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task MasterCanDisableOnlinePaymentType()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Online, userId: vpu.PaymentsUser.UserId);
+
+        await CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+
+        FinanceSettings.PaymentTypes.ShouldHaveSingleItem().Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task MasterCantEnableOnlinePaymentTypeBack()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Online, isActive: false, userId: vpu.PaymentsUser.UserId);
+
+        _ = await Should.ThrowAsync<MustBeAdminException>(
+            () => CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId));
+    }
+
+    [Fact]
+    public async Task AdminCanEnableOnlinePaymentTypeBack()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Online, isActive: false, userId: vpu.PaymentsUser.UserId);
+
+        await CreateService(currentUserId: mock.Player.UserId, isAdmin: true)
+            .TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+
+        FinanceSettings.PaymentTypes.ShouldHaveSingleItem().Enabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CantTogglePaymentTypeWithoutManageMoneyPermission()
+    {
+        var paymentType = AddPaymentType(PaymentTypeKind.Custom);
+
+        _ = await Should.ThrowAsync<NoAccessToProjectException>(
+            () => CreateService(currentUserId: mock.Player.UserId)
+                .TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId));
+    }
+
+    #endregion
+}

--- a/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
@@ -29,6 +29,9 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         return paymentType;
     }
 
+    private PaymentTypeIdentification PaymentTypeId(PaymentType paymentType)
+        => new(ProjectId, paymentType.PaymentTypeId);
+
     /// <summary>Добавляет строку расписания взносов прямо в мок, минуя сервис.</summary>
     private ProjectFeeSetting AddFeeSetting(DateTime startDate)
     {
@@ -226,7 +229,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
     {
         var paymentType = AddPaymentType(PaymentTypeKind.Custom);
 
-        await CreateService().EditCustomPaymentType(ProjectId, paymentType.PaymentTypeId, "Перевод на карту", isDefault: true);
+        await CreateService().EditCustomPaymentType(PaymentTypeId(paymentType), "Перевод на карту", isDefault: true);
 
         var result = FinanceSettings.PaymentTypes.ShouldHaveSingleItem();
         result.Name.ShouldBe("Перевод на карту");
@@ -242,7 +245,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
     {
         var paymentType = AddPaymentType(PaymentTypeKind.Custom);
 
-        await CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+        await CreateService().TogglePaymentActiveness(PaymentTypeId(paymentType));
 
         paymentType.IsActive.ShouldBeFalse();
         mock.Project.PaymentTypes.ShouldContain(paymentType);
@@ -254,7 +257,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
     {
         var paymentType = AddPaymentType(PaymentTypeKind.Online, userId: vpu.PaymentsUser.UserId);
 
-        await CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+        await CreateService().TogglePaymentActiveness(PaymentTypeId(paymentType));
 
         FinanceSettings.PaymentTypes.ShouldHaveSingleItem().Enabled.ShouldBeFalse();
     }
@@ -265,7 +268,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         var paymentType = AddPaymentType(PaymentTypeKind.Online, isActive: false, userId: vpu.PaymentsUser.UserId);
 
         _ = await Should.ThrowAsync<MustBeAdminException>(
-            () => CreateService().TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId));
+            () => CreateService().TogglePaymentActiveness(PaymentTypeId(paymentType)));
     }
 
     [Fact]
@@ -274,7 +277,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         var paymentType = AddPaymentType(PaymentTypeKind.Online, isActive: false, userId: vpu.PaymentsUser.UserId);
 
         await CreateService(currentUserId: mock.Player.UserId, isAdmin: true)
-            .TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId);
+            .TogglePaymentActiveness(PaymentTypeId(paymentType));
 
         FinanceSettings.PaymentTypes.ShouldHaveSingleItem().Enabled.ShouldBeTrue();
     }
@@ -286,7 +289,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
 
         _ = await Should.ThrowAsync<NoAccessToProjectException>(
             () => CreateService(currentUserId: mock.Player.UserId)
-                .TogglePaymentActiveness(ProjectId, paymentType.PaymentTypeId));
+                .TogglePaymentActiveness(PaymentTypeId(paymentType)));
     }
 
     #endregion

--- a/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/Projects/ProjectFinanceSettingsServiceTest.cs
@@ -46,7 +46,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
 
     private SetFinanceSettingsRequest GlobalSettings(bool preferentialFeeEnabled) => new()
     {
-        ProjectId = ProjectId.Value,
+        ProjectId = ProjectId,
         WarnOnOverPayment = true,
         PreferentialFeeEnabled = preferentialFeeEnabled,
         PreferentialFeeConditions = "Условия",
@@ -91,8 +91,9 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
 
         await CreateService().CreateFeeSetting(new CreateFeeSettingRequest
         {
-            ProjectId = ProjectId.Value,
+            ProjectId = ProjectId,
             Fee = 500,
+            PreferentialFee = null,
             StartDate = startDate,
         });
 
@@ -108,8 +109,8 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         var service = CreateService();
         var startDate = DateTime.UtcNow.Date.AddDays(10);
 
-        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId.Value, Fee = 500, StartDate = DateTime.UtcNow.Date });
-        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId.Value, Fee = 700, StartDate = startDate });
+        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId, Fee = 500, PreferentialFee = null, StartDate = DateTime.UtcNow.Date });
+        await service.CreateFeeSetting(new CreateFeeSettingRequest { ProjectId = ProjectId, Fee = 700, PreferentialFee = null, StartDate = startDate });
 
         FinanceSettings.FeeSchedule.Count.ShouldBe(2);
         FinanceSettings.GetFeeForDate(startDate, preferential: false).ShouldBe(700);
@@ -120,8 +121,9 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         => _ = await Should.ThrowAsync<CannotPerformOperationInPast>(
             () => CreateService().CreateFeeSetting(new CreateFeeSettingRequest
             {
-                ProjectId = ProjectId.Value,
+                ProjectId = ProjectId,
                 Fee = 500,
+                PreferentialFee = null,
                 StartDate = DateTime.UtcNow.Date.AddDays(-10),
             }));
 
@@ -130,7 +132,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         => _ = await Should.ThrowAsync<PreferentialFeeNotEnabled>(
             () => CreateService().CreateFeeSetting(new CreateFeeSettingRequest
             {
-                ProjectId = ProjectId.Value,
+                ProjectId = ProjectId,
                 Fee = 500,
                 PreferentialFee = 100,
                 StartDate = DateTime.UtcNow.Date.AddDays(10),
@@ -144,7 +146,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
 
         await service.CreateFeeSetting(new CreateFeeSettingRequest
         {
-            ProjectId = ProjectId.Value,
+            ProjectId = ProjectId,
             Fee = 500,
             PreferentialFee = 100,
             StartDate = DateTime.UtcNow.Date.AddDays(10),
@@ -181,7 +183,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
     {
         await CreateService().CreatePaymentType(new CreatePaymentTypeRequest
         {
-            ProjectId = ProjectId.Value,
+            ProjectId = ProjectId,
             TargetMasterId = new UserIdentification(mock.Master.UserId),
             TypeKind = PaymentTypeKind.Cash,
             Name = null,
@@ -201,7 +203,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         _ = await Should.ThrowAsync<JoinRpgInvalidUserException>(
             () => CreateService().CreatePaymentType(new CreatePaymentTypeRequest
             {
-                ProjectId = ProjectId.Value,
+                ProjectId = ProjectId,
                 TargetMasterId = new UserIdentification(mock.Master.UserId),
                 TypeKind = PaymentTypeKind.Cash,
                 Name = null,
@@ -213,7 +215,7 @@ public class ProjectFinanceSettingsServiceTest : ProjectMetadataServiceTestBase
         => _ = await Should.ThrowAsync<NoAccessToProjectException>(
             () => CreateService().CreatePaymentType(new CreatePaymentTypeRequest
             {
-                ProjectId = ProjectId.Value,
+                ProjectId = ProjectId,
                 TargetMasterId = new UserIdentification(mock.Player.UserId),
                 TypeKind = PaymentTypeKind.Cash,
                 Name = null,

--- a/src/JoinRpg.Services.Impl/FinanceOperationsImpl.cs
+++ b/src/JoinRpg.Services.Impl/FinanceOperationsImpl.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Data.Entity;
 using System.Data.Entity.Validation;
 using JoinRpg.Data.Write.Interfaces;
@@ -6,7 +5,6 @@ using JoinRpg.DataModel;
 using JoinRpg.DataModel.Finances;
 using JoinRpg.Domain;
 using JoinRpg.DomainTypes.Characters.Claims;
-using JoinRpg.DomainTypes.ProjectMetadata.Payments;
 using JoinRpg.Services.Impl.Claims;
 using JoinRpg.Services.Interfaces.Notification;
 
@@ -15,7 +13,6 @@ namespace JoinRpg.Services.Impl;
 internal class FinanceOperationsImpl(
     IUnitOfWork unitOfWork,
     IEmailService emailService,
-    IVirtualUsersService vpu,
     ICurrentUserAccessor currentUserAccessor,
     ClaimNotificationService claimNotificationService,
     CommentHelper commentHelper,
@@ -39,186 +36,7 @@ internal class FinanceOperationsImpl(
         await claimNotificationService.SendNotification(email.WithCommentId(comment.CommentId));
     }
 
-    #region Payment type
-
-    /// <inheritdoc />
-    public async Task CreatePaymentType(CreatePaymentTypeRequest request)
-    {
-        // Loading project
-        var project = await ProjectRepository.GetProjectForFinanceSetup(request.ProjectId);
-
-        // Checking access rights of the current user
-        if (!IsCurrentUserAdmin)
-        {
-            _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-        }
-
-        // Preparing master Id and checking if the same payment type already created
-        int masterId;
-        if (!request.TypeKind.IsOnline())
-        {
-            _ = project.RequestMasterAccess(request.TargetMasterId);
-
-            // Cash payment could be only one
-            if (request.TypeKind == PaymentTypeKind.Cash
-                && project.PaymentTypes.Any(pt => pt.UserId == request.TargetMasterId && pt.TypeKind == PaymentTypeKind.Cash))
-            {
-                throw new JoinRpgInvalidUserException($@"Payment of type ${request.TypeKind.GetDisplayName()} is already created for the user ${request.TargetMasterId}");
-            }
-
-            masterId = request.TargetMasterId.Value;
-        }
-        else
-        {
-            if (project.PaymentTypes.Any(pt => pt.TypeKind == request.TypeKind))
-            {
-                throw new DataException($"Can't create more than one {request.TypeKind} payment type");
-            }
-
-            masterId = vpu.PaymentsUser.UserId;
-        }
-
-        // Creating payment type
-        var result = new PaymentType(request.TypeKind, request.ProjectId, masterId);
-
-        // Configuring payment type
-        if (result.TypeKind == PaymentTypeKind.Custom)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(request.Name);
-            // Checking custom payment type name
-            result.Name = request.Name.Trim();
-        }
-
-        // Saving
-        project.PaymentTypes.Add(result);
-        await UnitOfWork.SaveChangesAsync();
-    }
-
-    /// <inheritdoc />
-    public async Task TogglePaymentActiveness(int projectId, int paymentTypeId)
-    {
-        var project = await ProjectRepository.GetProjectForFinanceSetup(projectId);
-        var paymentType = project.PaymentTypes.Single(pt => pt.PaymentTypeId == paymentTypeId);
-
-        switch (paymentType.TypeKind)
-        {
-            case PaymentTypeKind.Custom:
-            case PaymentTypeKind.Cash:
-                if (!IsCurrentUserAdmin)
-                {
-                    _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-                }
-
-                break;
-            case PaymentTypeKind.Online:
-            case PaymentTypeKind.OnlineSubscription:
-                if (!IsCurrentUserAdmin)
-                {
-                    // Regular master with finance management permissions can disable online payments
-                    if (paymentType.IsActive)
-                    {
-                        _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-                    }
-                    // ...but to enable them back he must have admin permissions
-                    else
-                    {
-                        throw new MustBeAdminException();
-                    }
-                }
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(paymentType.TypeKind), paymentType.TypeKind, null);
-        }
-
-        if (paymentType.IsActive)
-        {
-            _ = SmartDelete(paymentType);
-        }
-        else
-        {
-            paymentType.IsActive = true;
-        }
-
-        await UnitOfWork.SaveChangesAsync();
-    }
-
-    public async Task EditCustomPaymentType(int projectId,
-        int paymentTypeId,
-        string name,
-        bool isDefault)
-    {
-        var project = await ProjectRepository.GetProjectForFinanceSetup(projectId);
-        _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-
-        var paymentType = project.PaymentTypes.Single(pt => pt.PaymentTypeId == paymentTypeId);
-
-        paymentType.IsActive = true;
-        paymentType.Name = Required(name);
-
-        if (isDefault && !paymentType.IsDefault)
-        {
-            foreach (var oldDefault in project.PaymentTypes.Where(pt => pt.IsDefault))
-            {
-                oldDefault.IsDefault = false;
-            }
-        }
-
-        paymentType.IsDefault = isDefault;
-
-        await UnitOfWork.SaveChangesAsync();
-    }
-
-    #endregion
-
-    #region Fee options
-
-    public async Task CreateFeeSetting(CreateFeeSettingRequest request)
-    {
-        var project = await ProjectRepository.GetProjectForFinanceSetup(request.ProjectId);
-        _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-
-        if (request.StartDate < DateTime.UtcNow.Date.AddDays(-1))
-        {
-            throw new CannotPerformOperationInPast();
-        }
-
-        if (!project.Details.PreferentialFeeEnabled && request.PreferentialFee != null)
-        {
-            throw new PreferentialFeeNotEnabled();
-        }
-
-        project.ProjectFeeSettings.Add(new ProjectFeeSetting()
-        {
-            Fee = request.Fee,
-            StartDate = request.StartDate,
-            ProjectId = request.ProjectId,
-            PreferentialFee = request.PreferentialFee,
-        });
-
-        var firstFee = project.ProjectFeeSettings.OrderBy(s => s.StartDate).First();
-        firstFee.StartDate = project.CreatedDate;
-
-        await UnitOfWork.SaveChangesAsync();
-    }
-
-    public async Task DeleteFeeSetting(int projectid, int projectFeeSettingId)
-    {
-        var project = await ProjectRepository.GetProjectForFinanceSetup(projectid);
-        _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-
-        var feeSetting =
-            project.ProjectFeeSettings.Single(pt =>
-                pt.ProjectFeeSettingId == projectFeeSettingId);
-
-        if (feeSetting.StartDate < DateTime.UtcNow)
-        {
-            throw new CannotPerformOperationInPast();
-        }
-
-        _ = UnitOfWork.GetDbSet<ProjectFeeSetting>().Remove(feeSetting);
-
-        await UnitOfWork.SaveChangesAsync();
-    }
+    #region Fee
 
     public async Task ChangeFee(ClaimIdentification claimId, int feeValue)
     {
@@ -235,22 +53,6 @@ internal class FinanceOperationsImpl(
 
     #endregion
 
-    #region Finance settings
-
-    public async Task SaveGlobalSettings(SetFinanceSettingsRequest request)
-    {
-        var project = await ProjectRepository.GetProjectForFinanceSetup(request.ProjectId);
-        _ = project.RequestMasterAccess(CurrentUserId, Permission.CanManageMoney);
-
-        project.Details.FinanceWarnOnOverPayment = request.WarnOnOverPayment;
-        project.Details.PreferentialFeeEnabled = request.PreferentialFeeEnabled;
-        project.Details.PreferentialFeeConditions =
-            new MarkdownDbValue(request.PreferentialFeeConditions);
-
-        await UnitOfWork.SaveChangesAsync();
-    }
-
-    #endregion
 
     #region Finance Operations
 

--- a/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
@@ -1,0 +1,215 @@
+using System.Data;
+using JoinRpg.DataModel;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes.ProjectMetadata.Payments;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.Services.Impl.Projects.Metadata;
+
+/// <summary>
+/// Настройки финансов проекта — всё, что попадает в
+/// <see cref="ProjectInfo.ProjectFinanceSettings"/>: типы оплаты, расписание взносов и общие
+/// финансовые флаги. Операции по конкретным заявкам (приём взноса, переводы) живут отдельно,
+/// в <see cref="FinanceOperationsImpl"/>.
+/// </summary>
+internal class ProjectFinanceSettingsService(
+    IProjectPropsService projectPropsService,
+    IVirtualUsersService vpu) : IProjectFinanceSettingsService
+{
+    /// <inheritdoc />
+    public Task CreatePaymentType(CreatePaymentTypeRequest request)
+        => projectPropsService.ChangeProjectProperties(
+            new ProjectIdentification(request.ProjectId),
+            Permission.CanManageMoney,
+            ProjectActiveRequirement.MustBeActive,
+            request,
+            ctx =>
+            {
+                var paymentTypes = ctx.ProjectInfo.ProjectFinanceSettings.PaymentTypes;
+
+                // Preparing master Id and checking if the same payment type already created
+                int masterId;
+                if (!ctx.Request.TypeKind.IsOnline())
+                {
+                    _ = ctx.ProjectInfo.RequestMasterAccess(ctx.Request.TargetMasterId);
+
+                    // Cash payment could be only one
+                    if (ctx.Request.TypeKind == PaymentTypeKind.Cash
+                        && paymentTypes.Any(pt => pt.User.UserId == ctx.Request.TargetMasterId && pt.TypeKind == PaymentTypeKind.Cash))
+                    {
+                        throw new JoinRpgInvalidUserException($@"Payment of type ${ctx.Request.TypeKind.GetDisplayName()} is already created for the user ${ctx.Request.TargetMasterId}");
+                    }
+
+                    masterId = ctx.Request.TargetMasterId!.Value;
+                }
+                else
+                {
+                    if (paymentTypes.Any(pt => pt.TypeKind == ctx.Request.TypeKind))
+                    {
+                        throw new DataException($"Can't create more than one {ctx.Request.TypeKind} payment type");
+                    }
+
+                    masterId = vpu.PaymentsUser.UserId;
+                }
+
+                // Creating payment type
+                var result = new PaymentType(ctx.Request.TypeKind, ctx.Request.ProjectId, masterId);
+
+                // Configuring payment type
+                if (result.TypeKind == PaymentTypeKind.Custom)
+                {
+                    ArgumentException.ThrowIfNullOrWhiteSpace(ctx.Request.Name);
+                    // Checking custom payment type name
+                    result.Name = ctx.Request.Name.Trim();
+                }
+
+                ctx.Project.PaymentTypes.Add(result);
+            });
+
+    /// <inheritdoc />
+    public Task TogglePaymentActiveness(ProjectIdentification projectId, int paymentTypeId)
+        // Право проверяется внутри мутации: оно зависит от вида платежа и от того, включаем мы его
+        // или выключаем (включить онлайн-оплату может только админ).
+        => projectPropsService.ChangeProjectProperties(
+            projectId,
+            Permission.None,
+            ProjectActiveRequirement.MustBeActive,
+            paymentTypeId,
+            ctx =>
+            {
+                var paymentType = ctx.GetPaymentTypeForChange(ctx.Request);
+
+                switch (paymentType.TypeKind)
+                {
+                    case PaymentTypeKind.Custom:
+                    case PaymentTypeKind.Cash:
+                        ctx.RequireManageMoney();
+                        break;
+                    case PaymentTypeKind.Online:
+                    case PaymentTypeKind.OnlineSubscription:
+                        if (!ctx.CurrentUser.IsAdmin)
+                        {
+                            // Regular master with finance management permissions can disable online payments
+                            if (paymentType.IsActive)
+                            {
+                                ctx.RequireManageMoney();
+                            }
+                            // ...but to enable them back he must have admin permissions
+                            else
+                            {
+                                throw new MustBeAdminException();
+                            }
+                        }
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(paymentType.TypeKind), paymentType.TypeKind, null);
+                }
+
+                if (paymentType.IsActive)
+                {
+                    _ = ctx.SmartDelete(paymentType);
+                }
+                else
+                {
+                    paymentType.IsActive = true;
+                }
+            });
+
+    /// <inheritdoc />
+    public Task EditCustomPaymentType(ProjectIdentification projectId,
+        int paymentTypeId,
+        string name,
+        bool isDefault)
+        => projectPropsService.ChangeProjectProperties(
+            projectId,
+            Permission.CanManageMoney,
+            ProjectActiveRequirement.MustBeActive,
+            (paymentTypeId, name, isDefault),
+            ctx =>
+            {
+                var paymentType = ctx.GetPaymentTypeForChange(ctx.Request.paymentTypeId);
+
+                paymentType.IsActive = true;
+                paymentType.Name = ServiceValidation.Required(ctx.Request.name);
+
+                if (ctx.Request.isDefault && !paymentType.IsDefault)
+                {
+                    foreach (var oldDefault in ctx.Project.PaymentTypes.Where(pt => pt.IsDefault))
+                    {
+                        oldDefault.IsDefault = false;
+                    }
+                }
+
+                paymentType.IsDefault = ctx.Request.isDefault;
+            });
+
+    /// <inheritdoc />
+    public Task CreateFeeSetting(CreateFeeSettingRequest request)
+        => projectPropsService.ChangeProjectProperties(
+            new ProjectIdentification(request.ProjectId),
+            Permission.CanManageMoney,
+            ProjectActiveRequirement.MustBeActive,
+            request,
+            ctx =>
+            {
+                if (ctx.Request.StartDate < ctx.Now.UtcDateTime.Date.AddDays(-1))
+                {
+                    throw new CannotPerformOperationInPast();
+                }
+
+                if (!ctx.ProjectInfo.ProjectFinanceSettings.PreferentialFeeEnabled && ctx.Request.PreferentialFee != null)
+                {
+                    throw new PreferentialFeeNotEnabled();
+                }
+
+                ctx.Project.ProjectFeeSettings.Add(new ProjectFeeSetting()
+                {
+                    Fee = ctx.Request.Fee,
+                    StartDate = ctx.Request.StartDate,
+                    ProjectId = ctx.Request.ProjectId,
+                    PreferentialFee = ctx.Request.PreferentialFee,
+                });
+
+                // Самая ранняя строка расписания всегда действует с момента создания проекта —
+                // иначе до её начала взнос был бы не определён.
+                var firstFee = ctx.Project.ProjectFeeSettings.OrderBy(s => s.StartDate).First();
+                firstFee.StartDate = ctx.Project.CreatedDate;
+            });
+
+    /// <inheritdoc />
+    public Task DeleteFeeSetting(ProjectIdentification projectId, int projectFeeSettingId)
+        => projectPropsService.ChangeProjectProperties(
+            projectId,
+            Permission.CanManageMoney,
+            ProjectActiveRequirement.MustBeActive,
+            projectFeeSettingId,
+            ctx =>
+            {
+                var feeSetting =
+                    ctx.Project.ProjectFeeSettings.SingleOrDefault(pt =>
+                        pt.ProjectFeeSettingId == ctx.Request)
+                    ?? throw new JoinRpgEntityNotFoundException(ctx.Request, nameof(ProjectFeeSetting));
+
+                if (feeSetting.StartDate < ctx.Now.UtcDateTime)
+                {
+                    throw new CannotPerformOperationInPast();
+                }
+
+                ctx.RemovePermanently(feeSetting);
+            });
+
+    /// <inheritdoc />
+    public Task SaveGlobalSettings(SetFinanceSettingsRequest request)
+        => projectPropsService.ChangeProjectProperties(
+            new ProjectIdentification(request.ProjectId),
+            Permission.CanManageMoney,
+            ProjectActiveRequirement.MustBeActive,
+            request,
+            ctx =>
+            {
+                ctx.Project.Details.FinanceWarnOnOverPayment = ctx.Request.WarnOnOverPayment;
+                ctx.Project.Details.PreferentialFeeEnabled = ctx.Request.PreferentialFeeEnabled;
+                ctx.Project.Details.PreferentialFeeConditions =
+                    new MarkdownDbValue(ctx.Request.PreferentialFeeConditions);
+            });
+}

--- a/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
@@ -67,11 +67,11 @@ internal class ProjectFinanceSettingsService(
             });
 
     /// <inheritdoc />
-    public Task TogglePaymentActiveness(ProjectIdentification projectId, int paymentTypeId)
+    public Task TogglePaymentActiveness(PaymentTypeIdentification paymentTypeId)
         // Право проверяется внутри мутации: оно зависит от вида платежа и от того, включаем мы его
         // или выключаем (включить онлайн-оплату может только админ).
         => projectPropsService.ChangeProjectProperties(
-            projectId,
+            paymentTypeId.ProjectId,
             Permission.None,
             ProjectActiveRequirement.MustBeActive,
             paymentTypeId,
@@ -116,12 +116,11 @@ internal class ProjectFinanceSettingsService(
             });
 
     /// <inheritdoc />
-    public Task EditCustomPaymentType(ProjectIdentification projectId,
-        int paymentTypeId,
+    public Task EditCustomPaymentType(PaymentTypeIdentification paymentTypeId,
         string name,
         bool isDefault)
         => projectPropsService.ChangeProjectProperties(
-            projectId,
+            paymentTypeId.ProjectId,
             Permission.CanManageMoney,
             ProjectActiveRequirement.MustBeActive,
             (paymentTypeId, name, isDefault),

--- a/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/Metadata/ProjectFinanceSettingsService.cs
@@ -19,7 +19,7 @@ internal class ProjectFinanceSettingsService(
     /// <inheritdoc />
     public Task CreatePaymentType(CreatePaymentTypeRequest request)
         => projectPropsService.ChangeProjectProperties(
-            new ProjectIdentification(request.ProjectId),
+            request.ProjectId,
             Permission.CanManageMoney,
             ProjectActiveRequirement.MustBeActive,
             request,
@@ -53,7 +53,7 @@ internal class ProjectFinanceSettingsService(
                 }
 
                 // Creating payment type
-                var result = new PaymentType(ctx.Request.TypeKind, ctx.Request.ProjectId, masterId);
+                var result = new PaymentType(ctx.Request.TypeKind, ctx.Request.ProjectId.Value, masterId);
 
                 // Configuring payment type
                 if (result.TypeKind == PaymentTypeKind.Custom)
@@ -146,7 +146,7 @@ internal class ProjectFinanceSettingsService(
     /// <inheritdoc />
     public Task CreateFeeSetting(CreateFeeSettingRequest request)
         => projectPropsService.ChangeProjectProperties(
-            new ProjectIdentification(request.ProjectId),
+            request.ProjectId,
             Permission.CanManageMoney,
             ProjectActiveRequirement.MustBeActive,
             request,
@@ -166,7 +166,7 @@ internal class ProjectFinanceSettingsService(
                 {
                     Fee = ctx.Request.Fee,
                     StartDate = ctx.Request.StartDate,
-                    ProjectId = ctx.Request.ProjectId,
+                    ProjectId = ctx.Request.ProjectId.Value,
                     PreferentialFee = ctx.Request.PreferentialFee,
                 });
 
@@ -201,7 +201,7 @@ internal class ProjectFinanceSettingsService(
     /// <inheritdoc />
     public Task SaveGlobalSettings(SetFinanceSettingsRequest request)
         => projectPropsService.ChangeProjectProperties(
-            new ProjectIdentification(request.ProjectId),
+            request.ProjectId,
             Permission.CanManageMoney,
             ProjectActiveRequirement.MustBeActive,
             request,

--- a/src/JoinRpg.Services.Impl/Projects/ProjectOperationContext.cs
+++ b/src/JoinRpg.Services.Impl/Projects/ProjectOperationContext.cs
@@ -1,4 +1,5 @@
 using JoinRpg.DataModel;
+using JoinRpg.Domain;
 
 namespace JoinRpg.Services.Impl.Projects;
 
@@ -113,6 +114,27 @@ internal static class ProjectOperationContextExtensions
             ?? throw new JoinRpgEntityNotFoundException(id.ProjectRolesListId, "ProjectRolesList");
         var info = ctx.ProjectInfo.GetRolesListById(id);
         return (entity, info);
+    }
+
+    /// <summary>
+    /// Резолвит тип оплаты для изменения. Аудит-полей <see cref="PaymentType"/> не несёт, поэтому
+    /// (как и <see cref="GetProjectRolesListForChange"/>) не помечает сущность изменённой.
+    /// </summary>
+    public static PaymentType GetPaymentTypeForChange(this ProjectMutationContext ctx, int paymentTypeId)
+        => ctx.Project.PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == paymentTypeId)
+            ?? throw new JoinRpgEntityNotFoundException(paymentTypeId, nameof(PaymentType));
+
+    /// <summary>
+    /// Проверяет право <see cref="Permission.CanManageMoney"/> внутри мутации. Нужно операциям, у
+    /// которых требуемое право зависит от данных и не может быть указано в
+    /// <c>ChangeProjectProperties</c> заранее. Админ проходит проверку, как и в самом сервисе.
+    /// </summary>
+    public static void RequireManageMoney(this ProjectMutationContext ctx)
+    {
+        if (!ctx.CurrentUser.IsAdmin)
+        {
+            _ = ctx.ProjectInfo.RequestMasterAccess(ctx.CurrentUser, Permission.CanManageMoney);
+        }
     }
 
     /// <summary>

--- a/src/JoinRpg.Services.Impl/Projects/ProjectOperationContext.cs
+++ b/src/JoinRpg.Services.Impl/Projects/ProjectOperationContext.cs
@@ -1,5 +1,6 @@
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
+using JoinRpg.DomainTypes.ProjectMetadata.Payments;
 
 namespace JoinRpg.Services.Impl.Projects;
 
@@ -120,9 +121,9 @@ internal static class ProjectOperationContextExtensions
     /// Резолвит тип оплаты для изменения. Аудит-полей <see cref="PaymentType"/> не несёт, поэтому
     /// (как и <see cref="GetProjectRolesListForChange"/>) не помечает сущность изменённой.
     /// </summary>
-    public static PaymentType GetPaymentTypeForChange(this ProjectMutationContext ctx, int paymentTypeId)
-        => ctx.Project.PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == paymentTypeId)
-            ?? throw new JoinRpgEntityNotFoundException(paymentTypeId, nameof(PaymentType));
+    public static PaymentType GetPaymentTypeForChange(this ProjectMutationContext ctx, PaymentTypeIdentification id)
+        => ctx.Project.PaymentTypes.SingleOrDefault(pt => pt.PaymentTypeId == id.PaymentTypeId)
+            ?? throw new JoinRpgEntityNotFoundException(id.PaymentTypeId, nameof(PaymentType));
 
     /// <summary>
     /// Проверяет право <see cref="Permission.CanManageMoney"/> внутри мутации. Нужно операциям, у

--- a/src/JoinRpg.Services.Impl/Services.cs
+++ b/src/JoinRpg.Services.Impl/Services.cs
@@ -56,6 +56,7 @@ public static class Services
             .AddTransient<IProjectRolesListService, ProjectRolesListService>()
             .AddTransient<IProjectAccessService, ProjectAccessService>()
             .AddTransient<IRespMasterRuleService, RespMasterRuleService>()
+            .AddTransient<IProjectFinanceSettingsService, ProjectFinanceSettingsService>()
             .AddTransient<IPaymentsService, PaymentsService>()
             .AddTransient<CommentHelper>()
             .AddTransient<IMassProjectEmailService, MassProjectEmailService>()

--- a/src/JoinRpg.Services.Interfaces/IFinanceService.cs
+++ b/src/JoinRpg.Services.Interfaces/IFinanceService.cs
@@ -2,23 +2,6 @@ using JoinRpg.DomainTypes.ProjectMetadata.Payments;
 
 namespace JoinRpg.Services.Interfaces;
 
-public class SetFinanceSettingsRequest
-{
-    public int ProjectId { get; set; }
-    public bool WarnOnOverPayment { get; set; }
-    public bool PreferentialFeeEnabled { get; set; }
-    public required string? PreferentialFeeConditions { get; set; }
-}
-
-public class CreateFeeSettingRequest
-{
-    public int ProjectId { get; set; }
-    public int Fee { get; set; }
-    public int? PreferentialFee { get; set; }
-    public DateTime StartDate { get; set; }
-}
-
-
 public class MarkPreferentialRequest : IClaimOperationRequest
 {
     public int ProjectId { get; set; }
@@ -63,17 +46,6 @@ public class ApproveRejectTransferRequest
 }
 
 /// <summary>
-/// Payload for <see cref="IFinanceService.CreatePaymentType"/>
-/// </summary>
-public class CreatePaymentTypeRequest
-{
-    public int ProjectId { get; set; }
-    public UserIdentification? TargetMasterId { get; set; }
-    public PaymentTypeKind TypeKind { get; set; }
-    public required string? Name { get; set; }
-}
-
-/// <summary>
 /// Payload for <see cref="IFinanceService.TransferPaymentAsync"/>
 /// </summary>
 public class ClaimPaymentTransferRequest : ClaimPaymentRequest, IClaimOperationRequest
@@ -91,31 +63,12 @@ public interface IFinanceService
     Task FeeAcceptedOperation(FeeAcceptedOperationRequest request);
 
     /// <summary>
-    /// Creates payment type for specified project
-    /// </summary>
-    /// <param name="request">Request payload</param>
-    Task CreatePaymentType(CreatePaymentTypeRequest request);
-
-    /// <summary>
-    /// Toggles state of a payment type. If payment type has to be deactivated, it will be
-    /// deleted if no payments associated with it and it could be permanently deleted
-    /// </summary>
-    /// <param name="projectId">Database Id of a project</param>
-    /// <param name="paymentTypeId">Database Id of a payment type to toggle state of</param>
-    Task TogglePaymentActiveness(int projectId, int paymentTypeId);
-
-    /// <summary>
     /// Transfers money from one claim to another
     /// </summary>
     /// <param name="request">Request data</param>
     Task TransferPaymentAsync(ClaimPaymentTransferRequest request);
 
-
-    Task EditCustomPaymentType(int projectId, int paymentTypeId, string name, bool isDefault);
-    Task CreateFeeSetting(CreateFeeSettingRequest request);
-    Task DeleteFeeSetting(int projectid, int projectFeeSettingId);
     Task ChangeFee(ClaimIdentification claimIdentification, int feeValue);
-    Task SaveGlobalSettings(SetFinanceSettingsRequest request);
     Task MarkPreferential(MarkPreferentialRequest request);
     Task RequestPreferentialFee(MarkMeAsPreferentialFeeOperationRequest request);
 

--- a/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
@@ -1,0 +1,55 @@
+using JoinRpg.DomainTypes.ProjectMetadata.Payments;
+
+namespace JoinRpg.Services.Interfaces.Projects;
+
+public class SetFinanceSettingsRequest
+{
+    public int ProjectId { get; set; }
+    public bool WarnOnOverPayment { get; set; }
+    public bool PreferentialFeeEnabled { get; set; }
+    public required string? PreferentialFeeConditions { get; set; }
+}
+
+public class CreateFeeSettingRequest
+{
+    public int ProjectId { get; set; }
+    public int Fee { get; set; }
+    public int? PreferentialFee { get; set; }
+    public DateTime StartDate { get; set; }
+}
+
+public class CreatePaymentTypeRequest
+{
+    public int ProjectId { get; set; }
+    public UserIdentification? TargetMasterId { get; set; }
+    public PaymentTypeKind TypeKind { get; set; }
+    public required string? Name { get; set; }
+}
+
+/// <summary>
+/// Настройки финансов проекта: типы оплаты, расписание взносов, общие финансовые флаги. Всё, что
+/// меняет этот сервис, попадает в снапшот метаданных проекта
+/// (<c>ProjectInfo.ProjectFinanceSettings</c>), поэтому изменения идут через <c>ProjectPropsService</c>.
+/// Операции по конкретным заявкам (приём взноса, переводы) — в <see cref="IFinanceService"/>.
+/// </summary>
+public interface IProjectFinanceSettingsService
+{
+    /// <summary>
+    /// Создаёт тип оплаты указанного вида для проекта и ответственного мастера.
+    /// </summary>
+    Task CreatePaymentType(CreatePaymentTypeRequest request);
+
+    /// <summary>
+    /// Включает или выключает тип оплаты. Выключение — всегда soft-delete
+    /// (<c>PaymentType.IsActive = false</c>), физически тип оплаты не удаляется.
+    /// </summary>
+    Task TogglePaymentActiveness(ProjectIdentification projectId, int paymentTypeId);
+
+    Task EditCustomPaymentType(ProjectIdentification projectId, int paymentTypeId, string name, bool isDefault);
+
+    Task CreateFeeSetting(CreateFeeSettingRequest request);
+
+    Task DeleteFeeSetting(ProjectIdentification projectId, int projectFeeSettingId);
+
+    Task SaveGlobalSettings(SetFinanceSettingsRequest request);
+}

--- a/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
@@ -4,26 +4,29 @@ namespace JoinRpg.Services.Interfaces.Projects;
 
 public class SetFinanceSettingsRequest
 {
-    public int ProjectId { get; set; }
-    public bool WarnOnOverPayment { get; set; }
-    public bool PreferentialFeeEnabled { get; set; }
-    public required string? PreferentialFeeConditions { get; set; }
+    public required ProjectIdentification ProjectId { get; init; }
+    public required bool WarnOnOverPayment { get; init; }
+    public required bool PreferentialFeeEnabled { get; init; }
+    public required string? PreferentialFeeConditions { get; init; }
 }
 
 public class CreateFeeSettingRequest
 {
-    public int ProjectId { get; set; }
-    public int Fee { get; set; }
-    public int? PreferentialFee { get; set; }
-    public DateTime StartDate { get; set; }
+    public required ProjectIdentification ProjectId { get; init; }
+    public required int Fee { get; init; }
+    /// <summary><c>null</c>, если льготный взнос не задан.</summary>
+    public required int? PreferentialFee { get; init; }
+    public required DateTime StartDate { get; init; }
 }
 
 public class CreatePaymentTypeRequest
 {
-    public int ProjectId { get; set; }
-    public UserIdentification? TargetMasterId { get; set; }
-    public PaymentTypeKind TypeKind { get; set; }
-    public required string? Name { get; set; }
+    public required ProjectIdentification ProjectId { get; init; }
+    /// <summary>Ответственный мастер. <c>null</c> для онлайн-оплаты — она не привязана к мастеру.</summary>
+    public required UserIdentification? TargetMasterId { get; init; }
+    public required PaymentTypeKind TypeKind { get; init; }
+    /// <summary>Имя нужно только для <see cref="PaymentTypeKind.Custom"/>, у остальных оно своё.</summary>
+    public required string? Name { get; init; }
 }
 
 /// <summary>

--- a/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
+++ b/src/JoinRpg.Services.Interfaces/Projects/IProjectFinanceSettingsService.cs
@@ -46,9 +46,9 @@ public interface IProjectFinanceSettingsService
     /// Включает или выключает тип оплаты. Выключение — всегда soft-delete
     /// (<c>PaymentType.IsActive = false</c>), физически тип оплаты не удаляется.
     /// </summary>
-    Task TogglePaymentActiveness(ProjectIdentification projectId, int paymentTypeId);
+    Task TogglePaymentActiveness(PaymentTypeIdentification paymentTypeId);
 
-    Task EditCustomPaymentType(ProjectIdentification projectId, int paymentTypeId, string name, bool isDefault);
+    Task EditCustomPaymentType(PaymentTypeIdentification paymentTypeId, string name, bool isDefault);
 
     Task CreateFeeSetting(CreateFeeSettingRequest request);
 


### PR DESCRIPTION
## Что сделано

Последняя из найденных дырок в ADR009: свойства `ProjectInfo`, которые менялись мимо `ProjectPropsService`.

`ProjectInfo.ProjectFinanceSettings` собирается из `Project.PaymentTypes`, `Project.ProjectFeeSettings` и `Details.PreferentialFeeEnabled`. Все три писались напрямую через EF из `FinanceOperationsImpl`, поэтому после изменения настроек уже загруженный в этом же запросе `ProjectInfo` оставался устаревшим — `PrimeCache` не вызывался, а у `PerRequestCache` инвалидации нет в принципе. Заодно проверка прав делалась вручную и вразнобой, проверки активности проекта не было вовсе, логирования операции тоже.

### Разделение сервиса

`FinanceOperationsImpl` смешивал две несвязанные вещи: настройки проекта и операции по заявкам. Шесть методов настройки вынесены в отдельный `ProjectFinanceSettingsService` (`Projects/Metadata/`, рядом с `FieldSetupServiceImpl`, `ProjectAccessService`, `ProjectRolesListService`) поверх `ChangeProjectProperties`:

- `CreatePaymentType`, `TogglePaymentActiveness`, `EditCustomPaymentType`
- `CreateFeeSetting`, `DeleteFeeSetting`
- `SaveGlobalSettings`

`IFinanceService` разделён соответственно: в нём остались операции по заявкам (`FeeAcceptedOperation`, `ChangeFee`, `MarkPreferential`, переводы), настройки проекта переехали в новый `IProjectFinanceSettingsService`. Побочный, но важный эффект — сервис настроек стал юнит-тестируемым без БД, ровно как задумано в ADR009.

### Изменения поведения

- **Настройки финансов больше нельзя менять в архивном проекте** (`MustBeActive`). Раньше проверки активности не было вообще.
- **`PaymentType.CanBePermanentlyDeleted` теперь всегда `false`** — выключение типа оплаты всегда soft-delete. Раньше тип оплаты без операций удалялся физически, и ради этой проверки приходилось тянуть `Operations`.
- `TogglePaymentActiveness`, `EditCustomPaymentType`, `DeleteFeeSetting` принимают `ProjectIdentification` вместо `int`.

Право `CanManageMoney` у `TogglePaymentActiveness` проверяется внутри мутации (`ctx.RequireManageMoney()`): оно зависит от вида платежа и от того, включаем мы его или выключаем — включить онлайн-оплату по-прежнему может только админ.

## Тесты

Новый `ProjectFinanceSettingsServiceTest` — 19 тестов поверх реального `ProjectPropsService` и фейков, результат проверяется через **пересобранный `ProjectInfo`**: расписание взносов (создание, сдвиг первой строки к дате создания проекта, удаление, запрет операций в прошлом, льготный взнос), общие настройки, типы оплаты (создание наличных, запрет дубля, запрет для не-мастера, редактирование), soft-delete при выключении, права на онлайн-оплату (мастер выключает, включает только админ), отказ без `CanManageMoney`, отказ в архивном проекте.

Полный прогон: 24 тестовых сборки зелёные, `dotnet format --verify-no-changes --severity warn` чистый.

> Слегка пересекается с #4740 по `ProjectOperationContext.cs` (обе ветки добавляют туда хелперы) — если мержить вторым, возможен тривиальный конфликт в списке using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nLrVeiLMRj5JYAohvBiFz