### PR TITLE
feat: причина запрета заявки как доменный тип ClaimForbiddenReason

### DIFF
--- a/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
@@ -118,7 +118,7 @@ public class AddClaimValidationRulesTest
         {
             Social = Mock.PlayerInfo.Social with { Vk = new VkSocialLink(1, isVerified: false) },
         };
-        Mock.Character.ValidateIfCanAddClaim(playerWithUnverifiedVk, projectInfo)
+        Mock.Character.ValidateIfCanAddClaim(playerWithUnverifiedVk, projectInfo).Kinds()
             .ShouldContain(AddClaimForbideReason.VkontakteMissing);
     }
 
@@ -139,6 +139,6 @@ public class AddClaimValidationRulesTest
 
     private void ShouldBeNotAllowed(Character claimSource, AddClaimForbideReason reason, ProjectInfo projectInfo)
     {
-        claimSource.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).ShouldContain(reason);
+        claimSource.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).Kinds().ShouldContain(reason);
     }
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/ClaimValidationTestExtensions.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/ClaimValidationTestExtensions.cs
@@ -1,0 +1,14 @@
+using JoinRpg.DomainTypes.Characters.Claims;
+
+namespace JoinRpg.Domain.Test.AddClaim;
+
+internal static class ClaimValidationTestExtensions
+{
+    /// <summary>
+    /// Причины запрета без флагов — чтобы тесты про правила говорили только о правилах,
+    /// а свойства причин проверялись отдельно (<see cref="ClaimForbiddenReasonTableTest"/>).
+    /// </summary>
+    public static IReadOnlyCollection<AddClaimForbideReason> Kinds(
+        this IReadOnlyCollection<ClaimForbiddenReason> reasons)
+        => [.. reasons.Select(r => r.Kind)];
+}

--- a/src/JoinRpg.Domain.Test/AddClaim/ExceptionTranslationTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/ExceptionTranslationTest.cs
@@ -15,6 +15,6 @@ public class ExceptionTranslationTest
     {
         var claim = new Claim();
         var projectInfo = new MockedProject().ProjectInfo;
-        _ = Should.Throw<JoinRpgBaseException>(() => ClaimAcceptOrMoveValidationExtensions.ThrowForReason(reason, claim, projectInfo));
+        _ = Should.Throw<JoinRpgBaseException>(() => ClaimAcceptOrMoveValidationExtensions.ThrowForReason(ClaimForbiddenReason.For(reason), claim, projectInfo));
     }
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/FatalReasonFilteringTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/FatalReasonFilteringTest.cs
@@ -1,0 +1,55 @@
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+
+namespace JoinRpg.Domain.Test.AddClaim;
+
+/// <summary>
+/// Фатальная причина (проект в архиве или не принимает заявки) вытесняет остальные: пока проект
+/// в таком состоянии, показывать игроку «роль занята» или «заполните телефон» бессмысленно.
+/// Раньше это делалось через <c>yield break</c> прямо в правилах.
+/// </summary>
+public class FatalReasonFilteringTest
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    [Fact]
+    public void FatalReasonHidesOtherReasons()
+    {
+        // Персонаж занят — сам по себе это нефатальная причина...
+        _ = Mock.CreateApprovedClaim(Mock.Character, Mock.Master);
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo).Kinds()
+            .ShouldContain(AddClaimForbideReason.Busy);
+
+        // ...но если проект вдобавок не принимает заявки, остаётся только это.
+        var closedProject = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.ActiveClaimsClosed);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, closedProject).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
+    }
+
+    [Fact]
+    public void ArchivedProjectHidesOtherReasons()
+    {
+        Mock.Character.CharacterType = CharacterType.NonPlayer;
+        var archived = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.Archived);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, archived).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectNotActive]);
+    }
+
+    [Fact]
+    public void NonFatalReasonsAreReportedTogether()
+    {
+        Mock.Character.CharacterType = CharacterType.NonPlayer;
+        Mock.Character.IsActive = false;
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo).Kinds()
+            .ShouldBe(
+                [
+                    AddClaimForbideReason.CharacterInactive,
+                    AddClaimForbideReason.Npc,
+                ],
+                ignoreOrder: true);
+    }
+}

--- a/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
@@ -56,5 +56,5 @@ public class MoveClaimValidationRulesTest
     private void ShouldAllowMove(Claim claim, Character character) => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBeEmpty();
 
     private void ShouldDisAllowMove(Claim claim, Character character, AddClaimForbideReason reason)
-        => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBe([reason]);
+        => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).Kinds().ShouldBe([reason]);
 }

--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -10,13 +10,13 @@ public static class ClaimAcceptOrMoveValidationExtensions
     public static bool IsAcceptingClaims(this Character character, ProjectInfo projectInfo)
         => !ValidateIfCanAddClaim(character, userInfo: null, projectInfo).Any();
 
-    public static IEnumerable<AddClaimForbideReason> ValidateIfCanAddClaim(
+    public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanAddClaim(
         this Character claimSource,
         UserInfo? userInfo, ProjectInfo projectInfo)
-        => ValidateImpl(claimSource, userInfo, existingClaim: null, projectInfo).ToList();
+        => Validate(claimSource, userInfo, existingClaim: null, projectInfo);
 
-    public static IEnumerable<AddClaimForbideReason> ValidateIfCanMoveClaim(this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
-        => ValidateImpl(claimSource, userInfo, claim, projectInfo);
+    public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanMoveClaim(this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
+        => Validate(claimSource, userInfo, claim, projectInfo);
 
     public static void EnsureCanAddClaim([NotNull] this Character claimSource, UserInfo userInfo, ProjectInfo projectInfo)
     {
@@ -31,19 +31,19 @@ public static class ClaimAcceptOrMoveValidationExtensions
     }
 
     private static void ThrowIfValidationFailed(
-        IEnumerable<AddClaimForbideReason> validation,
+        IReadOnlyCollection<ClaimForbiddenReason> validation,
         Claim? claim,
         ProjectInfo projectInfo)
     {
-        if (validation.Any())
+        if (validation.Count > 0)
         {
             ThrowForReason(validation.First(), claim, projectInfo);
         }
     }
 
-    internal static void ThrowForReason(AddClaimForbideReason reason, Claim? claim, ProjectInfo projectInfo)
+    internal static void ThrowForReason(ClaimForbiddenReason reason, Claim? claim, ProjectInfo projectInfo)
     {
-        throw reason switch
+        throw reason.Kind switch
         {
             AddClaimForbideReason.ProjectNotActive => new ProjectDeactivatedException(projectInfo.ProjectId),
 
@@ -56,9 +56,28 @@ public static class ClaimAcceptOrMoveValidationExtensions
 
             AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot or AddClaimForbideReason.CheckedInClaimCantBeMoved => new ClaimWrongStatusException(claim!),
             AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing or
-            AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing => throw new InsufficientContactsException(),
-            _ => new ArgumentOutOfRangeException(nameof(reason), reason, message: null),
+            AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing => new InsufficientContactsException(),
+            _ => new ArgumentOutOfRangeException(nameof(reason), reason.Kind, message: null),
         };
+    }
+
+    /// <summary>
+    /// Считает все причины запрета и отбрасывает те, которые не надо показывать.
+    /// </summary>
+    /// <remarks>
+    /// Если есть хотя бы одна фатальная причина (проект в архиве, приём заявок закрыт), остальные
+    /// не отдаём: пока проект в таком состоянии, разбираться с занятостью роли или контактами
+    /// игрока бессмысленно.
+    /// </remarks>
+    private static List<ClaimForbiddenReason> Validate(
+        Character character, UserInfo? userInfo, Claim? existingClaim, ProjectInfo projectInfo)
+    {
+        var reasons = ValidateImpl(character, userInfo, existingClaim, projectInfo)
+            .Select(ClaimForbiddenReason.For)
+            .ToList();
+
+        var fatal = reasons.Where(r => r.IsFatal).ToList();
+        return fatal.Count > 0 ? fatal : reasons;
     }
 
     /// <summary>
@@ -76,7 +95,6 @@ public static class ClaimAcceptOrMoveValidationExtensions
         if (ValidateProjectImpl(projectInfo) is AddClaimForbideReason projectReason)
         {
             yield return projectReason;
-            yield break;
         }
 
         if (character.ApprovedClaimId != null)

--- a/src/JoinRpg.DomainTypes.Test/Characters/ClaimForbiddenReasonTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/Characters/ClaimForbiddenReasonTest.cs
@@ -1,0 +1,66 @@
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+
+namespace JoinRpg.DomainTypes.Test.Characters;
+
+public class ClaimForbiddenReasonTest
+{
+    [Fact]
+    public void EveryReasonIsDescribedInTable()
+    {
+        foreach (var kind in Enum.GetValues<AddClaimForbideReason>())
+        {
+            var reason = Should.NotThrow(() => ClaimForbiddenReason.For(kind));
+            reason.Kind.ShouldBe(kind);
+        }
+    }
+
+    // Список причин, которые мастер вправе обойти, заморожен намеренно: если в
+    // AddClaimForbideReason появится новое значение, решение «может ли мастер его обойти»
+    // должно приниматься осознанно, а не достаться по умолчанию.
+    // См. https://github.com/joinrpg/joinrpg-net/issues/4743 про Npc/CharacterInactive/SlotsExhausted.
+    [Fact]
+    public void OnlyExpectedReasonsCanBeOverridenByMaster()
+    {
+        var overridable = Enum.GetValues<AddClaimForbideReason>()
+            .Where(kind => ClaimForbiddenReason.For(kind).MasterCanOverride)
+            .ToList();
+
+        overridable.ShouldBe(
+            [
+                AddClaimForbideReason.ProjectClaimsClosed,
+                AddClaimForbideReason.RealNameMissing,
+                AddClaimForbideReason.PhoneMissing,
+                AddClaimForbideReason.TelegramMissing,
+                AddClaimForbideReason.VkontakteMissing,
+            ],
+            ignoreOrder: true);
+    }
+
+    // Фатальность — это то, на чём держится «показать только главную причину»: пока проект
+    // в архиве или не принимает заявки, остальные причины игроку не показываем.
+    [Fact]
+    public void OnlyProjectLevelReasonsAreFatal()
+    {
+        var fatal = Enum.GetValues<AddClaimForbideReason>()
+            .Where(kind => ClaimForbiddenReason.For(kind).IsFatal)
+            .ToList();
+
+        fatal.ShouldBe(
+            [
+                AddClaimForbideReason.ProjectNotActive,
+                AddClaimForbideReason.ProjectClaimsClosed,
+            ],
+            ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ForReturnsSameInstance() =>
+        ClaimForbiddenReason.For(AddClaimForbideReason.Busy)
+            .ShouldBeSameAs(ClaimForbiddenReason.For(AddClaimForbideReason.Busy));
+
+    [Fact]
+    public void SeverityIsNeverHint() =>
+        Enum.GetValues<AddClaimForbideReason>()
+            .ShouldAllBe(kind => ClaimForbiddenReason.For(kind).Severity != ProblemSeverity.Hint);
+}

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
@@ -1,0 +1,67 @@
+using System.Collections.Frozen;
+
+namespace JoinRpg.DomainTypes.Characters.Claims;
+
+/// <summary>
+/// Причина, по которой заявку нельзя подать или перенести, вместе с её свойствами.
+/// </summary>
+/// <param name="Kind">
+/// Собственно причина. Остаётся идентификатором: на неё завязаны тексты в UI.
+/// </param>
+/// <param name="MasterCanOverride">
+/// Мастер может выполнить операцию несмотря на эту причину — например пригласить игрока в проект
+/// с закрытым приёмом заявок. Сам факт обхода определяется операцией, а не этим флагом: см.
+/// вызывающий код.
+/// </param>
+/// <param name="Severity">
+/// Насколько причина безнадёжна. <see cref="ProblemSeverity.Fatal"/> означает «делать тут больше
+/// нечего»: при наличии хотя бы одной фатальной причины остальные не показываются, потому что
+/// сначала надо разобраться с ней.
+/// </param>
+public record class ClaimForbiddenReason(
+    AddClaimForbideReason Kind,
+    bool MasterCanOverride,
+    ProblemSeverity Severity)
+{
+    public bool IsFatal => Severity == ProblemSeverity.Fatal;
+
+    public static ClaimForbiddenReason For(AddClaimForbideReason kind) => Table[kind];
+
+    private static readonly FrozenDictionary<AddClaimForbideReason, ClaimForbiddenReason> Table =
+        Enum.GetValues<AddClaimForbideReason>().ToFrozenDictionary(kind => kind, Create);
+
+    private static ClaimForbiddenReason Create(AddClaimForbideReason kind) => kind switch
+    {
+        // Проект в архиве — не поможет никто и ничто.
+        AddClaimForbideReason.ProjectNotActive
+            => new(kind, MasterCanOverride: false, ProblemSeverity.Fatal),
+
+        // Приём заявок закрыт: игроку тут делать нечего, но мастер вправе позвать игрока сам.
+        AddClaimForbideReason.ProjectClaimsClosed
+            => new(kind, MasterCanOverride: true, ProblemSeverity.Fatal),
+
+        // Свойства самого персонажа. Мастер может поменять их руками, но пока это осознанно
+        // жёсткие запреты — см. https://github.com/joinrpg/joinrpg-net/issues/4743.
+        AddClaimForbideReason.SlotsExhausted or AddClaimForbideReason.Npc
+            or AddClaimForbideReason.Busy or AddClaimForbideReason.CharacterInactive
+            => new(kind, MasterCanOverride: false, ProblemSeverity.Error),
+
+        // Ограничения целостности: две заявки на одного персонажа или две утверждённые заявки
+        // в проекте, который этого не допускает.
+        AddClaimForbideReason.AlreadySent or AddClaimForbideReason.OnlyOneCharacter
+            => new(kind, MasterCanOverride: false, ProblemSeverity.Error),
+
+        // Ограничения переноса заявки.
+        AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot
+            or AddClaimForbideReason.CheckedInClaimCantBeMoved
+            => new(kind, MasterCanOverride: false, ProblemSeverity.Error),
+
+        // Недозаполненный профиль игрока. Мастер может пригласить игрока и попросить дозаполнить
+        // профиль потом.
+        AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing
+            or AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing
+            => new(kind, MasterCanOverride: true, ProblemSeverity.Warning),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),
+    };
+}

--- a/src/JoinRpg.Portal/Views/Claim/Add.cshtml
+++ b/src/JoinRpg.Portal/Views/Claim/Add.cshtml
@@ -24,7 +24,7 @@
         {
             <component type="typeof(AddClaimForbideReasonMessage)"
                        render-mode="Static"
-                       param-Reason="validation"
+                       param-Reason="validation.Kind"
                        param-ProjectId="Model.ProjectIdentification"
                        param-CharacterName="Model.TargetName"
                        param-ProjectLifecycleStatus="Model.ProjectLifecycleStatus" />

--- a/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
@@ -25,7 +25,7 @@ public class AddClaimViewModel : IProjectIdAware
 
     public bool IsSlot { get; set; }
 
-    public IReadOnlyCollection<AddClaimForbideReason> ValidationStatus
+    public IReadOnlyCollection<ClaimForbiddenReason> ValidationStatus
     {
         get;
         private set;
@@ -53,14 +53,11 @@ public class AddClaimViewModel : IProjectIdAware
 
     public AddClaimViewModel Fill(Character claimSource, UserInfo userInfo, ProjectInfo projectInfo, Dictionary<int, string?>? overrideValues = null)
     {
-        var disallowReasons = claimSource.ValidateIfCanAddClaim(userInfo, projectInfo).ToList();
+        var disallowReasons = claimSource.ValidateIfCanAddClaim(userInfo, projectInfo);
 
-        IsProjectRelatedReason = disallowReasons.Intersect(
-            [
-                AddClaimForbideReason.ProjectClaimsClosed,
-                AddClaimForbideReason.ProjectNotActive,
-            ])
-            .Any();
+        // Фатальная причина означает, что заявку тут не подать в принципе (проект в архиве или
+        // приём заявок закрыт) — форму показывать незачем.
+        IsProjectRelatedReason = disallowReasons.Any(r => r.IsFatal);
 
         ProjectLifecycleStatus = projectInfo.ProjectStatus;
 


### PR DESCRIPTION
## Зачем

Плоский `AddClaimForbideReason` не нёс никаких свойств причины, из-за чего признаки расползлись по коду:

- `AddClaimViewModel.IsProjectRelatedReason` — захардкоженный `Intersect` с двумя значениями enum;
- «показать только главную причину» делалось через `yield break` посреди правил.

Второе — не просто некрасиво: это блокирует следующий шаг. Чтобы разрешить мастеру приглашать игрока в проект с закрытым приёмом заявок, надо убрать `ProjectClaimsClosed` из результата, а с `yield break` это молча отключило бы и все остальные проверки (`Busy`, `Npc`, `AlreadySent`).

## Что сделано

**`ClaimForbiddenReason(Kind, MasterCanOverride, Severity)`** в `DomainTypes` с одной таблицей соответствия. Enum остаётся идентификатором — на нём держатся тексты в UI, и ломать это незачем.

**Короткое замыкание заменено на фильтрацию по `Severity`.** `ProjectNotActive` и `ProjectClaimsClosed` фатальны; при наличии фатальной причины остальные не отдаются. Поведение ровно то же, что и было, но теперь это свойство причины, а не порядок операторов.

**`IsProjectRelatedReason`** читает `Any(r => r.IsFatal)` вместо захардкоженного списка.

`MasterCanOverride` пока только объявлен и никем не читается — обход мастером включается следующим PR вместе с `ClaimOperation`.

## Тесты

- `ClaimForbiddenReasonTest` — таблица покрывает все значения enum; множества обходимых и фатальных причин заморожены, чтобы новое значение enum требовало осознанного решения.
- `FatalReasonFilteringTest` — фатальная причина вытесняет остальные, нефатальные показываются вместе.
- Существующие тесты правил не менялись по сути (только `.Kinds()` в хелперах) — они и доказывают отсутствие дрейфа поведения.

Полный прогон `dotnet test` зелёный, `dotnet format --verify-no-changes --severity warn` чистый.

Часть рефакторинга причин запрета заявки (#4743, #4744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY
