### PR TITLE
fix: считать AdvertisementCount по реальному AdvertisementLog

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/ProjectRepository.cs
@@ -191,6 +191,8 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
             {
                 p.ProjectId,
                 ActiveClaimsCount = p.Claims.Count(claim => activeClaimPredicate.Invoke(claim)),
+                AdvertisementCount = Ctx.AdvertisementLogEntriesSet.Count(e =>
+                    e.ProjectId == p.ProjectId && e.Status == (int)AdvertisementLogStatus.Sent),
             });
 
         var result = await query.ToListAsync();
@@ -198,7 +200,7 @@ internal class ProjectRepository(MyDbContext ctx) : GameRepositoryImplBase(ctx),
         return [.. result.Select(x => new ProjectAdvertisementCandidate(
             new ProjectIdentification(x.ProjectId),
             x.ActiveClaimsCount,
-            AdvertisementCount: 0 /* TODO: считать по таблице AdvertisementLog, когда она появится (ADR010 §4) */))];
+            x.AdvertisementCount))];
     }
 
     Task<ProjectPersonalizedInfo[]> IProjectRepository.GetProjectsByIds(UserIdentification? userId, ProjectIdentification[] ids)

--- a/src/JoinRpg.IntegrationTests/Scenarios/AdvertisementProjectRankingScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/AdvertisementProjectRankingScenario.cs
@@ -1,0 +1,106 @@
+using System.Data.Entity;
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Dal.Impl;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Projects;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Advertisement;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.IntegrationTest.Scenarios;
+
+public class AdvertisementProjectRankingScenario(JoinApplicationFactory factory) : IClassFixture<JoinApplicationFactory>
+{
+    // Регрессия: GetPublicProjectsOpenForHotRoleAdvertisement() хардкодил AdvertisementCount: 0
+    // (см. ADR010 §4), из-за чего формула ранжирования AdvertisementGameRanking всегда получала
+    // одинаковый знаменатель и фактически ранжировала только по ActiveClaimsCount. Проверяем, что
+    // счётчик считается по реальным записям AdvertisementLog (только Sent, Failed не учитывается).
+    [Fact]
+    public async Task GetPublicProjectsOpenForHotRoleAdvertisement_CountsOnlySentAdvertisements()
+    {
+        UserIdentification masterId;
+        ProjectIdentification projectId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            masterId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+            projectId = await TestUserProjectHelpers.CreateProjectAsync(
+                scope.ServiceProvider, masterId, "Проект для проверки подсчёта рекламы");
+        }
+
+        var scheduleId = new AdvertisementScheduleIdentification(1);
+
+        // 1. Открываем приём заявок и заводим горячую роль — проект должен стать кандидатом
+        // GetPublicProjectsOpenForHotRoleAdvertisement().
+        var characterId = await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var projectService = sp.GetRequiredService<IProjectService>();
+            var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+            var projectInfo = await metadataRepository.GetProjectMetadata(projectId);
+            await projectService.SetClaimSettings(
+                projectId,
+                projectInfo.ClaimSettings with { IsAcceptingClaims = true });
+
+            var characterService = sp.GetRequiredService<ICharacterService>();
+            return await characterService.AddCharacter(new AddCharacterRequest(
+                projectId,
+                ParentCharacterGroupIds: [],
+                new CharacterTypeInfo(CharacterType.Player, IsHot: true, SlotLimit: null, SlotName: null, CharacterVisibility.Public),
+                FieldValues: FieldLayerContainer.Empty(projectInfo)));
+        });
+
+        // 2. Проект создаётся с ShouldNotBeOnKogdaIgra — снимаем флаг и заводим будущую активную
+        // привязку к КогдаИгра напрямую в БД (по образцу KogdaIgraMissingGamesScenario), иначе
+        // ProjectPredicates.HasFutureKogdaIgraGame() исключит проект из кандидатов.
+        using (var scope = factory.Services.CreateScope())
+        {
+            var myDb = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            var project = await myDb.Set<Project>()
+                .Include(p => p.KogdaIgraGames)
+                .Include(p => p.Details)
+                .SingleAsync(p => p.ProjectId == projectId.Value);
+
+            project.Details.DisableKogdaIgraMapping = false;
+
+            project.KogdaIgraGames.Add(new KogdaIgraGame
+            {
+                KogdaIgraGameId = projectId.Value + 1_000_000,
+                Name = "Тестовая будущая игра КогдаИгра",
+                JsonGameData = "{}",
+                Active = true,
+                Begin = DateTime.UtcNow.AddDays(30),
+                End = DateTime.UtcNow.AddDays(33),
+                UpdateRequestedAt = DateTimeOffset.UtcNow,
+                LastUpdatedAt = DateTimeOffset.UtcNow,
+            });
+            await myDb.SaveChangesAsync();
+        }
+
+        // 3. Записываем в лог рекламы две отправленные (Sent) и одну неудачную (Failed) записи.
+        await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var logRepository = sp.GetRequiredService<IAdvertisementLogRepository>();
+
+            await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                scheduleId, AdvertisementMethod.SingleHotRole, projectId, characterId, AdvertisementLogStatus.Sent, DateTimeOffset.UtcNow));
+            await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                scheduleId, AdvertisementMethod.SingleHotRole, projectId, characterId, AdvertisementLogStatus.Sent, DateTimeOffset.UtcNow));
+            await logRepository.RecordAdvertisement(new AdvertisementLogEntryInfo(
+                scheduleId, AdvertisementMethod.SingleHotRole, projectId, characterId, AdvertisementLogStatus.Failed, DateTimeOffset.UtcNow));
+        });
+
+        // 4. AdvertisementCount кандидата должен учитывать только две Sent-записи, Failed — не в счёт.
+        using (var scope = factory.Services.CreateScope())
+        {
+            var projectRepository = scope.ServiceProvider.GetRequiredService<IProjectRepository>();
+            var candidates = await projectRepository.GetPublicProjectsOpenForHotRoleAdvertisement();
+
+            var candidate = candidates.Single(c => c.ProjectId == projectId);
+            candidate.AdvertisementCount.ShouldBe(2);
+        }
+    }
+}


### PR DESCRIPTION
## Что сделано

`IProjectRepository.GetPublicProjectsOpenForHotRoleAdvertisement()` хардкодил
`AdvertisementCount: 0` с комментарием «TODO: считать по таблице AdvertisementLog,
когда она появится (ADR010 §4)» — хотя таблица `AdvertisementLog` давно
существует и реально используется (см. `AdvertisementLogRepository.GetHotCharactersAdvertisementInfo`,
которая уже считает аналогичный показатель для персонажей).

Из-за захардкоженного нуля формула ранжирования `AdvertisementGameRanking`
(`(ActiveClaimsCount + 1) / (AdvertisementCount + 1)`, ADR010 §4) не работала
как задумано: все проекты получали одинаковый знаменатель, и ранжирование
фактически шло только по `ActiveClaimsCount`, без учёта того, что менее
разрекламированным играм нужно давать приоритет.

- `AdvertisementCount` теперь считается по количеству записей
  `AdvertisementLogEntriesSet` со статусом `Sent` для данного проекта, по всем
  каналам — по аналогии с уже существующим подсчётом для персонажей.
  `Failed`-записи не учитываются (провал доставки не должен блокировать
  повторную рекламу, см. ADR010 §7).
- Убран устаревший TODO-комментарий.
- Добавлен интеграционный тест `AdvertisementProjectRankingScenario` в
  `src/JoinRpg.IntegrationTests/Scenarios/`: заводит проект, открытый для
  рекламы горячих ролей, пишет через `IAdvertisementLogRepository.RecordAdvertisement`
  две `Sent`- и одну `Failed`-запись, проверяет, что `AdvertisementCount`
  кандидата равен именно числу `Sent`-записей. Тест проверен на баге
  (без фикса падает: `AdvertisementCount == 0` вместо `2`).

См. `docs/adr010-hot-vacancy-advertisement.md` §4 (описание формулы ранжирования
уже соответствует правильному поведению — отдельных изменений в тексте ADR не
потребовалось).

## Проверено

- `dotnet build` — без ошибок
- `dotnet test src/JoinRpg.Dal.Impl.Tests` — 71/71 пройдено
- `dotnet test src/JoinRpg.IntegrationTests` — 159/159 пройдено
- `dotnet format --verify-no-changes --severity warn` — без изменений

Generated with [Claude Code](https://claude.ai/code)