### PR TITLE
refactor: перенести исключения заявок в DomainTypes, разобрать InsufficientContactsException

### DIFF
--- a/src/JoinRpg.Domain/Exceptions.cs
+++ b/src/JoinRpg.Domain/Exceptions.cs
@@ -148,23 +148,6 @@ public class EntityWrongStatusException : JoinRpgProjectEntityException
     }
 }
 
-public class ClaimAlreadyPresentException : JoinRpgBaseException
-{
-    public ClaimAlreadyPresentException() : base("Claim already present for this character or group.") { }
-}
-
-public class OnlyOneApprovedClaimException : JoinRpgBaseException
-{
-    public OnlyOneApprovedClaimException() : base("Approved claim already present for this player, and project allows only one character.") { }
-}
-
-public class ClaimTargetIsNotAcceptingClaims : JoinRpgBaseException
-{
-    public ClaimTargetIsNotAcceptingClaims() : base("This character or group does not accept claims.") { }
-}
-
-public class InsufficientContactsException() : JoinRpgBaseException("Для отправки заявки необходимы контакты");
-
 public class RoomIsOccupiedException : JoinRpgProjectEntityException
 {
     public RoomIsOccupiedException(ProjectAccommodation entity) : base(entity, "Cannot peforrm this operation on occupied room.")

--- a/src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs
@@ -1,0 +1,20 @@
+using JoinRpg.Helpers;
+
+namespace JoinRpg.DomainTypes.Characters.Claims;
+
+public class ClaimAlreadyPresentException : JoinRpgBaseException
+{
+    public ClaimAlreadyPresentException() : base("Claim already present for this character or group.") { }
+}
+
+public class OnlyOneApprovedClaimException : JoinRpgBaseException
+{
+    public OnlyOneApprovedClaimException() : base("Approved claim already present for this player, and project allows only one character.") { }
+}
+
+public class ClaimTargetIsNotAcceptingClaims : JoinRpgBaseException
+{
+    public ClaimTargetIsNotAcceptingClaims() : base("This character or group does not accept claims.") { }
+}
+
+public class InsufficientContactsException() : JoinRpgBaseException("Для отправки заявки необходимы контакты");

--- a/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
+++ b/src/JoinRpg.Portal.Test/Controllers/Common/JoinMvcControllerBaseTest.cs
@@ -1,5 +1,6 @@
 using JoinRpg.DataModel.Mocks;
 using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Portal.Controllers.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -54,6 +55,29 @@ public class JoinMvcControllerBaseTest
         controller.ModelState.IsValid.ShouldBeFalse();
         var error = controller.ModelState[""]!.Errors.ShouldHaveSingleItem();
         error.ErrorMessage.ShouldBe("Заявка не принята: у игрока уже есть одобренная заявка на другого персонажа в этом проекте");
+        logger.ErrorCount.ShouldBe(0);
+    }
+
+    // Регрессия: InsufficientContactsException (мастера требуют заполнить контакты, а игрок их не
+    // заполнил — ожидаемая бизнес-ситуация) не была разобрана в AddModelException и проваливалась
+    // в default-ветку: игрок вместо объяснения видел "Неожиданная ошибка, обратитесь в техподдержку".
+    [Fact]
+    public void AddModelException_InsufficientContactsException_ShouldAddFriendlyErrorWithoutLoggingError()
+    {
+        var logger = new RecordingLogger();
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContext(logger),
+            },
+        };
+
+        controller.CallAddModelException(new InsufficientContactsException());
+
+        controller.ModelState.IsValid.ShouldBeFalse();
+        var error = controller.ModelState[""]!.Errors.ShouldHaveSingleItem();
+        error.ErrorMessage.ShouldBe("Для отправки заявки необходимы контакты");
         logger.ErrorCount.ShouldBe(0);
     }
 

--- a/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
+++ b/src/JoinRpg.Portal/Controllers/Common/JoinMvcControllerBase.cs
@@ -1,5 +1,6 @@
 using System.Data.Entity.Validation;
 using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Characters.Claims;
 using Microsoft.AspNetCore.Mvc;
 
 namespace JoinRpg.Portal.Controllers.Common;
@@ -57,6 +58,7 @@ public abstract class JoinMvcControllerBase : Controller
             case ProjectDeactivatedException _:
             case ClaimAlreadyPresentException _:
             case ClaimTargetIsNotAcceptingClaims _:
+            case InsufficientContactsException _:
             case MasterHasResponsibleException _:
                 ModelState.AddModelError("", exception.Message);
                 return;


### PR DESCRIPTION
## Что сделано

### Перенос исключений в `DomainTypes`

`ClaimAlreadyPresentException`, `OnlyOneApprovedClaimException`, `ClaimTargetIsNotAcceptingClaims` и `InsufficientContactsException` не зависят от `DataModel` — это плоские `JoinRpgBaseException`, а база лежит в `JoinRpg.Helpers`, на который `DomainTypes` уже ссылается. Переехали в `src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs`.

Это подготовка к переезду правил валидации заявок в `DomainTypes` поверх `CharacterInfo` (ADR013): сейчас они не могут туда уехать, потому что бросают исключения из `JoinRpg.Domain`.

`ClaimWrongStatusException` осознанно остаётся в `JoinRpg.Domain` — ему нужна EF-сущность `Claim`.

### Починка сообщения об ошибке

`InsufficientContactsException` не был разобран в `JoinMvcControllerBase.AddModelException` и проваливался в `default`-ветку. Игрок, не заполнивший требуемые мастерами контакты, при отправке заявки видел «Неожиданная ошибка, обратитесь в техподдержку» вместо объяснения, а в лог писалась ошибка уровня Error на штатную бизнес-ситуацию.

Добавлен регрессионный тест по образцу соседних (`JoinMvcControllerBaseTest`).

Полный прогон `dotnet test` зелёный.

Часть рефакторинга причин запрета заявки (#4743, #4744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY