### PR TITLE
feat: дата рождения пользователя с блокировкой изменения и подтяжкой из ВК

### DIFF
--- a/src/JoinRpg.Blazor.Client/ApiClients/UserAdminHttpClient.cs
+++ b/src/JoinRpg.Blazor.Client/ApiClients/UserAdminHttpClient.cs
@@ -39,4 +39,13 @@ public class UserAdminHttpClient(HttpClient httpClient, CsrfTokenProvider csrfTo
 
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task SetBirthDate(UserIdentification userId, DateOnly? birthDate)
+    {
+        await csrfTokenProvider.SetCsrfToken(httpClient);
+        var query = birthDate is null ? "" : $"&birthDate={birthDate.Value:yyyy-MM-dd}";
+        var response = await httpClient.PostAsync($"webapi/UserAdmin/SetBirthDate?userId={userId.Value}{query}", content: null);
+
+        response.EnsureSuccessStatusCode();
+    }
 }

--- a/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
@@ -120,6 +120,7 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
                 user.Extra.PhoneNumber,
                 user.Auth.EmailConfirmed,
                 HasPassword = user.PasswordHash != null,
+                user.Extra.BirthDate,
             };
 
 
@@ -155,7 +156,8 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
             userFullName,
             result.VerifiedProfileFlag,
             result.PhoneNumber,
-            result.HasPassword
+            result.HasPassword,
+            result.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null
             );
         })];
     }

--- a/src/JoinRpg.Domain.Test/VkBirthDateParserTest.cs
+++ b/src/JoinRpg.Domain.Test/VkBirthDateParserTest.cs
@@ -1,0 +1,21 @@
+namespace JoinRpg.Domain.Test;
+
+public class VkBirthDateParserTest
+{
+    [Theory]
+    [InlineData("15.06.1990", true, "1990-06-15")]
+    [InlineData("15.06", false, null)]
+    [InlineData("", false, null)]
+    [InlineData(null, false, null)]
+    [InlineData("not a date", false, null)]
+    public void TryParse(string? raw, bool expectedSuccess, string? expectedDate)
+    {
+        var success = VkBirthDateParser.TryParse(raw, out var birthDate);
+
+        success.ShouldBe(expectedSuccess);
+        if (expectedSuccess)
+        {
+            birthDate.ShouldBe(DateOnly.Parse(expectedDate!));
+        }
+    }
+}

--- a/src/JoinRpg.Domain/UserExtensions.cs
+++ b/src/JoinRpg.Domain/UserExtensions.cs
@@ -26,7 +26,8 @@ public static class UserExtensions
             user.ExtractFullName(),
             user.VerifiedProfileFlag,
             user.Extra?.PhoneNumber,
-            user.PasswordHash != null
+            user.PasswordHash != null,
+            user.Extra?.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null
             );
     }
 

--- a/src/JoinRpg.Domain/VkBirthDateParser.cs
+++ b/src/JoinRpg.Domain/VkBirthDateParser.cs
@@ -1,0 +1,15 @@
+using System.Globalization;
+
+namespace JoinRpg.Domain;
+
+/// <summary>
+/// ВК отдаёт bdate либо как "dd.MM.yyyy", либо как "dd.MM" (год скрыт настройками приватности),
+/// либо не отдаёт вовсе. Нас интересует только полная дата с годом.
+/// </summary>
+public static class VkBirthDateParser
+{
+    public static bool TryParse(string? raw, out DateOnly birthDate)
+    {
+        return DateOnly.TryParseExact(raw, "dd.MM.yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out birthDate);
+    }
+}

--- a/src/JoinRpg.DomainTypes.Test/UserInfoAgeTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/UserInfoAgeTest.cs
@@ -28,10 +28,12 @@ public class UserInfoAgeTest
     }
 
     [Fact]
-    public void BirthdayIsToday_AgeIncreasesToday()
+    public void BirthdayIsToday_AgeNotYetIncreased()
     {
+        // По российской правовой традиции в день рождения человеку ещё не хватает года —
+        // возраст считается наступившим с 00:00 следующих суток (см. GetAgeOn).
         var user = BuildUserInfo(new DateOnly(2008, 6, 15));
-        user.GetAgeOn(new DateOnly(2026, 6, 15)).ShouldBe(18);
+        user.GetAgeOn(new DateOnly(2026, 6, 15)).ShouldBe(17);
     }
 
     [Fact]

--- a/src/JoinRpg.DomainTypes.Test/UserInfoAgeTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/UserInfoAgeTest.cs
@@ -1,0 +1,58 @@
+using JoinRpg.DomainTypes.Users;
+
+namespace JoinRpg.DomainTypes.Test;
+
+public class UserInfoAgeTest
+{
+    private static UserInfo BuildUserInfo(DateOnly? birthDate)
+        => new UserInfo(
+            UserId: new UserIdentification(1),
+            Social: new UserSocialNetworks(null, null, null, null, ContactsAccessType.OnlyForMasters),
+            ActiveClaims: [],
+            ActiveProjects: [],
+            AllProjects: [],
+            IsAdmin: false,
+            SelectedAvatarId: null,
+            Email: new Email("user@example.com"),
+            EmailConfirmed: true,
+            UserFullName: new UserFullName(null, BornName.FromOptional("Иван"), SurName.FromOptional("Иванов"), null),
+            VerifiedProfileFlag: false,
+            PhoneNumber: null,
+            HasPassword: false,
+            BirthDate: birthDate);
+
+    [Fact]
+    public void NoBirthDate_ReturnsNull()
+    {
+        BuildUserInfo(null).GetAgeOn(new DateOnly(2026, 1, 1)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BirthdayIsToday_AgeIncreasesToday()
+    {
+        var user = BuildUserInfo(new DateOnly(2008, 6, 15));
+        user.GetAgeOn(new DateOnly(2026, 6, 15)).ShouldBe(18);
+    }
+
+    [Fact]
+    public void DayBeforeBirthday_AgeNotYetIncreased()
+    {
+        var user = BuildUserInfo(new DateOnly(2008, 6, 15));
+        user.GetAgeOn(new DateOnly(2026, 6, 14)).ShouldBe(17);
+    }
+
+    [Fact]
+    public void DayAfterBirthday_AgeAlreadyIncreased()
+    {
+        var user = BuildUserInfo(new DateOnly(2008, 6, 15));
+        user.GetAgeOn(new DateOnly(2026, 6, 16)).ShouldBe(18);
+    }
+
+    [Fact]
+    public void LeapYearBirthday_HandledOnNonLeapYear()
+    {
+        var user = BuildUserInfo(new DateOnly(2008, 2, 29));
+        user.GetAgeOn(new DateOnly(2027, 3, 1)).ShouldBe(19);
+        user.GetAgeOn(new DateOnly(2027, 2, 28)).ShouldBe(18);
+    }
+}

--- a/src/JoinRpg.DomainTypes/Users/UserInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserInfo.cs
@@ -27,6 +27,13 @@ public record class UserInfo(
     /// <summary>
     /// Число полных лет на дату <paramref name="today"/>, или null, если дата рождения не указана.
     /// </summary>
+    /// <remarks>
+    /// В день самого рождения человеку ещё не хватает года: по российской правовой традиции
+    /// возраст считается наступившим с 00:00 суток, следующих за днём рождения (см. п. 7
+    /// Постановления Пленума Верховного Суда РФ от 01.02.2011 № 1 — в отношении 14/16/18 лет,
+    /// но правило общеупотребимо и для иного возраста). Поэтому дата годовщины считается ещё
+    /// не наступившей, если она совпадает с <paramref name="today"/>, а не только если она позже.
+    /// </remarks>
     public int? GetAgeOn(DateOnly today)
     {
         if (BirthDate is not DateOnly birthDate)
@@ -34,7 +41,7 @@ public record class UserInfo(
             return null;
         }
         var age = today.Year - birthDate.Year;
-        if (birthDate > today.AddYears(-age))
+        if (birthDate.AddYears(age) >= today)
         {
             age--;
         }

--- a/src/JoinRpg.DomainTypes/Users/UserInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserInfo.cs
@@ -16,12 +16,30 @@ public record class UserInfo(
     UserFullName UserFullName,
     bool VerifiedProfileFlag,
     string? PhoneNumber,
-    bool HasPassword)
+    bool HasPassword,
+    DateOnly? BirthDate = null)
 {
     public UserDisplayName DisplayName { get; } = new UserDisplayName(UserFullName, Email);
 
     // Не реализовано
     public bool PhoneNumberConfirmed { get; } = false;
+
+    /// <summary>
+    /// Число полных лет на дату <paramref name="today"/>, или null, если дата рождения не указана.
+    /// </summary>
+    public int? GetAgeOn(DateOnly today)
+    {
+        if (BirthDate is not DateOnly birthDate)
+        {
+            return null;
+        }
+        var age = today.Year - birthDate.Year;
+        if (birthDate > today.AddYears(-age))
+        {
+            age--;
+        }
+        return age;
+    }
 
     /// <summary>
     /// Есть ровно один способ войти в аккаунт. Привязка Telegram в расчёт не идёт — виджет

--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -223,7 +223,7 @@ public class ManageController(
             BornName = user.BornName ?? "",
             PrefferedName = user.GetDisplayName(),
             //Gender = user.Extra.Gender,
-            //BirthDate = user.Extra.BirthDate,
+            BirthDate = user.Extra?.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null,
             PhoneNumber = user.Extra?.PhoneNumber ?? "",
             Nicknames = user.Extra?.Nicknames ?? "",
             GroupNames = user.Extra?.GroupNames ?? "",
@@ -260,7 +260,7 @@ public class ManageController(
                     new FatherName(viewModel.FatherName)),
                 viewModel.Gender, viewModel.PhoneNumber, viewModel.Nicknames,
                 viewModel.GroupNames, viewModel.Livejournal, (ContactsAccessType)viewModel.SocialNetworkAccess,
-                viewModel.PassportData, viewModel.RegistrationAddress);
+                viewModel.PassportData, viewModel.RegistrationAddress, viewModel.BirthDate);
             var userId = currentUserAccessor.UserId;
             var user = await userManager.FindByIdAsync(userId.ToString());
             await signInManager.RefreshSignInAsync(user);

--- a/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/ManageController.cs
@@ -224,6 +224,7 @@ public class ManageController(
             PrefferedName = user.GetDisplayName(),
             //Gender = user.Extra.Gender,
             BirthDate = user.Extra?.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null,
+            AgeMarker = UserProfileDetailsViewModel.FormatAgeMarker(userInfo, DateOnly.FromDateTime(DateTime.UtcNow)),
             PhoneNumber = user.Extra?.PhoneNumber ?? "",
             Nicknames = user.Extra?.Nicknames ?? "",
             GroupNames = user.Extra?.GroupNames ?? "",

--- a/src/JoinRpg.Portal/Controllers/WebApi/UserAdminController.cs
+++ b/src/JoinRpg.Portal/Controllers/WebApi/UserAdminController.cs
@@ -39,4 +39,11 @@ public class UserAdminController(IUserAdminClient userAdminClient) : ControllerB
         await userAdminClient.ChangeEmail(userId, newEmail);
         return Ok();
     }
+
+    [HttpPost]
+    public async Task<ActionResult> SetBirthDate([FromQuery] UserIdentification userId, [FromQuery] DateOnly? birthDate)
+    {
+        await userAdminClient.SetBirthDate(userId, birthDate);
+        return Ok();
+    }
 }

--- a/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
+++ b/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
@@ -165,7 +165,10 @@
                 @if (Model.BirthDate.HasValue)
                 {
                     <p class="form-control-static">@Model.BirthDate.Value.ToString("dd.MM.yyyy")</p>
-                    <span class="help-block">Дату нельзя изменить самостоятельно, обратитесь в техподдержку.</span>
+                    <span class="help-block">
+                        Дату нельзя изменить самостоятельно, обратитесь в техподдержку.
+                        Мастера видят о вас только: @Model.AgeMarker.
+                    </span>
                 }
                 else
                 {

--- a/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
+++ b/src/JoinRpg.Portal/Views/Manage/SetupProfile.cshtml
@@ -160,6 +160,27 @@
         }
 
         <div class="form-group">
+            @Html.LabelFor(model => model.BirthDate, htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-7">
+                @if (Model.BirthDate.HasValue)
+                {
+                    <p class="form-control-static">@Model.BirthDate.Value.ToString("dd.MM.yyyy")</p>
+                    <span class="help-block">Дату нельзя изменить самостоятельно, обратитесь в техподдержку.</span>
+                }
+                else
+                {
+                    <component type="typeof(JoinRpg.Common.WebComponents.JoinRpgDatePicker)"
+                               param-Name="nameof(Model.BirthDate)"
+                               param-Value="Model.BirthDate"
+                               param-Max="DateOnly.FromDateTime(DateTime.Today)"
+                               render-mode="Static" />
+                    @Html.DescriptionFor(model => model.BirthDate)
+                }
+                @Html.ValidationMessageFor(model => model.BirthDate, "", new { @class = "text-danger" })
+            </div>
+        </div>
+
+        <div class="form-group">
             @Html.LabelFor(model => model.Livejournal, htmlAttributes: new { @class = "control-label col-md-2" })
             <div class="col-md-7">
                 <div class="input-group">

--- a/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
+++ b/src/JoinRpg.Portal/Views/Shared/DisplayTemplates/UserProfileDetailsViewModel.cshtml
@@ -26,6 +26,10 @@
             {
                 <br /><component type="typeof(PhoneLink)" render-mode="Static" param-Contact="@Model.PhoneNumber" />
             }
+            @if (Model.AgeMarker is not null)
+            {
+                <br /><span>@Model.AgeMarker</span>
+            }
             @if (Model.ViewAsAdmin && !Model.HasPassword)
             {
                 <br />

--- a/src/JoinRpg.Services.Impl/UserServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/UserServiceImpl.cs
@@ -26,7 +26,7 @@ public class UserServiceImpl(
         string groupNames,
         string livejournal,
         ContactsAccessType socialAccessType,
-        string passportData, string registrationAddress)
+        string passportData, string registrationAddress, DateOnly? birthDate)
     {
         if (CurrentUserId != userId)
         {
@@ -61,6 +61,8 @@ public class UserServiceImpl(
 
         user.Extra.SocialNetworksAccess = socialAccessType;
 
+        user.Extra.BirthDate ??= birthDate?.ToDateTime(TimeOnly.MinValue);
+
         await UnitOfWork.SaveChangesAsync();
     }
 
@@ -87,6 +89,19 @@ public class UserServiceImpl(
         }
         user.VerifiedProfileFlag = verificationFlag;
         //TODO: Send email
+        await UnitOfWork.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task SetBirthDate(int userId, DateOnly? birthDate)
+    {
+        if (!IsCurrentUserAdmin)
+        {
+            throw new MustBeAdminException();
+        }
+        var user = await UserRepository.WithProfile(userId);
+        user.Extra ??= new UserExtra();
+        user.Extra.BirthDate = birthDate?.ToDateTime(TimeOnly.MinValue);
         await UnitOfWork.SaveChangesAsync();
     }
 
@@ -122,6 +137,17 @@ public class UserServiceImpl(
         user.Extra.VkVerified = true;
 
         await TryAddSocialAvatarImplAsync(avatarInfo, user, "Vkontakte");
+
+        await UnitOfWork.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task SetBirthDateIfNotSetWithoutAccessChecks(int userId, DateOnly birthDate)
+    {
+        var user = await UserRepository.WithProfile(userId);
+
+        user.Extra ??= new UserExtra();
+        user.Extra.BirthDate ??= birthDate.ToDateTime(TimeOnly.MinValue);
 
         await UnitOfWork.SaveChangesAsync();
     }

--- a/src/JoinRpg.Services.Impl/UserServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/UserServiceImpl.cs
@@ -93,13 +93,13 @@ public class UserServiceImpl(
     }
 
     /// <inheritdoc />
-    public async Task SetBirthDate(int userId, DateOnly? birthDate)
+    public async Task SetBirthDate(UserIdentification userId, DateOnly? birthDate)
     {
         if (!IsCurrentUserAdmin)
         {
             throw new MustBeAdminException();
         }
-        var user = await UserRepository.WithProfile(userId);
+        var user = await UserRepository.WithProfile(userId.Value);
         user.Extra ??= new UserExtra();
         user.Extra.BirthDate = birthDate?.ToDateTime(TimeOnly.MinValue);
         await UnitOfWork.SaveChangesAsync();
@@ -142,9 +142,9 @@ public class UserServiceImpl(
     }
 
     /// <inheritdoc />
-    public async Task SetBirthDateIfNotSetWithoutAccessChecks(int userId, DateOnly birthDate)
+    public async Task SetBirthDateIfNotSetWithoutAccessChecks(UserIdentification userId, DateOnly birthDate)
     {
-        var user = await UserRepository.WithProfile(userId);
+        var user = await UserRepository.WithProfile(userId.Value);
 
         user.Extra ??= new UserExtra();
         user.Extra.BirthDate ??= birthDate.ToDateTime(TimeOnly.MinValue);

--- a/src/JoinRpg.Services.Interfaces/IUserService.cs
+++ b/src/JoinRpg.Services.Interfaces/IUserService.cs
@@ -2,7 +2,7 @@ namespace JoinRpg.Services.Interfaces;
 
 public interface IUserService
 {
-    Task UpdateProfile(int userId, UserFullName userFullName, Gender gender, string phoneNumber, string nicknames, string groupNames, string livejournal, ContactsAccessType socialNetworkAccess, string passportData, string registrationAddress);
+    Task UpdateProfile(int userId, UserFullName userFullName, Gender gender, string phoneNumber, string nicknames, string groupNames, string livejournal, ContactsAccessType socialNetworkAccess, string passportData, string registrationAddress, DateOnly? birthDate);
     Task SetAdminFlag(int userId, bool administratorFlag);
     Task SetVerificationFlag(int userId, bool verificationFlag);
     /// <summary>
@@ -17,6 +17,16 @@ public interface IUserService
     /// All access check fortfeit (cause is method typically called during login, so ICurrentUserAccessor could be old).
     /// </summary>
     Task SetVkIfNotSetWithoutAccessChecks(int id, VkSocialLink vk, AvatarInfo? avatarInfo);
+
+    /// <summary>
+    /// Set birth date if not set already (e.g. pulled from VK on login). Never overwrites an already-set value.
+    /// </summary>
+    Task SetBirthDateIfNotSetWithoutAccessChecks(int userId, DateOnly birthDate);
+
+    /// <summary>
+    /// Admin-only: set or clear birth date, bypassing the "already set" lock.
+    /// </summary>
+    Task SetBirthDate(int userId, DateOnly? birthDate);
 
 
     Task SetTelegramIfNotSetWithoutAccessChecks(int id, TelegramSocialLink telegram, AvatarInfo? avatarInfo);

--- a/src/JoinRpg.Services.Interfaces/IUserService.cs
+++ b/src/JoinRpg.Services.Interfaces/IUserService.cs
@@ -21,12 +21,12 @@ public interface IUserService
     /// <summary>
     /// Set birth date if not set already (e.g. pulled from VK on login). Never overwrites an already-set value.
     /// </summary>
-    Task SetBirthDateIfNotSetWithoutAccessChecks(int userId, DateOnly birthDate);
+    Task SetBirthDateIfNotSetWithoutAccessChecks(UserIdentification userId, DateOnly birthDate);
 
     /// <summary>
     /// Admin-only: set or clear birth date, bypassing the "already set" lock.
     /// </summary>
-    Task SetBirthDate(int userId, DateOnly? birthDate);
+    Task SetBirthDate(UserIdentification userId, DateOnly? birthDate);
 
 
     Task SetTelegramIfNotSetWithoutAccessChecks(int id, TelegramSocialLink telegram, AvatarInfo? avatarInfo);

--- a/src/JoinRpg.Web.AdminTools/AdminUserActionsPanel.razor
+++ b/src/JoinRpg.Web.AdminTools/AdminUserActionsPanel.razor
@@ -44,6 +44,21 @@
             OnClick="RemoveVkLinkAsync" />
     }
 
+    <a href="#" class="disabled btn btn-default">
+        Дата рождения: @(panel.BirthDate is null ? "не указана" : panel.BirthDate.Value.ToString("dd.MM.yyyy"))
+    </a>
+
+    <JoinButton Label="@(panel.BirthDate is null ? "Указать дату рождения" : "Изменить дату рождения")" OnClick="OpenBirthDateDialogAsync" />
+
+    @if (panel.BirthDate is not null)
+    {
+        <JoinButton
+            Label="Очистить дату рождения"
+            AutoConfirm="true"
+            AutoConfirmMessage="Действительно очистить дату рождения этого пользователя?"
+            OnClick="ClearBirthDateAsync" />
+    }
+
     <JoinButton Label="Логи" Title="Посмотреть логи действий пользователя на сайте" Link="@LogLink.AbsoluteUri" />
 </JoinButtonGroup>
 
@@ -56,6 +71,18 @@
 >
     <FormRowFor For="@(() => emailModel.NewEmail)">
         <JoinTextInput @bind-Value="emailModel.NewEmail" />
+    </FormRowFor>
+</JoinFormDialog>
+
+<JoinFormDialog
+    Caption="Дата рождения"
+    SubmitButtonPreset="ButtonPreset.Save"
+    Model="@birthDateModel"
+    FormName="BirthDateForm"
+    @ref="birthDateDialog"
+>
+    <FormRowFor For="@(() => birthDateModel.Value)">
+        <JoinRpgDatePicker Name="@nameof(birthDateModel.Value)" @bind-Value="birthDateModel.Value" Max="@DateOnly.FromDateTime(DateTime.Today)" />
     </FormRowFor>
 </JoinFormDialog>
 
@@ -73,6 +100,9 @@
 
     private JoinFormDialog<ChangeEmailFormModel> changeEmailDialog = default!;
     private readonly ChangeEmailFormModel emailModel = new();
+
+    private JoinFormDialog<BirthDateFormModel> birthDateDialog = default!;
+    private readonly BirthDateFormModel birthDateModel = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -122,9 +152,39 @@
         NavigationManager.Refresh(forceReload: true);
     }
 
+    private async Task OpenBirthDateDialogAsync(ButtonClickEventArgs args)
+    {
+        try
+        {
+            birthDateModel.Value = panel!.BirthDate;
+            var result = await birthDateDialog.ShowModalAsync();
+            if (result is not null)
+            {
+                await UserAdminClient.SetBirthDate(UserId, result.Value);
+                NavigationManager.Refresh(forceReload: true);
+            }
+        }
+        finally
+        {
+            args.ExitProgressState = true;
+        }
+    }
+
+    private async Task ClearBirthDateAsync(ButtonClickEventArgs args)
+    {
+        await UserAdminClient.SetBirthDate(UserId, null);
+        NavigationManager.Refresh(forceReload: true);
+    }
+
     public class ChangeEmailFormModel
     {
         [Required, EmailAddress, Display(Name = "Новый email")]
         public string NewEmail { get; set; } = "";
+    }
+
+    public class BirthDateFormModel
+    {
+        [Display(Name = "Дата рождения")]
+        public DateOnly? Value { get; set; }
     }
 }

--- a/src/JoinRpg.Web.AdminTools/IUserAdminClient.cs
+++ b/src/JoinRpg.Web.AdminTools/IUserAdminClient.cs
@@ -7,4 +7,5 @@ public interface IUserAdminClient
     Task SetAdminFlag(UserIdentification userId, bool value);
     Task SetVerificationFlag(UserIdentification userId, bool value);
     Task ChangeEmail(UserIdentification userId, string newEmail);
+    Task SetBirthDate(UserIdentification userId, DateOnly? birthDate);
 }

--- a/src/JoinRpg.Web.AdminTools/UserAdminPanelViewModel.cs
+++ b/src/JoinRpg.Web.AdminTools/UserAdminPanelViewModel.cs
@@ -1,3 +1,3 @@
 namespace JoinRpg.Web.AdminTools;
 
-public record UserAdminPanelViewModel(bool IsAdmin, bool IsVerifiedUser, bool HasVkLink, bool IsVkOnlyLoginMethod);
+public record UserAdminPanelViewModel(bool IsAdmin, bool IsVerifiedUser, bool HasVkLink, bool IsVkOnlyLoginMethod, DateOnly? BirthDate);

--- a/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
@@ -53,6 +53,13 @@ public class EditUserProfileViewModel
     [Display(Name = "Дата рождения", Description = "Указание даты рождения подтверждает мастерам, что вы совершеннолетний (или несовершеннолетний). Для совершеннолетних дата не показывается мастерам.")]
     public DateOnly? BirthDate { get; set; }
 
+    /// <summary>
+    /// То же самое, что видят мастера в профиле — «Совершеннолетний» или точный возраст.
+    /// Показывается пользователю после того, как дата рождения уже установлена.
+    /// </summary>
+    [ReadOnly(true)]
+    public string? AgeMarker { get; set; }
+
     public IList<UserLoginInfoViewModel> SocialLoginStatus { get; set; }
 
     public string Email { get; set; }

--- a/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
@@ -50,8 +50,8 @@ public class EditUserProfileViewModel
     [Display(Name = "Публичность соцсетей")]
     public ContactsAccessTypeView SocialNetworkAccess { get; set; }
 
-    /*[Display(Name="Дата рождения", Description = "Указание даты рождения подтверждает мастерам, что вы совершеннолетний"), Required]
-    public DateTime? BirthDate { get; set; }*/
+    [Display(Name = "Дата рождения", Description = "После сохранения дату нельзя будет изменить самостоятельно.")]
+    public DateOnly? BirthDate { get; set; }
 
     public IList<UserLoginInfoViewModel> SocialLoginStatus { get; set; }
 

--- a/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/EditUserProfileViewModel.cs
@@ -50,7 +50,7 @@ public class EditUserProfileViewModel
     [Display(Name = "Публичность соцсетей")]
     public ContactsAccessTypeView SocialNetworkAccess { get; set; }
 
-    [Display(Name = "Дата рождения", Description = "После сохранения дату нельзя будет изменить самостоятельно.")]
+    [Display(Name = "Дата рождения", Description = "Указание даты рождения подтверждает мастерам, что вы совершеннолетний (или несовершеннолетний). Для совершеннолетних дата не показывается мастерам.")]
     public DateOnly? BirthDate { get; set; }
 
     public IList<UserLoginInfoViewModel> SocialLoginStatus { get; set; }

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -109,7 +109,7 @@ public class UserProfileDetailsViewModel
             IsVerifiedUser = user.VerifiedProfileFlag;
             if (user.GetAgeOn(DateOnly.FromDateTime(DateTime.UtcNow)) is int age)
             {
-                AgeMarker = age >= 18 ? "Совершеннолетний" : $"{age} {PluralizeYears(age)}";
+                AgeMarker = age >= 18 ? "Совершеннолетний" : CountHelper.DisplayCount(age, "год", "года", "лет");
             }
         }
         if (Reason != AccessReasonView.NoAccess || user.Social.SocialNetworksAccess == ContactsAccessType.Public)
@@ -125,22 +125,6 @@ public class UserProfileDetailsViewModel
     }
 
     public bool HasSocialAccess { get; }
-
-    private static string PluralizeYears(int age)
-    {
-        var lastTwoDigits = age % 100;
-        var lastDigit = age % 10;
-        if (lastTwoDigits is >= 11 and <= 14)
-        {
-            return "лет";
-        }
-        return lastDigit switch
-        {
-            1 => "год",
-            >= 2 and <= 4 => "года",
-            _ => "лет",
-        };
-    }
 }
 
 public enum AccessReasonView

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -107,10 +107,7 @@ public class UserProfileDetailsViewModel
             FullName = user.UserFullName.FullName;
             PhoneNumber = PhoneNumber.FromOptional(user.PhoneNumber);
             IsVerifiedUser = user.VerifiedProfileFlag;
-            if (user.GetAgeOn(DateOnly.FromDateTime(DateTime.UtcNow)) is int age)
-            {
-                AgeMarker = age >= 18 ? "Совершеннолетний" : CountHelper.DisplayCount(age, "год", "года", "лет");
-            }
+            AgeMarker = FormatAgeMarker(user, DateOnly.FromDateTime(DateTime.UtcNow));
         }
         if (Reason != AccessReasonView.NoAccess || user.Social.SocialNetworksAccess == ContactsAccessType.Public)
         {
@@ -125,6 +122,19 @@ public class UserProfileDetailsViewModel
     }
 
     public bool HasSocialAccess { get; }
+
+    /// <summary>
+    /// «Совершеннолетний» или точный возраст — то же самое, что видят мастера в профиле игрока.
+    /// Используется и здесь, и на странице настроек профиля, чтобы пользователь видел ту же пометку.
+    /// </summary>
+    public static string? FormatAgeMarker(UserInfo user, DateOnly today)
+    {
+        if (user.GetAgeOn(today) is not int age)
+        {
+            return null;
+        }
+        return age >= 18 ? "Совершеннолетний" : CountHelper.DisplayCount(age, "год", "года", "лет");
+    }
 }
 
 public enum AccessReasonView

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -69,6 +69,11 @@ public class UserProfileDetailsViewModel
 
     public bool IsVerifiedUser { get; }
 
+    /// <summary>
+    /// «Совершеннолетний» или точный возраст — саму дату рождения эта ViewModel никогда не несёт.
+    /// </summary>
+    public string? AgeMarker { get; }
+
     public bool ViewAsAdmin { get; }
 
     public ContactsAccessTypeView SocialNetworkAccess { get; }
@@ -102,6 +107,10 @@ public class UserProfileDetailsViewModel
             FullName = user.UserFullName.FullName;
             PhoneNumber = PhoneNumber.FromOptional(user.PhoneNumber);
             IsVerifiedUser = user.VerifiedProfileFlag;
+            if (user.GetAgeOn(DateOnly.FromDateTime(DateTime.UtcNow)) is int age)
+            {
+                AgeMarker = age >= 18 ? "Совершеннолетний" : $"{age} {PluralizeYears(age)}";
+            }
         }
         if (Reason != AccessReasonView.NoAccess || user.Social.SocialNetworksAccess == ContactsAccessType.Public)
         {
@@ -116,6 +125,22 @@ public class UserProfileDetailsViewModel
     }
 
     public bool HasSocialAccess { get; }
+
+    private static string PluralizeYears(int age)
+    {
+        var lastTwoDigits = age % 100;
+        var lastDigit = age % 10;
+        if (lastTwoDigits is >= 11 and <= 14)
+        {
+            return "лет";
+        }
+        return lastDigit switch
+        {
+            1 => "год",
+            >= 2 and <= 4 => "года",
+            _ => "лет",
+        };
+    }
 }
 
 public enum AccessReasonView

--- a/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
+++ b/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
@@ -50,7 +50,7 @@ public class ExternalLoginProfileExtractor(IUserService userService, JoinUserMan
 
             if (VkBirthDateParser.TryParse(loginInfo.Principal.FindFirstValue(IdentityConfigurator.VkBirthDateClaimType), out var birthDate))
             {
-                await userService.SetBirthDateIfNotSetWithoutAccessChecks(user.Id, birthDate);
+                await userService.SetBirthDateIfNotSetWithoutAccessChecks(new UserIdentification(user.Id), birthDate);
             }
         }
     }

--- a/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
+++ b/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using AspNet.Security.OAuth.Vkontakte;
 using JoinRpg.DataModel;
+using JoinRpg.Domain;
 using JoinRpg.Services.Interfaces;
 
 namespace Joinrpg.Web.Identity;
@@ -46,6 +47,11 @@ public class ExternalLoginProfileExtractor(IUserService userService, JoinUserMan
             var avatar = AvatarInfo.FromOptional(loginInfo.Principal.FindFirstValue(VkontakteAuthenticationConstants.Claims.PhotoUrl));
 
             await userService.SetVkIfNotSetWithoutAccessChecks(user.Id, vk, avatar);
+
+            if (VkBirthDateParser.TryParse(loginInfo.Principal.FindFirstValue(IdentityConfigurator.VkBirthDateClaimType), out var birthDate))
+            {
+                await userService.SetBirthDateIfNotSetWithoutAccessChecks(user.Id, birthDate);
+            }
         }
     }
 

--- a/src/Joinrpg.Web.Identity/IdentityConfigurator.cs
+++ b/src/Joinrpg.Web.Identity/IdentityConfigurator.cs
@@ -1,6 +1,7 @@
 using JoinRpg.Common.WebInfrastructure;
 using JoinRpg.Services.Interfaces.Notification;
 using JoinRpg.Web.AdminTools;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,8 @@ namespace Joinrpg.Web.Identity;
 
 public static class IdentityConfigurator
 {
+    public const string VkBirthDateClaimType = "urn:vkontakte:bdate";
+
     public static IServiceCollection AddJoinIdentity(this IServiceCollection services)
     {
 
@@ -61,6 +64,8 @@ public static class IdentityConfigurator
             _ = authBuilder.AddVkontakte(options =>
             {
                 options.Scope.Add("email");
+                options.Fields.Add("bdate");
+                options.ClaimActions.MapJsonKey(VkBirthDateClaimType, "bdate");
 
                 SetCommonProperties(options, vkConfig);
             });

--- a/src/Joinrpg.Web.Identity/UserAdminViewService.cs
+++ b/src/Joinrpg.Web.Identity/UserAdminViewService.cs
@@ -18,7 +18,7 @@ public class UserAdminViewService(
         var hasVkLink = userInfo.Social.Vk is not null;
         var isVkOnlyLoginMethod = IsVkOnlyLoginMethod(userInfo);
 
-        return new UserAdminPanelViewModel(userInfo.IsAdmin, userInfo.VerifiedProfileFlag, hasVkLink, isVkOnlyLoginMethod);
+        return new UserAdminPanelViewModel(userInfo.IsAdmin, userInfo.VerifiedProfileFlag, hasVkLink, isVkOnlyLoginMethod, userInfo.BirthDate);
     }
 
     public async Task RemoveVkLink(UserIdentification userId)
@@ -67,4 +67,7 @@ public class UserAdminViewService(
             throw new InvalidOperationException($"Не удалось изменить email: {result}");
         }
     }
+
+    public Task SetBirthDate(UserIdentification userId, DateOnly? birthDate)
+        => userService.SetBirthDate(userId.Value, birthDate);
 }

--- a/src/Joinrpg.Web.Identity/UserAdminViewService.cs
+++ b/src/Joinrpg.Web.Identity/UserAdminViewService.cs
@@ -69,5 +69,5 @@ public class UserAdminViewService(
     }
 
     public Task SetBirthDate(UserIdentification userId, DateOnly? birthDate)
-        => userService.SetBirthDate(userId.Value, birthDate);
+        => userService.SetBirthDate(userId, birthDate);
 }


### PR DESCRIPTION
## Что сделано
- В профиль пользователя добавлена дата рождения: устанавливается один раз (вручную на странице настроек или автоматически из ВК при логине) и после этого недоступна для изменения самим пользователем.
- Администратор может установить или очистить дату рождения любого пользователя из панели администратора.
- Сама дата видна только администратору. Мастера и со-мастера, которым виден профиль игрока, видят только производную пометку — «Совершеннолетний» или точный возраст в годах.
- При логине через ВК дата подтягивается автоматически (`bdate` из VK API), если у пользователя ещё не задана.

## Контекст
Колонка `dbo.UserExtras.BirthDate` существует с самой первой миграции (2015), но связанный UI когда-то был закомментирован — эта правка доводит старую незавершённую попытку до конца с новой логикой блокировки и видимости. Новая миграция БД не нужна.

## Test plan
- [x] `dotnet build` — весь solution собирается без ошибок
- [x] `dotnet test src/JoinRpg.Domain.Test` — тесты парсера даты ВК (`VkBirthDateParserTest`)
- [x] `dotnet test src/JoinRpg.DomainTypes.Test` — тесты вычисления возраста (`UserInfoAgeTest`, включая границу 18-летия и 29 февраля)
- [x] `dotnet test src/JoinRpg.Services.Impl.Test`, `src/JoinRpg.WebPortal.Models.Test` — регрессий нет
- [ ] Вручную проверить на деве: установка даты на `/Manage/SetupProfile`, видимость пометки в профиле для мастера, установка/очистка даты администратором

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013mxFS9qg9xVoM2hYegB6Fh