### PR TITLE
fix: привести логирование ComponentBook к настройкам Portal

### DIFF
--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/Program.cs
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/Program.cs
@@ -4,10 +4,13 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
 builder.Services.ConfigureForwardedHeaders();
+builder.Host.UseJoinSerilog("ComponentBook");
 
 var app = builder.Build();
 
 app.UseForwardedHeaders();
+
+app.UseJoinRequestLogging();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/appsettings.Development.json
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Logging": {
+    "Structured": "False"
+  }
+}

--- a/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/appsettings.json
+++ b/src/Common/WebComponents/JoinRpg.Common.WebComponentBook.Portal/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "Structured": "True",
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Что сделано
- ComponentBook (`JoinRpg.Common.WebComponentBook.Portal`) не подключал Serilog и использовал дефолтный логгер ASP.NET Core, логировавший каждый запрос, включая health checks, без фильтрации
- Добавлены `builder.Host.UseJoinSerilog("ComponentBook")` и `app.UseJoinRequestLogging()`, как в Portal
- Добавлены `appsettings.json`/`appsettings.Development.json` с секцией `Logging`, аналогичной Portal

Теперь health-check запросы логируются на уровне `Verbose` и не засоряют вывод при обычном `MinimumLevel=Information` — тем же механизмом (`ExcludeHealthChecks`), что уже используется в Portal.

## Test plan
- [x] `dotnet build` проекта ComponentBook проходит без ошибок
- [ ] Проверить в проде/dev, что шум health-check запросов в логах ComponentBook пропал