### PR TITLE
fix: парсить дату рождения из ВК без ведущего нуля в дне/месяце

### DIFF
--- a/src/JoinRpg.Domain.Test/VkBirthDateParserTest.cs
+++ b/src/JoinRpg.Domain.Test/VkBirthDateParserTest.cs
@@ -4,6 +4,7 @@ public class VkBirthDateParserTest
 {
     [Theory]
     [InlineData("15.06.1990", true, "1990-06-15")]
+    [InlineData("12.6.1985", true, "1985-06-12")]
     [InlineData("15.06", false, null)]
     [InlineData("", false, null)]
     [InlineData(null, false, null)]

--- a/src/JoinRpg.Domain/VkBirthDateParser.cs
+++ b/src/JoinRpg.Domain/VkBirthDateParser.cs
@@ -3,13 +3,14 @@ using System.Globalization;
 namespace JoinRpg.Domain;
 
 /// <summary>
-/// ВК отдаёт bdate либо как "dd.MM.yyyy", либо как "dd.MM" (год скрыт настройками приватности),
-/// либо не отдаёт вовсе. Нас интересует только полная дата с годом.
+/// ВК отдаёт bdate либо как "d.M.yyyy" (день/месяц без ведущего нуля, например "12.6.1985"),
+/// либо как "d.M" (год скрыт настройками приватности), либо не отдаёт вовсе.
+/// Нас интересует только полная дата с годом.
 /// </summary>
 public static class VkBirthDateParser
 {
     public static bool TryParse(string? raw, out DateOnly birthDate)
     {
-        return DateOnly.TryParseExact(raw, "dd.MM.yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out birthDate);
+        return DateOnly.TryParseExact(raw, "d.M.yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out birthDate);
     }
 }


### PR DESCRIPTION
## Что сделано
- `VkBirthDateParser` парсит `bdate` форматом `d.M.yyyy` вместо `dd.MM.yyyy` — ВК отдаёт день/месяц без ведущего нуля (например `"12.6.1985"`).
- Добавлен регрессионный тест-кейс `"12.6.1985"` в `VkBirthDateParserTest`.

## Зачем
Продолжение #4764 (диагностическое логирование). На dev.joinrpg.ru реальная попытка входа через ВК залогировала:

```
Не удалось получить дату рождения из ВК для 1: claim "urn:vkontakte:bdate" = "12.6.1985"
```

То есть ВК присылал полную дату с годом, но `DateOnly.TryParseExact(..., "dd.MM.yyyy", ...)` требовал ровно два знака в месяце и молча отклонял валидную дату — из-за этого автозаполнение даты рождения при логине через ВК (#4758) не срабатывало.

## Test plan
- [x] `dotnet test src/JoinRpg.Domain.Test --filter VkBirthDateParserTest` — 6/6 зелёные
- [ ] Задеплоить на dev, повторно войти через ВК, проверить что дата рождения подтянулась

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01P3AimYPdHiH3qvJzEurZHV