### PR TITLE
refactor: ApprovedClaimMovedToGroupOrSlot → ApprovedClaimMovedToSlot

### DIFF
--- a/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
@@ -28,13 +28,13 @@ public class MoveClaimValidationRulesTest
     }
 
     [Fact]
-    public void CantMoveApprovedClaimFromCharacterToGroup()
+    public void CantMoveApprovedClaimFromCharacterToSlot()
     {
         var claim = Mock.CreateApprovedClaim(Mock.Character, Mock.Player);
         var another = Mock.CreateCharacter("another");
         another.CharacterType = CharacterType.Slot;
         another.CharacterSlotLimit = null;
-        ShouldDisAllowMove(claim, another, AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot);
+        ShouldDisAllowMove(claim, another, AddClaimForbideReason.ApprovedClaimMovedToSlot);
     }
 
 
@@ -101,7 +101,7 @@ public class MoveClaimValidationRulesTest
         slot.CharacterSlotLimit = null;
 
         slot.ValidateIfCanAddClaim(Mock.PlayerInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
-            .ShouldNotContain(AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot);
+            .ShouldNotContain(AddClaimForbideReason.ApprovedClaimMovedToSlot);
     }
 
     private void ShouldAllowMove(Claim claim, Character character) => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBeEmpty();

--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -72,7 +72,7 @@ public static class ClaimAcceptOrMoveValidationExtensions
             AddClaimForbideReason.AlreadySent => new ClaimAlreadyPresentException(),
             AddClaimForbideReason.OnlyOneCharacter => new OnlyOneApprovedClaimException(),
 
-            AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot or AddClaimForbideReason.CheckedInClaimCantBeMoved => new ClaimWrongStatusException(claim!),
+            AddClaimForbideReason.ApprovedClaimMovedToSlot or AddClaimForbideReason.CheckedInClaimCantBeMoved => new ClaimWrongStatusException(claim!),
             AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing or
             AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing => new InsufficientContactsException(),
             _ => new ArgumentOutOfRangeException(nameof(reason), reason.Kind, message: null),
@@ -158,7 +158,7 @@ public static class ClaimAcceptOrMoveValidationExtensions
         {
             if (existingClaim?.IsApproved == true && character.CharacterType == CharacterType.Slot)
             {
-                yield return AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot;
+                yield return AddClaimForbideReason.ApprovedClaimMovedToSlot;
             }
 
             if (existingClaim?.ClaimStatus == ClaimStatus.CheckedIn)

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimEnums.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimEnums.cs
@@ -33,7 +33,7 @@ public enum AddClaimForbideReason
     Busy,
     AlreadySent,
     OnlyOneCharacter,
-    ApprovedClaimMovedToGroupOrSlot,
+    ApprovedClaimMovedToSlot,
     CheckedInClaimCantBeMoved,
     CharacterInactive,
     RealNameMissing,

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
@@ -52,7 +52,7 @@ public record class ClaimForbiddenReason(
             => new(kind, MasterCanOverride: false, ProblemSeverity.Error),
 
         // Ограничения переноса заявки.
-        AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot
+        AddClaimForbideReason.ApprovedClaimMovedToSlot
             or AddClaimForbideReason.CheckedInClaimCantBeMoved
             => new(kind, MasterCanOverride: false, ProblemSeverity.Error),
 

--- a/src/JoinRpg.Web.Claims/AddClaimForbideReasonMessage.razor
+++ b/src/JoinRpg.Web.Claims/AddClaimForbideReasonMessage.razor
@@ -66,7 +66,7 @@
             <br /><JoinProfileButton />
     </JoinAlert>
         break;
-    case AddClaimForbideReason.ApprovedClaimMovedToGroupOrSlot:
+    case AddClaimForbideReason.ApprovedClaimMovedToSlot:
         <JoinAlert Variation="VariationStyleEnum.Warning">
             Утверждённую заявку нельзя перенести в слот «@CharacterName». Выберите конкретного персонажа.
         </JoinAlert>


### PR DESCRIPTION
## Что сделано

Заявок в группы больше нет, а название причины утверждало обратное. Правило срабатывает только на переносе утверждённой заявки **в слот**:

```csharp
if (existingClaim?.IsApproved == true && character.CharacterType == CharacterType.Slot)
```

Переименовано в `ApprovedClaimMovedToSlot`. Заодно тест `CantMoveApprovedClaimFromCharacterToGroup` → `CantMoveApprovedClaimFromCharacterToSlot`.

Переименование безопасно: `AddClaimForbideReason` нигде не сохраняется — снапшотом в `EnumVerifyTest` защищён только `CommentExtraAction`, а тот единственный enum, который «хранится в БД в виде числовых значений».

5 файлов, 8 строк. `dotnet build`, полный `dotnet test` и `dotnet format --verify-no-changes --severity warn` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY
