### PR TITLE
fix(tests): MockedProject.CreateClaim присваивает ClaimId

### DIFF
--- a/src/JoinRpg.DataModel.Mocks/MockedProject.cs
+++ b/src/JoinRpg.DataModel.Mocks/MockedProject.cs
@@ -171,6 +171,7 @@ public class MockedProject
     {
         var claim = new Claim
         {
+            ClaimId = Project.Claims.GetNextId(),
             Project = Project,
             Character = mockCharacter,
             CharacterId = mockCharacter.CharacterId,


### PR DESCRIPTION
## Что сделано

`MockedProject.CreateClaim` не присваивал `ClaimId` — у всех заявок, создаваемых в моках, он оставался равным `0`.

Это блокирует переход валидации заявок на агрегат `CharacterInfo` (ADR013): его конструктор ищет утверждённую заявку через `claims.SingleOrDefault(c => c.ClaimId == approvedClaimId)` и на двух заявках с нулевым id падает.

Выделено в отдельный PR, потому что смена id теоретически может задеть тесты, которые неявно полагались на `0`. Полный прогон `dotnet test` зелёный.

Подготовка к рефакторингу причин запрета заявки (#4743, #4744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY