### PR TITLE
diag: логировать подтягивание даты рождения из ВК при логине

### DIFF
--- a/src/JoinRpg.Services.Impl/UserServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/UserServiceImpl.cs
@@ -147,7 +147,15 @@ public class UserServiceImpl(
         var user = await UserRepository.WithProfile(userId.Value);
 
         user.Extra ??= new UserExtra();
-        user.Extra.BirthDate ??= birthDate.ToDateTime(TimeOnly.MinValue);
+
+        if (user.Extra.BirthDate is DateTime existing)
+        {
+            logger.LogInformation("Birth date for {userId} already set to {existing}, skipping value {birthDate} from external login", userId, existing, birthDate);
+            return;
+        }
+
+        logger.LogInformation("Setting birth date for {userId} to {birthDate} from external login", userId, birthDate);
+        user.Extra.BirthDate = birthDate.ToDateTime(TimeOnly.MinValue);
 
         await UnitOfWork.SaveChangesAsync();
     }

--- a/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
+++ b/src/Joinrpg.Web.Identity/ExternalLoginProfileExtractor.cs
@@ -3,13 +3,14 @@ using AspNet.Security.OAuth.Vkontakte;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.Services.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Joinrpg.Web.Identity;
 
 /// <summary>
 /// Task of this class is to extract useful data from social logins
 /// </summary>
-public class ExternalLoginProfileExtractor(IUserService userService, JoinUserManager userManager)
+public class ExternalLoginProfileExtractor(IUserService userService, JoinUserManager userManager, ILogger<ExternalLoginProfileExtractor> logger)
 {
     /// <summary>
     /// Removes external login and cleans up profile fields populated from it.
@@ -39,6 +40,8 @@ public class ExternalLoginProfileExtractor(IUserService userService, JoinUserMan
 
     public async Task TryExtractProfile(JoinIdentityUser user, ExternalLoginInfo loginInfo)
     {
+        logger.LogInformation("TryExtractProfile для {userId} по логину {loginProvider}", user.Id, loginInfo.LoginProvider);
+
         UserFullName userFullName = TryGetUserName(loginInfo);
         await userService.SetNameIfNotSetWithoutAccessChecks(user.Id, userFullName);
 
@@ -48,9 +51,15 @@ public class ExternalLoginProfileExtractor(IUserService userService, JoinUserMan
 
             await userService.SetVkIfNotSetWithoutAccessChecks(user.Id, vk, avatar);
 
-            if (VkBirthDateParser.TryParse(loginInfo.Principal.FindFirstValue(IdentityConfigurator.VkBirthDateClaimType), out var birthDate))
+            var rawBirthDate = loginInfo.Principal.FindFirstValue(IdentityConfigurator.VkBirthDateClaimType);
+            if (VkBirthDateParser.TryParse(rawBirthDate, out var birthDate))
             {
                 await userService.SetBirthDateIfNotSetWithoutAccessChecks(new UserIdentification(user.Id), birthDate);
+            }
+            else
+            {
+                logger.LogInformation("Не удалось получить дату рождения из ВК для {userId}: claim {claimType} = {rawBirthDate}",
+                    user.Id, IdentityConfigurator.VkBirthDateClaimType, rawBirthDate ?? "<null>");
             }
         }
     }


### PR DESCRIPTION
## Что сделано
- В `ExternalLoginProfileExtractor.TryExtractProfile` добавлен лог вызова (userId, loginProvider) и лог сырого значения claim `bdate`, когда его не удалось распарсить.
- В `UserServiceImpl.SetBirthDateIfNotSetWithoutAccessChecks` добавлен лог: записывается ли новая дата рождения или пропускается, т.к. уже установлена.

## Зачем
После #4758 подтягивание даты рождения при обычном логине через ВК на dev.joinrpg.ru всё ещё не работает, а видимости в логах, на каком шаге теряется дата, не было.

## Test plan
- [ ] Задеплоить на dev
- [ ] Повторно войти через ВК на dev.joinrpg.ru
- [ ] Проверить в логах: дошёл ли вызов до TryExtractProfile, какое сырое значение bdate пришло, записалась ли дата рождения

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01P3AimYPdHiH3qvJzEurZHV