### PR TITLE
feat: доменные правила поверх SQL-выборки персонажей в списках выбора

### DIFF
--- a/src/JoinRpg.Portal/Views/CheckIn/SecondRole.cshtml
+++ b/src/JoinRpg.Portal/Views/CheckIn/SecondRole.cshtml
@@ -27,7 +27,7 @@
         <component type="typeof(JoinRpg.Web.ProjectCommon.CharacterSelector)"
                    param-Name="nameof(Model.CharacterId)"
                    param-ProjectId="new JoinRpg.DomainTypes.ProjectIdentification(Model.ProjectId)"
-                   param-ListType="JoinRpg.Web.ProjectCommon.CharacterListType.Available"
+                   param-ListType="JoinRpg.Web.ProjectCommon.CharacterListType.AvailableForMaster"
                    param-Multiple="false"
                    render-mode="Static" />
         @Html.ValidationMessageFor(model => model.CharacterId, "", new {@class = "text-danger"})

--- a/src/JoinRpg.Portal/Views/Claim/Edit.cshtml
+++ b/src/JoinRpg.Portal/Views/Claim/Edit.cshtml
@@ -329,9 +329,11 @@ new { Model.ProjectId, Model.Player.UserId }, null).
 new { Model.CharacterId, Model.ProjectId }, null)
                                 Вам необходимо выбрать, куда перенести эту заявку.
                             </div>
+                            @* RestoreByMaster переводит заявку в AddedByMaster, так что она не утверждена и слоты допустимы. *@
                             @(await Html.RenderComponentAsync<AvailClaimTargets>(RenderMode.WebAssembly, new {
                                 ProjectId = new ProjectIdentification(Model.ProjectId),
                                 CurrentCharacterId = new CharacterIdentification(Model.ProjectId, Model.CharacterId),
+                                ClaimIsApproved = false,
                             }))
                         }
                         else

--- a/src/JoinRpg.Portal/Views/Claim/MoveClaimOperationPartial.cshtml
+++ b/src/JoinRpg.Portal/Views/Claim/MoveClaimOperationPartial.cshtml
@@ -18,6 +18,7 @@
 @(await Html.RenderComponentAsync<AvailClaimTargets>(RenderMode.WebAssembly, new {
     ProjectId = new ProjectIdentification(Model.ProjectId),
     CurrentCharacterId = new CharacterIdentification(Model.ProjectId, Model.CurrentCharacterId),
+    ClaimIsApproved = Model.IsAlreadyAccepted,
 }))
 <div class="form-horizontal">
     @Html.ValidationSummary(true, "", new { @class = "text-danger" })

--- a/src/JoinRpg.Web.Claims/AvailClaimTargets.razor
+++ b/src/JoinRpg.Web.Claims/AvailClaimTargets.razor
@@ -1,12 +1,22 @@
 <FormHorizontal>
     <FormRow Label="Переместить заявку">
-        <SingleCharacterSelector Name="characterId" ProjectId="@ProjectId" ListType="@CharacterListType.Available" AllowEmpty="false" ExcludeCharacterIds="@excludeCharacterIds" />
+        <SingleCharacterSelector Name="characterId" ProjectId="@ProjectId" ListType="@listType" AllowEmpty="false" ExcludeCharacterIds="@excludeCharacterIds" />
     </FormRow>
 </FormHorizontal>
 
 @code {
     [Parameter, EditorRequired] public ProjectIdentification ProjectId { get; set; }
     [Parameter, EditorRequired] public CharacterIdentification CurrentCharacterId { get; set; }
+
+    /// <summary>
+    /// Утверждённую заявку нельзя перенести в слот, поэтому слоты в список не попадают.
+    /// См. AddClaimForbideReason.ApprovedClaimMovedToSlot.
+    /// </summary>
+    [Parameter] public bool ClaimIsApproved { get; set; }
+
+    private CharacterListType listType => ClaimIsApproved
+        ? CharacterListType.AvailableNonSlotsForMaster
+        : CharacterListType.AvailableForMaster;
 
     private CharacterIdentification[] excludeCharacterIds => [CurrentCharacterId];
 }

--- a/src/JoinRpg.Web.Claims/InvitePlayer.razor
+++ b/src/JoinRpg.Web.Claims/InvitePlayer.razor
@@ -65,7 +65,7 @@
     private string? successMessage = null;
 
     private CharacterListType characterListType =>
-        HasMultiplePlayers(model.UserLinks) ? CharacterListType.AvailableTemplates : CharacterListType.Available;
+        HasMultiplePlayers(model.UserLinks) ? CharacterListType.AvailableTemplatesForMaster : CharacterListType.AvailableForMaster;
 
     private static bool HasMultiplePlayers(List<string> userLinks) => userLinks.Count(l => !string.IsNullOrWhiteSpace(l)) > 1;
 

--- a/src/JoinRpg.Web.ProjectCommon/ICharactersClient.cs
+++ b/src/JoinRpg.Web.ProjectCommon/ICharactersClient.cs
@@ -5,12 +5,39 @@ public interface ICharactersClient
     Task<List<CharacterDto>> GetCharacters(ProjectIdentification projectId, CharacterListType listType = CharacterListType.All);
 }
 
+/// <summary>
+/// Какой набор персонажей показать в списке выбора.
+/// </summary>
+/// <remarks>
+/// Варианты <c>*ForMaster</c> считаются от лица мастера: они включают персонажей в проекте с
+/// закрытым приёмом заявок, потому что мастер вправе туда приглашать и переносить заявки. В
+/// игроцком UI использовать их нельзя.
+/// </remarks>
 public enum CharacterListType
 {
     All,
     AllTemplates,
-    Available,
-    AvailableNonSlots,
-    AvailableTemplates,
+
+    /// <summary>Куда мастер может создать или перенести заявку.</summary>
+    AvailableForMaster,
+
+    /// <summary>
+    /// То же, но без слотов. Нужен для переноса утверждённой заявки: в слот её перенести нельзя,
+    /// см. <c>AddClaimForbideReason.ApprovedClaimMovedToSlot</c>.
+    /// </summary>
+    AvailableNonSlotsForMaster,
+
+    /// <summary>Только слоты, куда мастер может создать заявку.</summary>
+    AvailableTemplatesForMaster,
 }
 
+public static class CharacterListTypeExtensions
+{
+    /// <summary>
+    /// Списку нужен точный ответ доменных правил поверх грубого SQL-префильтра.
+    /// </summary>
+    public static bool RequiresAvailabilityCheck(this CharacterListType listType)
+        => listType is CharacterListType.AvailableForMaster
+            or CharacterListType.AvailableNonSlotsForMaster
+            or CharacterListType.AvailableTemplatesForMaster;
+}

--- a/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/CharacterListViewServiceTest.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/CharacterGroups/CharacterListViewServiceTest.cs
@@ -1,0 +1,231 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.Interfaces;
+using JoinRpg.Web.ProjectCommon;
+using JoinRpg.WebPortal.Managers.CharacterGroupList;
+
+namespace JoinRpg.WebPortal.Managers.Test.CharacterGroups;
+
+/// <summary>
+/// Списки <c>*ForMaster</c> считаются в два шага: грубый SQL-префильтр, поверх которого
+/// накладываются доменные правила заявки. Здесь проверяется именно композиция.
+/// </summary>
+public class CharacterListViewServiceTest
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    private async Task<List<CharacterDto>> GetList(CharacterListType listType, ProjectInfo? projectInfo = null)
+    {
+        var service = new CharacterListViewService(
+            new FakeCharacterRepository(Mock),
+            new FakeProjectMetadataRepository(projectInfo ?? Mock.ProjectInfo),
+            new FakeCurrentUserAccessor { UserIdentification = new UserIdentification(Mock.Master.UserId) });
+
+        return await service.GetCharacters(Mock.ProjectInfo.ProjectId, listType);
+    }
+
+    private async Task<IReadOnlyCollection<string>> GetNames(CharacterListType listType, ProjectInfo? projectInfo = null)
+        => [.. (await GetList(listType, projectInfo)).Select(x => x.Name)];
+
+    [Fact]
+    public async Task OrdinaryCharacterIsAvailable()
+        => (await GetNames(CharacterListType.AvailableForMaster)).ShouldContain(Mock.Character.CharacterName);
+
+    /// <summary>
+    /// Главный регресс: SQL-префильтр про лимит слота не знает, и раньше исчерпанный слот
+    /// доезжал до выпадашки — мастер выбирал его и получал SlotsExhausted только при отправке.
+    /// </summary>
+    [Fact]
+    public async Task ExhaustedSlotIsNotAvailable()
+    {
+        var slot = CreateSlot("exhausted", slotLimit: 0);
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldNotContain(slot.CharacterName);
+    }
+
+    [Fact]
+    public async Task SlotWithFreePlacesIsAvailable()
+    {
+        var slot = CreateSlot("with places", slotLimit: 3);
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldContain(slot.CharacterName);
+    }
+
+    [Fact]
+    public async Task UnlimitedSlotIsAvailable()
+    {
+        var slot = CreateSlot("unlimited", slotLimit: null);
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldContain(slot.CharacterName);
+    }
+
+    [Fact]
+    public async Task BusyCharacterIsNotAvailable()
+    {
+        var busy = Mock.CreateCharacter("busy");
+        _ = Mock.CreateApprovedClaim(busy, Mock.Player);
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldNotContain(busy.CharacterName);
+    }
+
+    /// <summary>
+    /// NPC отсекается доменными правилами, даже если легаси-колонка
+    /// <c>Character.IsAcceptingClaims</c>, на которую смотрит SQL-префильтр, разъехалась с
+    /// <c>CharacterType</c> у старых записей.
+    /// </summary>
+    [Fact]
+    public async Task NpcIsNotAvailableEvenWithStaleLegacyFlag()
+    {
+        var npc = Mock.CreateCharacter("npc");
+        npc.CharacterType = CharacterType.NonPlayer;
+        npc.IsAcceptingClaims = true;
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldNotContain(npc.CharacterName);
+    }
+
+    [Fact]
+    public async Task InactiveCharacterIsNotAvailable()
+    {
+        var inactive = Mock.CreateCharacter("inactive");
+        inactive.IsActive = false;
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldNotContain(inactive.CharacterName);
+    }
+
+    /// <summary>
+    /// Список считается от лица мастера: закрытый приём заявок его не опустошает. Если бы фильтр
+    /// звался с DisplayForPlayer, фатальный ProjectClaimsClosed вычистил бы список целиком и
+    /// мастер не смог бы никого пригласить.
+    /// </summary>
+    [Fact]
+    public async Task ClaimsClosedDoesNotEmptyListForMaster()
+    {
+        Mock.Project.IsAcceptingClaims = false;
+        Mock.ReInitProjectInfo();
+        Mock.ProjectInfo.ProjectStatus.ShouldBe(ProjectLifecycleStatus.ActiveClaimsClosed);
+
+        (await GetNames(CharacterListType.AvailableForMaster)).ShouldContain(Mock.Character.CharacterName);
+    }
+
+    // А вот архив не обходится никем.
+    [Fact]
+    public async Task ArchivedProjectHasNoAvailableCharacters()
+    {
+        Mock.Project.Active = false;
+        Mock.Project.IsAcceptingClaims = false;
+        Mock.ReInitProjectInfo();
+        Mock.ProjectInfo.ProjectStatus.ShouldBe(ProjectLifecycleStatus.Archived);
+
+        (await GetList(CharacterListType.AvailableForMaster)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonSlotsListHasNoSlots()
+    {
+        var slot = CreateSlot("with places", slotLimit: 3);
+
+        var names = await GetNames(CharacterListType.AvailableNonSlotsForMaster);
+
+        names.ShouldNotContain(slot.CharacterName);
+        names.ShouldContain(Mock.Character.CharacterName);
+    }
+
+    [Fact]
+    public async Task TemplatesListHasOnlySlots()
+    {
+        var slot = CreateSlot("with places", slotLimit: 3);
+
+        var names = await GetNames(CharacterListType.AvailableTemplatesForMaster);
+
+        names.ShouldBe([slot.CharacterName]);
+    }
+
+    [Fact]
+    public async Task ExhaustedSlotIsNotInTemplatesList()
+    {
+        var slot = CreateSlot("exhausted", slotLimit: 0);
+
+        (await GetNames(CharacterListType.AvailableTemplatesForMaster)).ShouldNotContain(slot.CharacterName);
+    }
+
+    // Списки без "ForMaster" доменными правилами не фильтруются — они не про доступность.
+    [Fact]
+    public async Task AllListIsNotFilteredByAvailability()
+    {
+        var busy = Mock.CreateCharacter("busy");
+        _ = Mock.CreateApprovedClaim(busy, Mock.Player);
+
+        (await GetNames(CharacterListType.All)).ShouldContain(busy.CharacterName);
+    }
+
+    private Character CreateSlot(string name, int? slotLimit)
+    {
+        var slot = Mock.CreateCharacter(name);
+        slot.CharacterType = CharacterType.Slot;
+        slot.CharacterSlotLimit = slotLimit;
+        return slot;
+    }
+
+    /// <summary>
+    /// Повторяет в памяти SQL-предикат <c>CharacterPredicates.IsAvailable</c> — тот самый грубый
+    /// префильтр, поверх которого сервис накладывает доменные правила.
+    /// </summary>
+    private sealed class FakeCharacterRepository(MockedProject mock) : ICharacterRepository
+    {
+        private IEnumerable<Character> Available => mock.Project.Characters
+            .Where(character => character.IsAcceptingClaims
+                && character.IsActive
+                && !mock.Project.Claims.Any(claim => claim.IsApproved && claim.CharacterId == character.CharacterId));
+
+        public Task<IEnumerable<Character>> GetAvailableCharacters(ProjectIdentification projectId)
+            => Task.FromResult(Available);
+
+        public Task<IEnumerable<Character>> GetAvailableNonSlotCharacters(ProjectIdentification projectId)
+            => Task.FromResult(Available.Where(c => c.CharacterType != CharacterType.Slot));
+
+        public Task<IEnumerable<Character>> GetAvailableTemplateCharacters(ProjectIdentification projectId)
+            => Task.FromResult(Available.Where(c => c.CharacterType == CharacterType.Slot));
+
+        public Task<IEnumerable<Character>> GetAllCharacters(int projectId)
+            => Task.FromResult<IEnumerable<Character>>(mock.Project.Characters);
+
+        public Task<IEnumerable<Character>> GetActiveTemplateCharacters(int projectId)
+            => Task.FromResult(mock.Project.Characters.Where(c => c.IsActive && c.CharacterType == CharacterType.Slot));
+
+        public void Dispose() { }
+
+        public Task<IReadOnlyCollection<CharacterHeader>> GetCharacterHeaders(int projectId, DateTime? modifiedSince) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<Character>> GetCharacters(IReadOnlyCollection<CharacterIdentification> characterIds) => throw new NotImplementedException();
+        [Obsolete]
+        public Task<Character> GetCharacterAsync(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterAsync(CharacterIdentification characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterWithGroups(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterWithDetails(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<CharacterView> GetCharacterViewAsync(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<Character>> LoadCharactersWithGroups(IReadOnlyCollection<CharacterIdentification> characterIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<Character>> LoadCharactersWithGroups(ProjectIdentification projectId) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeProjectMetadataRepository(ProjectInfo projectInfo) : IProjectMetadataRepository
+    {
+        public Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId, bool ignoreCache = false)
+            => Task.FromResult(projectInfo);
+
+        public Task<DomainTypes.ProjectMetadata.ProjectDetails> GetProjectDetails(ProjectIdentification projectId)
+            => Task.FromResult(new DomainTypes.ProjectMetadata.ProjectDetails(new MarkdownString(""), [], false));
+
+        public void PrimeCache(ProjectInfo projectInfo) { }
+    }
+
+    private sealed class FakeCurrentUserAccessor : ICurrentUserAccessor
+    {
+        public UserIdentification UserIdentification { get; set; } = new UserIdentification(0);
+        public int? UserIdOrDefault => UserIdentification.Value;
+        public UserDisplayName DisplayName => new UserDisplayName("Test Master", null);
+        public bool IsAdmin => false;
+        public AvatarIdentification? Avatar => null;
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/CharacterGroupList/CharacterListViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/CharacterGroupList/CharacterListViewService.cs
@@ -1,6 +1,7 @@
 using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Interfaces;
 using JoinRpg.Markdown;
 using JoinRpg.Web.ProjectCommon;
@@ -18,12 +19,29 @@ public class CharacterListViewService(
         {
             CharacterListType.All => await characterRepository.GetAllCharacters(projectId),
             CharacterListType.AllTemplates => await characterRepository.GetActiveTemplateCharacters(projectId),
-            CharacterListType.Available => await characterRepository.GetAvailableCharacters(projectId),
-            CharacterListType.AvailableNonSlots => await characterRepository.GetAvailableNonSlotCharacters(projectId),
-            CharacterListType.AvailableTemplates => await characterRepository.GetAvailableTemplateCharacters(projectId),
+            CharacterListType.AvailableForMaster => await characterRepository.GetAvailableCharacters(projectId),
+            CharacterListType.AvailableNonSlotsForMaster => await characterRepository.GetAvailableNonSlotCharacters(projectId),
+            CharacterListType.AvailableTemplatesForMaster => await characterRepository.GetAvailableTemplateCharacters(projectId),
             _ => throw new ArgumentOutOfRangeException(nameof(listType), listType, null)
         };
         var project = await projectMetadataRepository.GetProjectMetadata(projectId);
+
+        if (listType.RequiresAvailabilityCheck())
+        {
+            // SQL-предикат (CharacterPredicates.IsAvailable) — только грубый префильтр: он не знает
+            // ни про лимит слота, ни про статус проекта. Точный ответ даёт общий движок правил.
+            //
+            // AddByMaster, а не DisplayForPlayer: все потребители этих списков — мастерские
+            // операции, и мастер вправе заявлять в проект с закрытым приёмом заявок. С
+            // DisplayForPlayer фатальный ProjectClaimsClosed вычистил бы весь список.
+            //
+            // ВАЖНО: при userInfo: null правила читают только скалярные поля уже загруженной
+            // сущности. Если в них появится обращение к character.Claims или character.Project
+            // вне ветки "известен игрок", здесь будет ленивая подгрузка на каждого персонажа.
+            characters = characters.Where(character =>
+                character.ValidateIfCanAddClaim(userInfo: null, project, ClaimOperation.AddByMaster).Count == 0);
+        }
+
         var masterAccess = project.HasMasterAccess(currentUserAccessor);
         return [.. characters
             .Select(CreateDto)


### PR DESCRIPTION
Часть [#4766](https://github.com/joinrpg/joinrpg-net/issues/4766).

## Проблема

Выпадашка выбора персонажа (приглашение игрока, перенос заявки, вторая роль) наполняется SQL-предикатом `CharacterPredicates.IsAvailable`, а доменные правила заявки поверх него **не применялись**. Единственный фильтр в памяти в `CharacterListViewService` — `.Where(x => masterAccess || x.IsPublic)`, и он про видимость, а не про доступность.

Мастер видел в списке то, чего выбрать нельзя, и узнавал об этом только при отправке формы:

1. **Слоты с исчерпанным лимитом** — SQL про `CharacterSlotLimit` не знает, на выходе `SlotsExhausted`.
2. **Слоты при переносе утверждённой заявки** — запрещено правилом `ApprovedClaimMovedToSlot`, но список этого не учитывал.

Для второго случая механизм уже был написан и просто **никем не использовался**: `CharacterListType.AvailableNonSlots` и `GetAvailableNonSlotCharacters` добавлены в c29ea1572 (closes #4232), а потребителя им тогда не сделали. Теперь он есть.

## Что сделано

**SQL-предикат становится грубым префильтром**, точный ответ даёт общий движок правил — один `if` в `CharacterListViewService.GetCharacters`.

**`Available*` → `*ForMaster`.** Имя должно говорить, что список считается от лица мастера: он включает персонажей в проекте с закрытым приёмом заявок. Со старым именем `Available` это неочевидно и провоцирует использование в игроцком UI. Enum ездит по HTTP строкой, но клиент и сервер деплоятся вместе, а в БД он не хранится.

**`AvailClaimTargets` получил параметр `ClaimIsApproved`** и выбирает `AvailableNonSlotsForMaster`. `MoveClaimOperationPartial.cshtml` передаёт `Model.IsAlreadyAccepted` (свойство уже было и используется рядом для предупреждения); форма `RestoreByMaster` в `Edit.cshtml` передаёт `false` — восстановление переводит заявку в `AddedByMaster`, то есть она не утверждена.

## Почему `AddByMaster` для всех списков

Для списка **без конкретного игрока и без конкретной заявки** `AddByMaster` и `MoveByMaster` дают одинаковый результат: правила игрока (`AlreadySent`, `OnlyOneCharacter`, контакты) считаются только при `userInfo != null`, а правила переноса требуют `existingClaim`, которого у списка нет. Различие «в слот нельзя» выражается выбором типа списка.

`DisplayForPlayer` здесь нельзя: фатальный `ProjectClaimsClosed` вычистил бы список целиком, и мастер не смог бы никого пригласить в проект с закрытым приёмом заявок. На это есть тест.

## N+1 не будет

Главный риск — и он снят: при `userInfo: null` правила читают только скалярные поля уже загруженной сущности (`ApprovedClaimId`, `IsActive`, `CharacterType`, `CharacterSlotLimit`). К навигационным `character.Claims` и `character.Project.Claims` движок обращается исключительно внутри ветки «известен игрок». В коде на это стоит комментарий.

## Тесты

Новый `CharacterListViewServiceTest`, 13 тестов. Фейк репозитория повторяет SQL-предикат в памяти, так что проверяется именно композиция «префильтр + доменные правила»:

- исчерпанный слот **не** в списке (главный регресс), слот с местами и безлимитный — в списке;
- занятый персонаж и неактивный — не в списке;
- NPC отсекается доменными правилами, **даже если легаси-колонка `Character.IsAcceptingClaims` разъехалась** с `CharacterType` у старой записи;
- при закрытом приёме заявок список **не пустеет**, при архиве — пустой;
- `AvailableNonSlotsForMaster` без слотов, `AvailableTemplatesForMaster` только со слотами;
- `All` фильтром не затронут.

Полный `dotnet test` и `dotnet format --verify-no-changes --severity warn` зелёные.

## Не входит

Вторая роль (`SecondRole.cshtml`) остаётся на `AvailableForMaster`. `MoveToSecondRole` создаёт заявку сразу в статусе `Approved`, так что по той же логике слоты стоило бы исключить, — но этот путь вообще не проходит валидацию, и менять только выпадашку half-way. Отмечено в #4744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY

