### PR TITLE
feat: мастер может приглашать и переносить заявки в обход части запретов

### DIFF
--- a/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
@@ -21,7 +21,7 @@ public class AddClaimValidationRulesTest
     }
 
     [Fact]
-    public void AddClaimAllowedCharacterWithoutUser() => Mock.Character.ValidateIfCanAddClaim(userInfo: null, Mock.ProjectInfo).ShouldBeEmpty();
+    public void AddClaimAllowedCharacterWithoutUser() => Mock.Character.ValidateIfCanAddClaim(userInfo: null, Mock.ProjectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
 
     [Fact]
     public void CantSendClaimIfProjectClaimsClosed()
@@ -118,7 +118,7 @@ public class AddClaimValidationRulesTest
         {
             Social = Mock.PlayerInfo.Social with { Vk = new VkSocialLink(1, isVerified: false) },
         };
-        Mock.Character.ValidateIfCanAddClaim(playerWithUnverifiedVk, projectInfo).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(playerWithUnverifiedVk, projectInfo, ClaimOperation.AddByPlayer).Kinds()
             .ShouldContain(AddClaimForbideReason.VkontakteMissing);
     }
 
@@ -131,7 +131,7 @@ public class AddClaimValidationRulesTest
         {
             Social = Mock.PlayerInfo.Social with { Vk = new VkSocialLink(1, isVerified: true) },
         };
-        Mock.Character.ValidateIfCanAddClaim(playerWithVerifiedVk, projectInfo).ShouldBeEmpty();
+        Mock.Character.ValidateIfCanAddClaim(playerWithVerifiedVk, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class AddClaimValidationRulesTest
     {
         var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
             ProjectProfileRequirementSettings.AllNotRequired with { RequirePhone = MandatoryStatus.Required });
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).Kinds()
             .ShouldContain(AddClaimForbideReason.PhoneMissing);
     }
 
@@ -149,7 +149,7 @@ public class AddClaimValidationRulesTest
         var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
             ProjectProfileRequirementSettings.AllNotRequired with { RequirePhone = MandatoryStatus.Required });
         var playerWithPhone = Mock.PlayerInfo with { PhoneNumber = "+79991234567" };
-        Mock.Character.ValidateIfCanAddClaim(playerWithPhone, projectInfo).ShouldBeEmpty();
+        Mock.Character.ValidateIfCanAddClaim(playerWithPhone, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class AddClaimValidationRulesTest
     {
         var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
             ProjectProfileRequirementSettings.AllNotRequired with { RequireRealName = MandatoryStatus.Required });
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).Kinds()
             .ShouldContain(AddClaimForbideReason.RealNameMissing);
     }
 
@@ -170,14 +170,14 @@ public class AddClaimValidationRulesTest
         {
             UserFullName = new UserFullName(new PrefferedName("Player"), new BornName("Иван"), new SurName("Иванов"), null),
         };
-        Mock.Character.ValidateIfCanAddClaim(playerWithRealName, projectInfo).ShouldBeEmpty();
+        Mock.Character.ValidateIfCanAddClaim(playerWithRealName, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
     }
 
     private void ShouldBeAllowed(Character mockCharacter, ProjectInfo projectInfo)
-        => mockCharacter.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).ShouldBeEmpty();
+        => mockCharacter.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
 
     private void ShouldBeNotAllowed(Character claimSource, AddClaimForbideReason reason, ProjectInfo projectInfo)
     {
-        claimSource.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo).Kinds().ShouldContain(reason);
+        claimSource.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).Kinds().ShouldContain(reason);
     }
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/FatalReasonFilteringTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/FatalReasonFilteringTest.cs
@@ -18,13 +18,13 @@ public class FatalReasonFilteringTest
     {
         // Персонаж занят — сам по себе это нефатальная причина...
         _ = Mock.CreateApprovedClaim(Mock.Character, Mock.Master);
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
             .ShouldContain(AddClaimForbideReason.Busy);
 
         // ...но если проект вдобавок не принимает заявки, остаётся только это.
         var closedProject = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.ActiveClaimsClosed);
 
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, closedProject).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, closedProject, ClaimOperation.AddByPlayer).Kinds()
             .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
     }
 
@@ -34,7 +34,7 @@ public class FatalReasonFilteringTest
         Mock.Character.CharacterType = CharacterType.NonPlayer;
         var archived = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.Archived);
 
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, archived).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, archived, ClaimOperation.AddByPlayer).Kinds()
             .ShouldBe([AddClaimForbideReason.ProjectNotActive]);
     }
 
@@ -44,7 +44,7 @@ public class FatalReasonFilteringTest
         Mock.Character.CharacterType = CharacterType.NonPlayer;
         Mock.Character.IsActive = false;
 
-        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo).Kinds()
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
             .ShouldBe(
                 [
                     AddClaimForbideReason.CharacterInactive,

--- a/src/JoinRpg.Domain.Test/AddClaim/MasterBypassTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MasterBypassTest.cs
@@ -1,0 +1,108 @@
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.DomainTypes.Users;
+
+namespace JoinRpg.Domain.Test.AddClaim;
+
+/// <summary>
+/// Мастер вправе обойти часть причин запрета: закрытый приём заявок и незаполненные контакты
+/// игрока. Всё остальное остаётся запретом и для него.
+/// </summary>
+public class MasterBypassTest
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    private ProjectInfo ClaimsClosed => Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.ActiveClaimsClosed);
+
+    private ProjectInfo RequiringPhone => Mock.ProjectInfo.WithProfileRequirementSettings(
+        ProjectProfileRequirementSettings.AllNotRequired with { RequirePhone = MandatoryStatus.Required });
+
+    private UserInfo PlayerWithoutPhone => Mock.PlayerInfo with { PhoneNumber = null };
+
+    [Fact]
+    public void MasterCanInviteWhenClaimsClosed()
+        => Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, ClaimsClosed, ClaimOperation.AddByMaster)
+            .ShouldBeEmpty();
+
+    [Fact]
+    public void PlayerStillCantSendClaimWhenClaimsClosed()
+        => Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, ClaimsClosed, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
+
+    [Fact]
+    public void MasterCanInvitePlayerWithoutRequiredContacts()
+        => Mock.Character.ValidateIfCanAddClaim(PlayerWithoutPhone, RequiringPhone, ClaimOperation.AddByMaster)
+            .ShouldBeEmpty();
+
+    [Fact]
+    public void PlayerStillCantSendClaimWithoutRequiredContacts()
+        => Mock.Character.ValidateIfCanAddClaim(PlayerWithoutPhone, RequiringPhone, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldBe([AddClaimForbideReason.PhoneMissing]);
+
+    /// <summary>
+    /// Ключевой тест: обход мастером убирает только обходимую причину, а не выключает проверки
+    /// целиком. Если фильтр обхода применить после вытеснения по фатальности, фатальный
+    /// <see cref="AddClaimForbideReason.ProjectClaimsClosed"/> сначала вытеснит
+    /// <see cref="AddClaimForbideReason.Busy"/>, а потом уйдёт сам — и мастер сможет пригласить
+    /// игрока на уже занятую роль.
+    /// </summary>
+    [Fact]
+    public void MasterInvitingIntoClosedProjectStillSeesNonOverridableReasons()
+    {
+        _ = Mock.CreateApprovedClaim(Mock.Character, Mock.Master);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, ClaimsClosed, ClaimOperation.AddByMaster).Kinds()
+            .ShouldBe([AddClaimForbideReason.Busy]);
+    }
+
+    [Fact]
+    public void MasterCantInviteIntoArchivedProject()
+    {
+        var archived = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.Archived);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, archived, ClaimOperation.AddByMaster).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectNotActive]);
+    }
+
+    // См. https://github.com/joinrpg/joinrpg-net/issues/4743 — пока это осознанно запрет.
+    [Fact]
+    public void MasterCantInviteIntoNpc()
+    {
+        Mock.Character.CharacterType = CharacterType.NonPlayer;
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByMaster).Kinds()
+            .ShouldBe([AddClaimForbideReason.Npc]);
+    }
+
+    [Fact]
+    public void MasterCantInviteIntoBusyCharacter()
+    {
+        _ = Mock.CreateApprovedClaim(Mock.Character, Mock.Master);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByMaster).Kinds()
+            .ShouldBe([AddClaimForbideReason.Busy]);
+    }
+
+    [Fact]
+    public void MasterCantInviteTwice()
+    {
+        _ = Mock.CreateClaim(Mock.Character, Mock.Player);
+
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByMaster).Kinds()
+            .ShouldBe([AddClaimForbideReason.AlreadySent]);
+    }
+
+    /// <summary>
+    /// Показ считается глазами игрока, кто бы страницу ни открыл: мастеру нельзя показывать, что
+    /// закрытый проект принимает заявки.
+    /// </summary>
+    [Fact]
+    public void DisplayNeverBypasses()
+        => Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, ClaimsClosed, ClaimOperation.DisplayForPlayer).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
+
+    [Fact]
+    public void IsAcceptingClaimsNeverBypasses()
+        => Mock.Character.IsAcceptingClaims(ClaimsClosed).ShouldBeFalse();
+}

--- a/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
@@ -53,6 +53,57 @@ public class MoveClaimValidationRulesTest
         ShouldAllowMove(claim, Mock.CreateCharacter("another"));
     }
 
+    // Перенос выполняет мастер, поэтому незаполненные контакты игрока ему не мешают: игрок эту
+    // заявку уже подал, требовать от мастера дозаполнить чужой профиль бессмысленно.
+    [Fact]
+    public void MasterCanMoveClaimOfPlayerWithoutRequiredContacts()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequirePhone = MandatoryStatus.Required });
+        var playerWithoutPhone = Mock.PlayerInfo with { PhoneNumber = null };
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanMoveClaim(claim, playerWithoutPhone, projectInfo)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MasterCanMoveClaimWhenClaimsClosed()
+    {
+        var claimsClosed = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.ActiveClaimsClosed);
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, claimsClosed)
+            .ShouldBeEmpty();
+    }
+
+    // ...но целостность данных обход мастером не отменяет.
+    [Fact]
+    public void MasterStillCantMoveCheckedInClaimWhenClaimsClosed()
+    {
+        var claimsClosed = Mock.ProjectInfo.WithChangedStatus(ProjectLifecycleStatus.ActiveClaimsClosed);
+        var claim = Mock.CreateCheckedInClaim(Mock.Character, Mock.Player);
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, claimsClosed).Kinds()
+            .ShouldBe([AddClaimForbideReason.CheckedInClaimCantBeMoved]);
+    }
+
+    // Правила переноса не должны срабатывать на подаче заявки: они гейтятся операцией, а не
+    // тем, передали ли существующую заявку.
+    [Fact]
+    public void MoveOnlyRulesDoNotApplyToAddingClaim()
+    {
+        var slot = Mock.CreateCharacter("slot");
+        slot.CharacterType = CharacterType.Slot;
+        slot.CharacterSlotLimit = null;
+
+        slot.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldNotContain(AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot);
+    }
+
     private void ShouldAllowMove(Claim claim, Character character) => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBeEmpty();
 
     private void ShouldDisAllowMove(Claim claim, Character character, AddClaimForbideReason reason)

--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -8,20 +8,38 @@ namespace JoinRpg.Domain;
 public static class ClaimAcceptOrMoveValidationExtensions
 {
     public static bool IsAcceptingClaims(this Character character, ProjectInfo projectInfo)
-        => !ValidateIfCanAddClaim(character, userInfo: null, projectInfo).Any();
+        => !ValidateIfCanAddClaim(character, userInfo: null, projectInfo, ClaimOperation.DisplayForPlayer).Any();
 
+    /// <summary>
+    /// Причины, по которым нельзя создать заявку на этого персонажа.
+    /// </summary>
+    /// <param name="userInfo">
+    /// Игрок, на которого оформляется заявка; <c>null</c> — если он неизвестен (тогда правила про
+    /// контакты и уже поданные заявки не считаются).
+    /// </param>
+    /// <param name="operation">
+    /// Для <see cref="ClaimOperation.DisplayForPlayer"/> мастерских послаблений нет: страница
+    /// показывает положение дел глазами игрока, кто бы её ни открыл.
+    /// </param>
     public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanAddClaim(
         this Character claimSource,
-        UserInfo? userInfo, ProjectInfo projectInfo)
-        => Validate(claimSource, userInfo, existingClaim: null, projectInfo);
+        UserInfo? userInfo, ProjectInfo projectInfo, ClaimOperation operation)
+        => Validate(claimSource, userInfo, existingClaim: null, projectInfo, operation);
 
     public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanMoveClaim(this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
-        => Validate(claimSource, userInfo, claim, projectInfo);
+        => Validate(claimSource, userInfo, claim, projectInfo, ClaimOperation.MoveByMaster);
 
-    public static void EnsureCanAddClaim([NotNull] this Character claimSource, UserInfo userInfo, ProjectInfo projectInfo)
+    /// <param name="userInfo">
+    /// Игрок, на которого оформляется заявка. При <see cref="ClaimOperation.AddByMaster"/> это не
+    /// тот, кто выполняет операцию: правила про контакты и уже поданные заявки относятся к игроку.
+    /// </param>
+    public static void EnsureCanAddClaim([NotNull] this Character claimSource, UserInfo userInfo, ProjectInfo projectInfo, ClaimOperation operation)
     {
         ArgumentNullException.ThrowIfNull(claimSource);
-        ThrowIfValidationFailed(claimSource.ValidateIfCanAddClaim(userInfo, projectInfo), claim: null, projectInfo);
+        ThrowIfValidationFailed(
+            claimSource.ValidateIfCanAddClaim(userInfo, projectInfo, operation),
+            claim: null,
+            projectInfo);
     }
 
     public static void EnsureCanMoveClaim([NotNull] this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
@@ -62,18 +80,29 @@ public static class ClaimAcceptOrMoveValidationExtensions
     }
 
     /// <summary>
-    /// Считает все причины запрета и отбрасывает те, которые не надо показывать.
+    /// Считает все причины запрета и отбрасывает те, которые не мешают этой операции.
     /// </summary>
     /// <remarks>
-    /// Если есть хотя бы одна фатальная причина (проект в архиве, приём заявок закрыт), остальные
-    /// не отдаём: пока проект в таком состоянии, разбираться с занятостью роли или контактами
-    /// игрока бессмысленно.
+    /// <para>
+    /// Сначала выбрасываются причины, которые мастер вправе обойти, и только потом применяется
+    /// фатальность. Порядок принципиален: если сделать наоборот, мастер, приглашающий игрока в
+    /// проект с закрытым приёмом заявок, увидел бы пустой список — фатальный
+    /// <c>ProjectClaimsClosed</c> вытеснил бы <c>Busy</c> и <c>Npc</c>, а потом ушёл бы сам,
+    /// и вместе с ним молча ушли бы все остальные проверки.
+    /// </para>
+    /// <para>
+    /// Фатальная причина (проект в архиве, приём заявок закрыт) вытесняет остальные: пока проект
+    /// в таком состоянии, разбираться с занятостью роли или контактами игрока бессмысленно.
+    /// </para>
     /// </remarks>
     private static List<ClaimForbiddenReason> Validate(
-        Character character, UserInfo? userInfo, Claim? existingClaim, ProjectInfo projectInfo)
+        Character character, UserInfo? userInfo, Claim? existingClaim, ProjectInfo projectInfo, ClaimOperation operation)
     {
-        var reasons = ValidateImpl(character, userInfo, existingClaim, projectInfo)
+        var byMaster = operation.PerformedByMaster();
+
+        var reasons = ValidateImpl(character, userInfo, existingClaim, projectInfo, operation)
             .Select(ClaimForbiddenReason.For)
+            .Where(r => !(byMaster && r.MasterCanOverride))
             .ToList();
 
         var fatal = reasons.Where(r => r.IsFatal).ToList();
@@ -88,7 +117,8 @@ public static class ClaimAcceptOrMoveValidationExtensions
     /// <param name="existingClaim">If we already have claim (move), that's it</param>
     /// <returns></returns>
     /// <param name="projectInfo"></param>
-    private static IEnumerable<AddClaimForbideReason> ValidateImpl(this Character character, UserInfo? playerUserId, Claim? existingClaim, ProjectInfo projectInfo)
+    /// <param name="operation">Операция, ради которой считаются правила.</param>
+    private static IEnumerable<AddClaimForbideReason> ValidateImpl(this Character character, UserInfo? playerUserId, Claim? existingClaim, ProjectInfo projectInfo, ClaimOperation operation)
     {
         var project = character.Project;
 
@@ -124,15 +154,17 @@ public static class ClaimAcceptOrMoveValidationExtensions
                 break;
         }
 
-        if (existingClaim?.IsApproved == true && character.CharacterType == CharacterType.Slot)
+        if (operation.IsMove())
         {
-            yield return AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot;
-        }
+            if (existingClaim?.IsApproved == true && character.CharacterType == CharacterType.Slot)
+            {
+                yield return AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot;
+            }
 
-
-        if (existingClaim?.ClaimStatus == ClaimStatus.CheckedIn)
-        {
-            yield return AddClaimForbideReason.CheckedInClaimCantBeMoved;
+            if (existingClaim?.ClaimStatus == ClaimStatus.CheckedIn)
+            {
+                yield return AddClaimForbideReason.CheckedInClaimCantBeMoved;
+            }
         }
 
         if (playerUserId is UserInfo userInfo)

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimOperation.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimOperation.cs
@@ -1,0 +1,48 @@
+namespace JoinRpg.DomainTypes.Characters.Claims;
+
+/// <summary>
+/// Операция с заявкой, для которой считаются причины запрета. От операции зависит и набор правил
+/// (правила переноса не применяются к подаче), и то, какие причины вправе обойти мастер.
+/// </summary>
+/// <remarks>
+/// Тут перечислены только те операции, для которых правила реально считаются. Ещё два мастерских
+/// пути — <c>MoveToSecondRole</c> и <c>RestoreByMaster</c> — сейчас идут мимо общей валидации;
+/// они появятся здесь вместе со своими исключениями из правил, см.
+/// https://github.com/joinrpg/joinrpg-net/issues/4744.
+/// </remarks>
+public enum ClaimOperation
+{
+    /// <summary>Игрок подаёт заявку сам.</summary>
+    AddByPlayer,
+
+    /// <summary>Мастер приглашает игрока на роль.</summary>
+    AddByMaster,
+
+    /// <summary>Мастер переносит существующую заявку на другого персонажа.</summary>
+    MoveByMaster,
+
+    /// <summary>
+    /// Не операция, а показ: «может ли игрок сюда заявиться» на странице персонажа, в сетке
+    /// ролей и на форме подачи заявки.
+    /// </summary>
+    DisplayForPlayer,
+}
+
+public static class ClaimOperationExtensions
+{
+    /// <summary>
+    /// Операцию выполняет мастер, а значит часть причин запрета он вправе обойти — см.
+    /// <see cref="ClaimForbiddenReason.MasterCanOverride"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ClaimOperation.DisplayForPlayer"/> сюда не входит намеренно: страница, которую
+    /// открыл мастер, не должна утверждать, что закрытый проект принимает заявки. Показ считается
+    /// от лица игрока независимо от того, кто смотрит.
+    /// </remarks>
+    public static bool PerformedByMaster(this ClaimOperation operation)
+        => operation is ClaimOperation.AddByMaster or ClaimOperation.MoveByMaster;
+
+    /// <summary>Операция переносит уже существующую заявку, а не создаёт новую.</summary>
+    public static bool IsMove(this ClaimOperation operation)
+        => operation is ClaimOperation.MoveByMaster;
+}

--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -152,7 +152,7 @@ internal class ClaimServiceImpl(
         var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(characterId.ProjectId);
         var user = await UserRepository.GetRequiredUserInfo(currentUserAccessor.UserIdentification);
 
-        source.EnsureCanAddClaim(user, projectInfo);
+        source.EnsureCanAddClaim(user, projectInfo, ClaimOperation.AddByPlayer);
 
         User responsibleMaster = source.GetResponsibleMaster();
 
@@ -991,9 +991,10 @@ internal class ClaimServiceImpl(
         // Проверяем, что текущий пользователь (мастер) имеет право управлять заявками
         projectInfo.RequestMasterAccess(currentUserAccessor, Permission.CanManageClaims);
 
-        // Проверяем, что персонаж может принимать заявки (пока со всеми проверками, включая ProjectClaimsClosed и ValidateContacts)
-        // TODO: Придумать способ, чтобы разрешить посылать приглашения, даже если заявки закрыты.
-        source.EnsureCanAddClaim(playerUser, projectInfo);
+        // Проверяем, что персонаж может принимать заявки. Приглашение от мастера проходит мимо
+        // причин с MasterCanOverride: закрытый приём заявок и незаполненные контакты игрока
+        // мастера не останавливают — контакты игрок дозаполнит позже.
+        source.EnsureCanAddClaim(playerUser, projectInfo, ClaimOperation.AddByMaster);
 
         User responsibleMaster = source.GetResponsibleMaster();
 

--- a/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
@@ -53,7 +53,7 @@ public class AddClaimViewModel : IProjectIdAware
 
     public AddClaimViewModel Fill(Character claimSource, UserInfo userInfo, ProjectInfo projectInfo, Dictionary<int, string?>? overrideValues = null)
     {
-        var disallowReasons = claimSource.ValidateIfCanAddClaim(userInfo, projectInfo);
+        var disallowReasons = claimSource.ValidateIfCanAddClaim(userInfo, projectInfo, ClaimOperation.DisplayForPlayer);
 
         // Фатальная причина означает, что заявку тут не подать в принципе (проект в архиве или
         // приём заявок закрыт) — форму показывать незачем.


### PR DESCRIPTION
## Что меняется для мастеров

**Приглашение игрока** (`AddClaimFromMaster`) теперь работает при закрытом приёме заявок и при незаполненных контактах игрока. Это закрывает давний TODO прямо в коде:

```
// TODO: Придумать способ, чтобы разрешить посылать приглашения, даже если заявки закрыты.
```

**Перенос заявки** (`MoveByMaster`) больше не упирается в контакты игрока. Раньше мастер не мог перенести заявку, если у игрока не заполнен телефон, — хотя заявка уже подана, а дозаполнить чужой профиль мастер всё равно не может.

**Что осталось запретом и для мастера:** `Busy`, `Npc`, `CharacterInactive`, `SlotsExhausted`, `AlreadySent`, `OnlyOneCharacter`, архив проекта и правила переноса. Про первые три — отдельное решение в #4743.

Показ (страница персонажа, сетка ролей, форма подачи) послаблений не получает: страница, открытая мастером, не должна утверждать, что закрытый проект принимает заявки.

## Как сделано

`ClaimOperation` (`AddByPlayer` / `AddByMaster` / `MoveByMaster` / `DisplayForPlayer`) параметризует правила. Заодно правила переноса теперь гейтятся операцией, а не тем, передали ли существующую заявку.

**Порядок фильтров принципиален** — сначала отбрасываются обходимые причины, и только потом применяется вытеснение по фатальности. Наоборот нельзя: фатальный `ProjectClaimsClosed` сначала вытеснил бы `Busy`, а потом ушёл бы сам как обходимый — и мастер смог бы пригласить игрока на уже занятую роль. На это есть отдельный тест (`MasterInvitingIntoClosedProjectStillSeesNonOverridableReasons`).

В enum намеренно только четыре операции. `MoveToSecondRole` и `RestoreByMaster` идут мимо общей валидации и требуют своих исключений из правил — они появятся вместе с ними в #4744; заводить значения enum, которые никто не передаёт и ничто не покрывает, смысла нет.

## Найденный по дороге баг: #4760 — уже починен

Тест «игрок без телефона не может подать заявку» неожиданно позеленел на пустом списке причин: проверки были написаны как `userInfo.PhoneNumber?.Length < 5`, а `null < 5` в C# равно `false` — игрок **вообще без телефона** проверку проходил.

Починено отдельно в #4762, который уже в master. После ребейза тесты здесь используют естественный случай — отсутствующий телефон, а не короткий.

## Тесты

`MasterBypassTest` — матрица «операция × причина»: что мастер обходит, что нет, и что показ не обходит ничего. Плюс тесты переноса при закрытом приёме заявок и без контактов игрока.

Полный прогон `dotnet test` зелёный, включая контейнерные `JoinRpg.IntegrationTest` и `JoinRpg.IdPortal.Test`. `dotnet format --verify-no-changes --severity warn` чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY


