### PR TITLE
refactor: UserInfo.ActiveClaims хранит статусы заявок

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/UserInfoRepository.cs
@@ -107,7 +107,7 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
                 user.Email,
                 user.ExternalLogins,
                 user.Extra.Telegram,
-                Claims = user.Claims.Where(claim => activeclaimsPredicate.Invoke(claim)).Select(claim => new { claim.ClaimId, claim.ProjectId }),
+                Claims = user.Claims.Where(claim => activeclaimsPredicate.Invoke(claim)).Select(claim => new { claim.ClaimId, claim.ProjectId, claim.ClaimStatus }),
                 Projects = user.ProjectAcls.Select(acl => new { acl.ProjectId, acl.Project.Active }),
                 user.Auth.IsAdmin,
                 user.Extra!.Livejournal,
@@ -146,7 +146,7 @@ internal class UserInfoRepository(MyDbContext ctx) : IUserRepository, IUserSubsc
         return new UserInfo(
             new UserIdentification(result.UserId),
             new UserSocialNetworks(telegram, result.Livejournal, result.AllRpgInfoId, vk, result.SocialNetworksAccess),
-            result.Claims.Select(c => new ClaimIdentification(c.ProjectId, c.ClaimId)).ToList(),
+            result.Claims.Select(c => new UserClaimInfo(new ClaimIdentification(c.ProjectId, c.ClaimId), c.ClaimStatus)).ToList(),
             result.Projects.Where(p => p.Active).Select(p => new ProjectIdentification(p.ProjectId)).ToList(),
             result.Projects.Select(p => new ProjectIdentification(p.ProjectId)).ToList(),
             result.IsAdmin,

--- a/src/JoinRpg.DataModel.Mocks/MockedProject.cs
+++ b/src/JoinRpg.DataModel.Mocks/MockedProject.cs
@@ -14,7 +14,22 @@ public class MockedProject
     public Project Project { get; }
     public CharacterGroup Group { get; }
     public User Player { get; } = new User() { UserId = 1, PrefferedName = "Player", Email = "player@example.com", Claims = new HashSet<Claim>() };
-    public UserInfo PlayerInfo = new UserInfo(new UserIdentification(1), Social: new UserSocialNetworks(null, null, null, null, ContactsAccessType.Public), [], [], [], IsAdmin: false, SelectedAvatarId: null, new Email("player@example.com"), EmailConfirmed: true, new UserFullName(new PrefferedName("Player"), null, null, null), false, null, HasPassword: false);
+    private UserInfo PlayerInfoTemplate { get; } = new UserInfo(new UserIdentification(1), Social: new UserSocialNetworks(null, null, null, null, ContactsAccessType.Public), [], [], [], IsAdmin: false, SelectedAvatarId: null, new Email("player@example.com"), EmailConfirmed: true, new UserFullName(new PrefferedName("Player"), null, null, null), false, null, HasPassword: false);
+
+    /// <summary>
+    /// <see cref="UserInfo"/> игрока, согласованный с заявками мока.
+    /// </summary>
+    /// <remarks>
+    /// Именно свойство, а не поле: правила заявки читают <see cref="UserInfo.ActiveClaims"/>, и
+    /// если зафиксировать его на момент создания мока, заявки, созданные тестом позже, туда не
+    /// попадут — а правила молча решат, что заявок у игрока нет.
+    /// </remarks>
+    public UserInfo PlayerInfo => PlayerInfoTemplate with
+    {
+        ActiveClaims = [.. Player.Claims
+            .Where(claim => claim.ClaimStatus.IsActive())
+            .Select(claim => new UserClaimInfo(claim.GetId(), claim.ClaimStatus))],
+    };
     public User Master { get; } = new User() { UserId = 2, PrefferedName = "Master", Email = "master@example.com", Claims = new HashSet<Claim>() };
 
     public ProjectFieldInfo MasterOnlyFieldInfo { get; set; }

--- a/src/JoinRpg.Domain.Test/AddClaim/OnlyOneCharacterRuleTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/OnlyOneCharacterRuleTest.cs
@@ -1,0 +1,108 @@
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.DomainTypes.Users;
+
+namespace JoinRpg.Domain.Test.AddClaim;
+
+/// <summary>
+/// Правило «в проекте допустима только одна утверждённая заявка» считается по
+/// <see cref="UserInfo.ActiveClaims"/>, а не по заявкам всего проекта из EF-графа.
+/// </summary>
+public class OnlyOneCharacterRuleTest
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    private UserInfo WithClaims(params UserClaimInfo[] claims)
+        => Mock.PlayerInfo with { ActiveClaims = claims };
+
+    private ClaimIdentification ClaimIn(ProjectIdentification projectId, int claimId)
+        => new(projectId, claimId);
+
+    [Fact]
+    public void ApprovedClaimInSameProjectBlocksNewClaim()
+    {
+        var userInfo = WithClaims(
+            new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 100), ClaimStatus.Approved));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanAddClaim(userInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    [Fact]
+    public void CheckedInClaimCountsAsApproved()
+    {
+        var userInfo = WithClaims(
+            new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 100), ClaimStatus.CheckedIn));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanAddClaim(userInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    [Fact]
+    public void UnapprovedClaimDoesNotBlock()
+    {
+        var userInfo = WithClaims(
+            new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 100), ClaimStatus.AddedByUser));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanAddClaim(userInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldNotContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    /// <summary>
+    /// Правило про этот проект, а не про все сразу: утверждённая заявка на другой игре не мешает.
+    /// </summary>
+    [Fact]
+    public void ApprovedClaimInAnotherProjectDoesNotBlock()
+    {
+        var anotherProject = new ProjectIdentification(Mock.ProjectInfo.ProjectId.Value + 1);
+        var userInfo = WithClaims(new UserClaimInfo(ClaimIn(anotherProject, 100), ClaimStatus.Approved));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanAddClaim(userInfo, Mock.ProjectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldNotContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    /// <summary>
+    /// При переносе сама переносимая заявка не считается: иначе мастер не смог бы перенести
+    /// утверждённую заявку никуда.
+    /// </summary>
+    [Fact]
+    public void MovedClaimItselfDoesNotBlockMove()
+    {
+        var claim = Mock.CreateApprovedClaim(Mock.Character, Mock.Player);
+        var userInfo = WithClaims(new UserClaimInfo(claim.GetId(), ClaimStatus.Approved));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanMoveClaim(claim, userInfo, Mock.ProjectInfo).Kinds()
+            .ShouldNotContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    [Fact]
+    public void AnotherApprovedClaimStillBlocksMove()
+    {
+        var claim = Mock.CreateApprovedClaim(Mock.Character, Mock.Player);
+        var userInfo = WithClaims(
+            new UserClaimInfo(claim.GetId(), ClaimStatus.Approved),
+            new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 999), ClaimStatus.Approved));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanMoveClaim(claim, userInfo, Mock.ProjectInfo).Kinds()
+            .ShouldContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+
+    [Fact]
+    public void SettingOffDisablesRule()
+    {
+        var projectInfo = Mock.ProjectInfo.WithAllowManyClaims(strictlyOneCharacter: false);
+        var userInfo = WithClaims(
+            new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 100), ClaimStatus.Approved));
+
+        Mock.CreateCharacter("another")
+            .ValidateIfCanAddClaim(userInfo, projectInfo, ClaimOperation.AddByPlayer).Kinds()
+            .ShouldNotContain(AddClaimForbideReason.OnlyOneCharacter);
+    }
+}

--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -120,8 +120,6 @@ public static class ClaimAcceptOrMoveValidationExtensions
     /// <param name="operation">Операция, ради которой считаются правила.</param>
     private static IEnumerable<AddClaimForbideReason> ValidateImpl(this Character character, UserInfo? playerUserId, Claim? existingClaim, ProjectInfo projectInfo, ClaimOperation operation)
     {
-        var project = character.Project;
-
         if (ValidateProjectImpl(projectInfo) is AddClaimForbideReason projectReason)
         {
             yield return projectReason;
@@ -174,9 +172,7 @@ public static class ClaimAcceptOrMoveValidationExtensions
                 yield return AddClaimForbideReason.AlreadySent;
             }
 
-            // TODO вот здесь бы проверять по UserInfo
-            if (projectInfo.ClaimSettings.StrictlyOneCharacter &&
-                project.Claims.OfUserApproved(userInfo.UserId.Value).Except([existingClaim]).Any())
+            if (projectInfo.ClaimSettings.StrictlyOneCharacter && HasOtherApprovedClaim(userInfo, projectInfo, existingClaim))
             {
                 yield return AddClaimForbideReason.OnlyOneCharacter;
             }
@@ -186,6 +182,23 @@ public static class ClaimAcceptOrMoveValidationExtensions
                 yield return r;
             }
         }
+    }
+
+    /// <summary>
+    /// У игрока уже есть утверждённая заявка в этом проекте — не считая той, которую переносим.
+    /// </summary>
+    /// <remarks>
+    /// Считается по <see cref="UserInfo.ActiveClaims"/>, а не по заявкам всего проекта из EF-графа:
+    /// правилам не нужны чужие заявки, а поднимать ради этого весь граф дорого.
+    /// </remarks>
+    private static bool HasOtherApprovedClaim(UserInfo userInfo, ProjectInfo projectInfo, Claim? existingClaim)
+    {
+        var existingClaimId = existingClaim?.GetId();
+
+        return userInfo.ActiveClaims.Any(claim =>
+            claim.ProjectId == projectInfo.ProjectId
+            && claim.IsApproved
+            && claim.ClaimId != existingClaimId);
     }
 
     private static IEnumerable<AddClaimForbideReason> ValidateContacts(ProjectInfo projectInfo, UserInfo userInfo)

--- a/src/JoinRpg.Domain/UserExtensions.cs
+++ b/src/JoinRpg.Domain/UserExtensions.cs
@@ -1,4 +1,5 @@
 using JoinRpg.Common.PrimitiveTypes.Users;
+using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Domain;
@@ -16,7 +17,8 @@ public static class UserExtensions
         return new UserInfo(
             user.GetId(),
             new UserSocialNetworks(telegram, user.Extra?.Livejournal, user.Allrpg?.Sid, vk, user.Extra?.SocialNetworksAccess ?? ContactsAccessType.Public),
-            user.Claims.Select(c => c.GetId()).ToList(),
+            // Поле называется ActiveClaims — фильтр по активности тут был потерян.
+            [.. user.Claims.Where(c => c.ClaimStatus.IsActive()).Select(c => new UserClaimInfo(c.GetId(), c.ClaimStatus))],
             user.ProjectAcls.Where(p => p.Project.Active).Select(p => new ProjectIdentification(p.ProjectId)).ToList(),
             user.ProjectAcls.Select(p => new ProjectIdentification(p.ProjectId)).ToList(),
             user.Auth.IsAdmin,

--- a/src/JoinRpg.DomainTypes/Users/UserClaimInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserClaimInfo.cs
@@ -1,0 +1,20 @@
+using JoinRpg.DomainTypes.Characters.Claims;
+
+namespace JoinRpg.DomainTypes.Users;
+
+/// <summary>
+/// Заявка пользователя в составе <see cref="UserInfo"/> — идентификатор и статус, без полей и
+/// финансов.
+/// </summary>
+/// <remarks>
+/// Нужен, чтобы правила заявки могли отвечать на вопрос «есть ли у игрока утверждённая заявка в
+/// этом проекте», не поднимая заявки всего проекта из EF-графа.
+/// </remarks>
+public record class UserClaimInfo(ClaimIdentification ClaimId, ClaimStatus Status)
+{
+    public ProjectIdentification ProjectId => ClaimId.ProjectId;
+
+    public bool IsApproved => Status is ClaimStatus.Approved or ClaimStatus.CheckedIn;
+
+    public bool IsActive => Status.IsActive();
+}

--- a/src/JoinRpg.DomainTypes/Users/UserInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserInfo.cs
@@ -6,7 +6,7 @@ namespace JoinRpg.DomainTypes.Users;
 public record class UserInfo(
     UserIdentification UserId,
     UserSocialNetworks Social,
-    IReadOnlyCollection<ClaimIdentification> ActiveClaims, // Для заявок хорошо бы иметь статусы
+    IReadOnlyCollection<UserClaimInfo> ActiveClaims,
     IReadOnlyCollection<ProjectIdentification> ActiveProjects,
     IReadOnlyCollection<ProjectIdentification> AllProjects,
     bool IsAdmin,

--- a/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Claims/AddClaimViewModel.cs
@@ -61,7 +61,7 @@ public class AddClaimViewModel : IProjectIdAware
 
         ProjectLifecycleStatus = projectInfo.ProjectStatus;
 
-        WarnForAnotherClaim = claimSource.Project.Claims.OfUserActive(userInfo.UserId.Value).Any();
+        WarnForAnotherClaim = userInfo.ActiveClaims.Any(claim => claim.ProjectId == projectInfo.ProjectId);
 
         ValidationStatus = disallowReasons;
         ProjectAllowsMultipleCharacters = !projectInfo.ClaimSettings.StrictlyOneCharacter;


### PR DESCRIPTION
## Зачем

Правило `OnlyOneCharacter` было последним местом, где движок правил заявки поднимал заявки **всего проекта** из EF-графа:

```csharp
// TODO вот здесь бы проверять по UserInfo
project.Claims.OfUserApproved(userInfo.UserId.Value).Except([existingClaim]).Any()
```

Это ровно та причина, по которой ADR013 вынес `ValidateIfCanAddClaim` за пределы `DomainTypes`. Теперь правило считается по `UserInfo.ActiveClaims` — нужные заявки там уже были, не хватало только статуса.

## Цена в DAL — один столбец

`UserInfoRepository` уже проецировал `user.Claims.Where(активные).Select(c => new { c.ClaimId, c.ProjectId })`. Добавился `c.ClaimStatus`: нового запроса, репозитория и интерфейса не появляется.

Фильтр активности там и так достаточно широкий — `ClaimStatusExtensions.IsActive` исключает только `DeclinedByMaster`/`DeclinedByUser`/`OnHold`, так что `Approved` и `CheckedIn` в выборке есть.

Сам тип об этом уже просил — в `UserInfo` стоял комментарий `// Для заявок хорошо бы иметь статусы`.

## Попутно

**Баг в `UserExtensions.GetUserInfo`**: в поле `ActiveClaims` клались **все** заявки пользователя, без фильтра по активности. Метод `[Obsolete]`, и для `OnlyOneCharacter` это было безвредно (отклонённая заявка всё равно не `Approved`), но расхождение живое — починено.

**`AddClaimViewModel.WarnForAnotherClaim`** тоже считается из `UserInfo` — уходит ещё одно чтение EF-графа.

**`MockedProject.PlayerInfo` стал свойством**, согласованным с заявками мока. Это нашёл упавший тест: раньше это было поле с пустым `ActiveClaims`, заполняемое в конструкторе, — то есть заявки, созданные тестом позже через `Mock.CreateApprovedClaim`, туда не попадали. Старое правило читало EF-граф и этого не замечало; новое молча решило бы, что заявок у игрока нет. Мок врал, и это вскрылось только при переносе правила на `UserInfo`.

## Порядок относительно плана

В плане это была стадия S5, после шва `IClaimTarget` (S4). Поменял местами: `IClaimTarget` покрывает только персонажа, а `OnlyOneCharacter` нужны заявки игрока по проекту. Делая S4 первым, пришлось бы либо оставить это правило снаружи, либо протащить в валидатор булев параметр — и потом убрать его в S5. Так сигнатура меняется один раз.

## Тесты

Новый `OnlyOneCharacterRuleTest`: утверждённая и заехавшая заявка блокируют, неутверждённая — нет; заявка **в другом проекте** не мешает; при переносе сама переносимая заявка не считается, а вторая утверждённая — считается; настройка «много персонажей» правило выключает.

Полный `dotnet test` и `dotnet format --verify-no-changes --severity warn` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY
