### PR TITLE
fix: подтягивать данные из ВК при обычном логине

### DIFF
--- a/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
+++ b/src/JoinRpg.Portal/Controllers/UserProfile/AccountController.cs
@@ -418,7 +418,11 @@ public class AccountController(
 
         if (result.Succeeded)
         {
-            // TODO Обновлять профиль пользователя при логине
+            var loggedInUser = await userManager.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey);
+            if (loggedInUser is not null)
+            {
+                await externalLoginProfileExtractor.TryExtractProfile(loggedInUser, loginInfo);
+            }
             return RedirectToLocal(returnUrl);
         }
 


### PR DESCRIPTION
## Что сделано
После #4746 обнаружилось, что дата рождения из ВК не подтягивается для уже существующих пользователей. Причина глубже: `ExternalLoginProfileExtractor.TryExtractProfile` вызывался только при первой привязке ВК/регистрации, но не при обычном повторном логине уже привязанного аккаунта — на это место стоял `// TODO Обновлять профиль пользователя при логине` в `AccountController.ExternalLoginCallback`.

Теперь при успешном `ExternalLoginSignInAsync` профиль дозаполняется так же, как при первой привязке — включая дату рождения, если она ещё не установлена (все такие методы идемпотентны и не перезаписывают уже заполненные поля).

## Test plan
- [x] `dotnet build` — весь solution собирается без ошибок
- [ ] Вручную: войти существующим пользователем через ВК с указанной там датой рождения и без предварительной привязки её на joinrpg.ru — убедиться, что дата подтягивается и появляется на `/Manage/SetupProfile`

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013mxFS9qg9xVoM2hYegB6Fh