### PR TITLE
feat: кнопка «Приглашения на игру» рядом с «Поставить доступ в проект»

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectPredicates.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectPredicates.cs
@@ -50,6 +50,7 @@ internal static class ProjectPredicates
                 => predicate.And(ForCloning(userId)),
             { Criteria: ProjectListCriteria.HasSchedule } => predicate.And(project => project.Details.ScheduleEnabled),
             PersonalizedProjectListSpecification { Criteria: ProjectListCriteria.MasterGrantAccess, UserId: var userId } => predicate.And(project => project.ProjectAcls.Any(projectAcl => projectAcl.UserId == userId.Value && projectAcl.CanGrantRights)),
+            PersonalizedProjectListSpecification { Criteria: ProjectListCriteria.MasterManageClaimsAccess, UserId: var userId } => predicate.And(project => project.ProjectAcls.Any(projectAcl => projectAcl.UserId == userId.Value && projectAcl.CanManageClaims)),
             _ => throw new NotImplementedException(),
         };
         return predicate;

--- a/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IProjectRepository.cs
@@ -69,6 +69,9 @@ public record ProjectListSpecification(ProjectListCriteria Criteria, bool LoadAr
 
     public static PersonalizedProjectListSpecification ActiveProjectsWithGrantMasterAccess(UserIdentification userId)
         => new(ProjectListCriteria.MasterGrantAccess, LoadArchived: false, userId);
+
+    public static PersonalizedProjectListSpecification ActiveProjectsWithManageClaimsAccess(UserIdentification userId)
+        => new(ProjectListCriteria.MasterManageClaimsAccess, LoadArchived: false, userId);
     public static PersonalizedProjectListSpecification MyActiveProjects(UserIdentification userId)
         => new(ProjectListCriteria.MasterOrActiveClaim, LoadArchived: false, userId);
 
@@ -86,4 +89,4 @@ public record PersonalizedProjectListSpecification(ProjectListCriteria Criteria,
 
 }
 
-public enum ProjectListCriteria { MasterAccess, MasterOrActiveClaim, ForCloning, HasSchedule, KogdaIgraMissing, MasterGrantAccess, All, Public };
+public enum ProjectListCriteria { MasterAccess, MasterOrActiveClaim, ForCloning, HasSchedule, KogdaIgraMissing, MasterGrantAccess, MasterManageClaimsAccess, All, Public };

--- a/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/UserController.cs
@@ -54,6 +54,10 @@ public class UserController(IUserRepository userRepository, ICurrentUserAccessor
 
             userProfileViewModel.CanGrantAccessProjects = canGrantProjects.ToLinkViewModels().ToList();
 
+            var canInviteProjects = await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.ActiveProjectsWithManageClaimsAccess(currentUserAccessor.UserIdentification));
+
+            userProfileViewModel.CanInviteProjects = canInviteProjects.ToLinkViewModels().ToList();
+
             var claims = await claimsRepository.GetClaimsForPlayer(userId, ClaimStatusSpec.Any);
 
             userProfileViewModel.Claims = new MyClaimListViewModel(

--- a/src/JoinRpg.Portal/Pages/GamePages/InvitePlayer.cshtml
+++ b/src/JoinRpg.Portal/Pages/GamePages/InvitePlayer.cshtml
@@ -9,4 +9,4 @@
 
 <h3>@ViewData["Title"]</h3>
 
-@(await Html.RenderComponentAsync<InvitePlayer>(RenderMode.WebAssembly, new { Model.ProjectId, PreselectedCharacterId = CharacterIdentification.FromOptional(Model.ProjectId, Model.CharacterId) }))
+@(await Html.RenderComponentAsync<InvitePlayer>(RenderMode.WebAssembly, new { Model.ProjectId, PreselectedCharacterId = CharacterIdentification.FromOptional(Model.ProjectId, Model.CharacterId), PreselectedUserLink = Model.UserId?.ToString() }))

--- a/src/JoinRpg.Portal/Pages/GamePages/InvitePlayer.cshtml.cs
+++ b/src/JoinRpg.Portal/Pages/GamePages/InvitePlayer.cshtml.cs
@@ -17,4 +17,7 @@ public class InvitePlayerModel : PageModel
 
     [BindProperty(SupportsGet = true)]
     public int? CharacterId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? UserId { get; set; }
 }

--- a/src/JoinRpg.Portal/Views/User/Details.cshtml
+++ b/src/JoinRpg.Portal/Views/User/Details.cshtml
@@ -21,6 +21,14 @@
                    param-UserId="new UserIdentification(Model.UserId)" />
     }
 
+    @if (Model.CanInviteProjects.Any())
+    {
+        <component type="typeof(JoinRpg.Web.ProjectMasterTools.Acl.InvitePlayerButton)"
+                   render-mode="Static"
+                   param-Items="@Model.CanInviteProjects.ToArray()"
+                   param-UserId="new UserIdentification(Model.UserId)" />
+    }
+
     @if (Model.HasAdminAccess)
     {
         <component type="typeof(AdminUserActionsPanel)"

--- a/src/JoinRpg.Web.Claims/InvitePlayer.razor
+++ b/src/JoinRpg.Web.Claims/InvitePlayer.razor
@@ -56,6 +56,9 @@
     [Parameter]
     public CharacterIdentification? PreselectedCharacterId { get; set; }
 
+    [Parameter]
+    public string? PreselectedUserLink { get; set; }
+
     private InvitePlayerViewModel model = new();
     private bool loading = false;
     private string? errorMessage = null;
@@ -102,6 +105,10 @@
         if (PreselectedCharacterId is not null && PreselectedCharacterId.ProjectId == ProjectId)
         {
             model.CharacterId = PreselectedCharacterId.CharacterId;
+        }
+        if (!string.IsNullOrEmpty(PreselectedUserLink))
+        {
+            model.UserLinks = [PreselectedUserLink];
         }
         base.OnInitialized();
     }

--- a/src/JoinRpg.Web.ProjectMasterTools/Acl/InvitePlayerButton.razor
+++ b/src/JoinRpg.Web.ProjectMasterTools/Acl/InvitePlayerButton.razor
@@ -1,0 +1,13 @@
+@using JoinRpg.Web.ProjectCommon.Projects
+
+<TypedDropdownButton TKey="ProjectIdentification" TItem="ProjectLinkViewModel"
+    Label="Приглашения на игру"
+    Items="Items"
+    ToListItem="@(p => TypedSelectList.CreateItem(Value: p.ProjectId, Text: p.ProjectName))"
+    ToLink="@(p => $"/{p.ProjectId.Value}/claims/invite-player?UserId={UserId.Value}")" />
+
+@code {
+    [Parameter, EditorRequired] public ProjectLinkViewModel[] Items { get; set; } = null!;
+
+    [Parameter, EditorRequired] public UserIdentification UserId { get; set; } = null!;
+}

--- a/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/UserProfile/UserProfileViewModel.cs
@@ -25,6 +25,10 @@ public class UserProfileViewModel
 
     [ReadOnly(true)]
     public IEnumerable<ProjectLinkViewModel> CanGrantAccessProjects { get; set; } = [];
+
+    [ReadOnly(true)]
+    public IEnumerable<ProjectLinkViewModel> CanInviteProjects { get; set; } = [];
+
     public int UserId { get; set; }
 
     public IEnumerable<ProjectLinkViewModel> ProjectsToAdd => CanGrantAccessProjects.Except(ThisUserProjects);


### PR DESCRIPTION
## Что сделано
- Добавлен `InvitePlayerButton` — второй `TypedDropdownButton` (см. #4738) на странице профиля, рядом с `AddToProjectButton`.
- Список проектов гейтится новым `Permission.CanManageClaims` (`ProjectListCriteria.MasterManageClaimsAccess`, по аналогии с `MasterGrantAccess`), кнопка ведёт на `/{projectId}/claims/invite-player`.
- Страница `InvitePlayer` научилась принимать `userId` в query-строке (`PreselectedUserLink`) и предзаполнять поле «кому» в `JoinUserLinkEditor` — переход из профиля сразу открывает форму с уже выбранным игроком.

## Test plan
- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes` — форматирование в порядке
- [ ] Ручная проверка на localhost: профиль пользователя, у которого есть проекты с правом `CanManageClaims` — кнопка «Приглашения на игру» отображается рядом с «Поставить доступ в проект», переход по пункту меню открывает страницу приглашения с уже выбранным игроком

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KDk1wnfhPEHFUqtMkX9yGg