### PR TITLE
feat: экран согласия OAuth с выбором проектов (ADR012)

### DIFF
--- a/docs/adr012-llm-mcp-access.md
+++ b/docs/adr012-llm-mcp-access.md
@@ -83,7 +83,22 @@ Yandex Cloud AI Studio MCP Hub подключает внешние MCP-серв�
 `environment.IsDevelopment()`); в production она не попадает. Интеграционные тесты
 авторизуются через существующий `ImpersonationHelpers`, без браузерного флоу.
 
-### 3. Регистрация клиентов: CIMD основной, pre-registration запасной, DCR не реализуем
+### 3. Регистрация клиентов: сегодня admin UI, целевое решение — CIMD, DCR не реализуем
+
+**Текущее состояние.** Регистрация клиентов сделана через admin-панель IdPortal:
+`Components/Pages/Admin/OAuthClientCreate.razor` / `OAuthClientEdit.razor` /
+`OAuthClients.razor`, поверх `IOAuthClientService` и `IOpenIddictApplicationManager`.
+Администратор вручную заводит `client_id`, `client_name` (`DisplayName`, он же уходит
+на экран согласия), `redirect_uris`, тип клиента (Public/Confidential) и явный список
+разрешённых scope (`joinrpg.*` и OIDC-scope взаимоисключающи в форме создания). Записи
+хранятся в БД IdPortal (`IdPortalDbContext`) через стандартные таблицы OpenIddict.
+
+Ранее в этом разделе был описан отдельный config-based механизм pre-registration
+(`OAuthServer:Clients[]` + `OAuthRegistrator`) — он был реализован, а затем удалён
+(коммит `e3973a894` «удалить pre-registration OAuth-клиентов, добавить joinrpg.* scope
+и per-client permissions») в пользу admin UI. Секции `OAuthServer:Clients[]` и класса
+`OAuthRegistrator` в коде больше нет. CIMD, описанный ниже, остаётся нереализованным —
+раздел фиксирует его как целевое решение, а не как факт.
 
 Спецификация определяет три механизма: Client ID Metadata Documents (**SHOULD**),
 pre-registration и Dynamic Client Registration (**MAY**, помечена deprecated —
@@ -120,9 +135,10 @@ CIMD покрывает VS Code, Claude Code и ChatGPT; pre-registration доб
 Опасение про спам регистраций не теоретическое: у Cursor известен баг с новым DCR-вызовом
 на каждом переподключении.
 
-**Реализация CIMD.** В OpenIddict не поддержана, поэтому вклиниваемся в разрешение клиента
+**Реализация CIMD (план, не реализовано).** В OpenIddict не поддержана, поэтому нужно
+вклиниться в разрешение клиента
 на authorize- и token-эндпоинтах: если `client_id` — HTTPS URL с path-компонентом,
-забираем по нему JSON и валидируем. Обязательно целиком:
+забрать по нему JSON и провалидировать. Обязательно целиком:
 
 - `client_id` в документе совпадает с URL, по которому он получен;
 - `redirect_uri` из запроса присутствует в `redirect_uris` документа;
@@ -135,11 +151,12 @@ CIMD покрывает VS Code, Claude Code и ChatGPT; pre-registration доб
   отмечает, что CIMD сам по себе не защищает от подмены localhost);
 - `client_id_metadata_document_supported: true` в метаданных AS.
 
-**Pre-registration** — через существующий механизм IdPortal: секция `OAuthServer:Clients[]`,
-применяется `OAuthRegistrator`. Для каждого клиента фиксируются точные `redirect_uris`,
-grant types (`authorization_code`, `refresh_token`) и явный список разрешённых scope.
-У Cursor два callback'а: `https://www.cursor.com/agents/mcp/oauth/callback`
-и `http://localhost:8787/callback` — регистрировать оба.
+**Pre-registration** для клиентов без CIMD (Cursor, OpenCode) — через уже существующий
+admin UI (см. «Текущее состояние» выше), а не через отдельный config-based механизм.
+Для каждого такого клиента фиксируются точные `redirect_uris`, grant types
+(`authorization_code`, `refresh_token`) и явный список разрешённых scope. У Cursor два
+callback'а: `https://www.cursor.com/agents/mcp/oauth/callback` и
+`http://localhost:8787/callback` — регистрировать оба.
 
 `registration_endpoint` **не публикуется**. В OpenIddict 7.6 DCR всё равно не реализована
 ([openiddict-core#2404](https://github.com/openiddict/openiddict-core/issues/2404)),

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthConsent.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthConsent.cs
@@ -1,0 +1,33 @@
+namespace JoinRpg.IdPortal.OAuthServer;
+
+/// <summary>
+/// Query string contract between <c>connect/authorize</c> and the consent page (ADR012 §4):
+/// the consent page redirects back to <c>connect/authorize</c> carrying the user's decision.
+/// </summary>
+public static class OAuthConsent
+{
+    public const string ConsentParameter = "consent";
+    public const string ProjectsParameter = "projects";
+    public const string Granted = "granted";
+    public const string Denied = "denied";
+
+    /// <summary>
+    /// Claim type carrying the project ids the user granted access to. Access-token-only.
+    /// </summary>
+    public const string ProjectsClaimType = "projects";
+
+    public static string FormatProjectIds(IEnumerable<int> projectIds) => string.Join(",", projectIds);
+
+    public static IReadOnlyList<int> ParseProjectIds(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return [];
+        }
+
+        return value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(int.Parse)
+            .ToList();
+    }
+}

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
@@ -1,5 +1,7 @@
+using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using Joinrpg.Web.Identity;
 using JoinRpg.Common.PrimitiveTypes;
 using JoinRpg.Common.WebInfrastructure;
@@ -11,6 +13,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -183,7 +186,11 @@ public static class OAuthServerRegistration
         return TypedResults.Ok(claims);
     }
 
-    private async static Task<Results<ChallengeHttpResult, SignInHttpResult>> AuthorizeMethod(HttpContext context, IOpenIddictApplicationManager applicationManager, ICurrentUserAccessor currentUserAccessor)
+    private async static Task<Results<ChallengeHttpResult, RedirectHttpResult, SignInHttpResult>> AuthorizeMethod(
+        HttpContext context,
+        IOpenIddictApplicationManager applicationManager,
+        IOpenIddictAuthorizationManager authorizationManager,
+        ICurrentUserAccessor currentUserAccessor)
     {
 
         var principal = (await context.AuthenticateAsync())?.Principal;
@@ -198,33 +205,139 @@ public static class OAuthServerRegistration
         }
 
         var request = context.GetOpenIddictServerRequest();
-        if (request?.IsAuthorizationCodeFlow() == true && request.ClientId is not null)
+        if (request?.IsAuthorizationCodeFlow() != true || request.ClientId is null)
         {
-            // Note: the client credentials are automatically validated by OpenIddict:
-            // if client_id or client_secret are invalid, this action won't be invoked.
-
-            var application = await applicationManager.FindByClientIdAsync(request.ClientId) ??
-                throw new InvalidOperationException("The application cannot be found.");
-
-            // Create a new ClaimsIdentity containing the claims that
-            // will be used to create an id_token, a token or a code.
-            var identity = new ClaimsIdentity(TokenValidationParameters.DefaultAuthenticationType, Claims.Name, Claims.Role);
-
-            identity.SetClaim(Claims.Subject, currentUserAccessor.UserIdentification.ToString());
-
-            identity.SetScopes(request.GetScopes());
-
-            identity.SetDestinations(static claim => claim.Type switch
-            {
-                Claims.Subject
-                    => [Destinations.AccessToken, Destinations.IdentityToken],
-                Claims.Name when claim.Subject.HasScope(Scopes.Profile)
-                    => [Destinations.AccessToken, Destinations.IdentityToken],
-                _ => [Destinations.AccessToken]
-            });
-
-            return TypedResults.SignIn(new ClaimsPrincipal(identity), authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+            throw new NotImplementedException("The specified grant is not implemented.");
         }
-        else { throw new NotImplementedException("The specified grant is not implemented."); }
+
+        // Note: the client credentials are automatically validated by OpenIddict:
+        // if client_id or client_secret are invalid, this action won't be invoked.
+        var application = await applicationManager.FindByClientIdAsync(request.ClientId) ??
+            throw new InvalidOperationException("The application cannot be found.");
+        var applicationId = await applicationManager.GetIdAsync(application) ??
+            throw new InvalidOperationException("The application has no id.");
+
+        var subject = currentUserAccessor.UserIdentification.ToString();
+        var requestedScopes = request.GetScopes();
+
+        // Only joinrpg.* (MCP) scopes go through explicit consent (ADR012 §4) — the site's own
+        // OIDC login (openid/email/profile/...) keeps behaving exactly as before this change.
+        var requiresConsent = requestedScopes.Any(JoinRpgScopes.IsJoinRpgScope);
+
+        IReadOnlyList<int> grantedProjectIds = [];
+        if (requiresConsent)
+        {
+            if (context.Request.Query[OAuthConsent.ConsentParameter] == OAuthConsent.Denied)
+            {
+                return TypedResults.Redirect(BuildAccessDeniedRedirectUri(request));
+            }
+
+            if (context.Request.Query[OAuthConsent.ConsentParameter] == OAuthConsent.Granted)
+            {
+                // The user just came back from the consent page: persist the decision as a
+                // permanent authorization, so subsequent sign-ins skip the consent screen.
+                grantedProjectIds = OAuthConsent.ParseProjectIds(context.Request.Query[OAuthConsent.ProjectsParameter]);
+
+                var descriptor = new OpenIddictAuthorizationDescriptor
+                {
+                    ApplicationId = applicationId,
+                    Subject = subject,
+                    Type = AuthorizationTypes.Permanent,
+                    Status = Statuses.Valid,
+                };
+                foreach (var scope in requestedScopes)
+                {
+                    descriptor.Scopes.Add(scope);
+                }
+                StoreGrantedProjects(descriptor.Properties, grantedProjectIds);
+
+                _ = await authorizationManager.CreateAsync(descriptor);
+            }
+            else
+            {
+                var existingAuthorization = await FindMatchingAuthorizationAsync(
+                    authorizationManager, subject, applicationId, requestedScopes);
+
+                if (existingAuthorization is null)
+                {
+                    // No consent on file yet for this client/scope combination — ask the user.
+                    return TypedResults.Redirect($"/oauth/consent{context.Request.QueryString}");
+                }
+
+                grantedProjectIds = ReadGrantedProjects(await authorizationManager.GetPropertiesAsync(existingAuthorization));
+            }
+        }
+
+        // Create a new ClaimsIdentity containing the claims that
+        // will be used to create an id_token, a token or a code.
+        var identity = new ClaimsIdentity(TokenValidationParameters.DefaultAuthenticationType, Claims.Name, Claims.Role);
+
+        identity.SetClaim(Claims.Subject, subject);
+        identity.SetScopes(requestedScopes);
+
+        if (grantedProjectIds.Count > 0)
+        {
+            identity.SetClaim(OAuthConsent.ProjectsClaimType, OAuthConsent.FormatProjectIds(grantedProjectIds));
+        }
+
+        identity.SetDestinations(static claim => claim.Type switch
+        {
+            Claims.Subject
+                => [Destinations.AccessToken, Destinations.IdentityToken],
+            Claims.Name when claim.Subject.HasScope(Scopes.Profile)
+                => [Destinations.AccessToken, Destinations.IdentityToken],
+            OAuthConsent.ProjectsClaimType
+                => [Destinations.AccessToken],
+            _ => [Destinations.AccessToken]
+        });
+
+        return TypedResults.SignIn(new ClaimsPrincipal(identity), authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
     }
+
+    private static string BuildAccessDeniedRedirectUri(OpenIddictRequest request)
+    {
+        var redirectUri = request.RedirectUri ?? throw new InvalidOperationException("The authorization request has no redirect_uri.");
+        var parameters = new Dictionary<string, string?> { ["error"] = Errors.AccessDenied };
+        if (request.State is { } state)
+        {
+            parameters["state"] = state;
+        }
+        return QueryHelpers.AddQueryString(redirectUri, parameters);
+    }
+
+    private async static Task<object?> FindMatchingAuthorizationAsync(
+        IOpenIddictAuthorizationManager authorizationManager,
+        string subject,
+        string applicationId,
+        ImmutableArray<string> requestedScopes)
+    {
+        await foreach (var authorization in authorizationManager.FindAsync(
+            subject: subject,
+            client: applicationId,
+            status: Statuses.Valid,
+            type: AuthorizationTypes.Permanent,
+            scopes: null))
+        {
+            var grantedScopes = await authorizationManager.GetScopesAsync(authorization);
+            if (requestedScopes.All(grantedScopes.Contains))
+            {
+                return authorization;
+            }
+        }
+
+        return null;
+    }
+
+    private static void StoreGrantedProjects(IDictionary<string, JsonElement> properties, IReadOnlyList<int> projectIds)
+    {
+        if (projectIds.Count > 0)
+        {
+            properties[OAuthConsent.ProjectsClaimType] = JsonSerializer.SerializeToElement(projectIds);
+        }
+    }
+
+    private static IReadOnlyList<int> ReadGrantedProjects(ImmutableDictionary<string, JsonElement> properties)
+        => properties.TryGetValue(OAuthConsent.ProjectsClaimType, out var element)
+            ? element.Deserialize<int[]>() ?? []
+            : [];
 }

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.OAuthServer/OAuthServerRegistration.cs
@@ -328,7 +328,7 @@ public static class OAuthServerRegistration
         return null;
     }
 
-    private static void StoreGrantedProjects(IDictionary<string, JsonElement> properties, IReadOnlyList<int> projectIds)
+    private static void StoreGrantedProjects(Dictionary<string, JsonElement> properties, IReadOnlyList<int> projectIds)
     {
         if (projectIds.Count > 0)
         {
@@ -336,7 +336,7 @@ public static class OAuthServerRegistration
         }
     }
 
-    private static IReadOnlyList<int> ReadGrantedProjects(ImmutableDictionary<string, JsonElement> properties)
+    private static int[] ReadGrantedProjects(ImmutableDictionary<string, JsonElement> properties)
         => properties.TryGetValue(OAuthConsent.ProjectsClaimType, out var element)
             ? element.Deserialize<int[]>() ?? []
             : [];

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthConsentScenario.cs
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test/Scenarios/OAuthConsentScenario.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.Json;
+using JoinRpg.IdPortal.OAuthServer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using OpenIddict.Abstractions;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace JoinRpg.IdPortal.Test.Scenarios;
+
+// Covers ADR012 §4 (consent screen + per-project claim). The consent page itself is
+// InteractiveServer (see OAuthClientCreateScenario for why that can't be driven over plain
+// HTTP), so these tests exercise AuthorizeMethod directly by simulating what the page sends
+// back: a "consent=granted&projects=..." (or "consent=denied") query on connect/authorize.
+// Each test uses its own client id: authorizations are keyed by (subject, client), and the
+// same test user is shared across tests in the collection, so reusing a client id would leak
+// consent state between tests.
+[Collection("IdPortal")]
+public class OAuthConsentScenario(IdPortalApplicationFactory factory)
+{
+    private const string RedirectUri = "http://localhost/mcp-callback";
+
+    [Fact]
+    public async Task Authorize_WithJoinRpgScope_NoExistingConsent_RedirectsToConsentPage()
+    {
+        var clientId = await CreateMcpClientAsync();
+        var client = await LoginAsync();
+
+        var response = await client.GetAsync(BuildAuthorizeUrl(clientId, challenge: CreatePkcePair().Challenge));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        var location = response.Headers.Location!.ToString();
+        location.ShouldStartWith("/oauth/consent");
+        location.ShouldContain($"client_id={clientId}");
+    }
+
+    [Fact]
+    public async Task Authorize_ConsentDenied_RedirectsToClientWithAccessDenied()
+    {
+        var clientId = await CreateMcpClientAsync();
+        var client = await LoginAsync();
+
+        var response = await client.GetAsync(BuildAuthorizeUrl(clientId, challenge: CreatePkcePair().Challenge) +
+            $"&{OAuthConsent.ConsentParameter}={OAuthConsent.Denied}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        var location = response.Headers.Location!.ToString();
+        location.ShouldStartWith(RedirectUri);
+        location.ShouldContain($"error={Errors.AccessDenied}");
+    }
+
+    [Fact]
+    public async Task Authorize_ConsentGranted_CreatesAuthorizationWithProjectsProperty()
+    {
+        var clientId = await CreateMcpClientAsync();
+        var client = await LoginAsync();
+        var (_, challenge) = CreatePkcePair();
+
+        var response = await client.GetAsync(BuildAuthorizeUrl(clientId, challenge) +
+            $"&{OAuthConsent.ConsentParameter}={OAuthConsent.Granted}&{OAuthConsent.ProjectsParameter}=123,456");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        var location = response.Headers.Location!.ToString();
+        location.ShouldStartWith(RedirectUri, Case.Insensitive);
+        location.ShouldContain("code=");
+
+        using var scope = factory.Services.CreateScope();
+        var authorizationManager = scope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+        var applicationManager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+        var application = await applicationManager.FindByClientIdAsync(clientId);
+        var applicationId = await applicationManager.GetIdAsync(application!);
+
+        object? authorization = null;
+        await foreach (var candidate in authorizationManager.FindAsync(
+            subject: null, client: applicationId, status: Statuses.Valid, type: AuthorizationTypes.Permanent, scopes: null))
+        {
+            authorization = candidate;
+            break;
+        }
+        authorization.ShouldNotBeNull();
+
+        var properties = await authorizationManager.GetPropertiesAsync(authorization);
+        properties.ShouldContainKey(OAuthConsent.ProjectsClaimType);
+        var projectIds = properties[OAuthConsent.ProjectsClaimType].Deserialize<int[]>();
+        projectIds.ShouldBe([123, 456]);
+    }
+
+    [Fact]
+    public async Task Authorize_WithExistingConsent_SkipsConsentPage()
+    {
+        var clientId = await CreateMcpClientAsync();
+        var client = await LoginAsync();
+
+        // First pass grants consent...
+        var granted = await client.GetAsync(BuildAuthorizeUrl(clientId, CreatePkcePair().Challenge) +
+            $"&{OAuthConsent.ConsentParameter}={OAuthConsent.Granted}&{OAuthConsent.ProjectsParameter}=789");
+        granted.StatusCode.ShouldBe(HttpStatusCode.Found);
+
+        // ...second pass, without a consent decision, should go straight to the client callback.
+        var response = await client.GetAsync(BuildAuthorizeUrl(clientId, CreatePkcePair().Challenge));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        var location = response.Headers.Location!.ToString();
+        location.ShouldStartWith(RedirectUri, Case.Insensitive);
+    }
+
+    private async Task<string> CreateMcpClientAsync()
+    {
+        var clientId = $"test-mcp-consent-{Guid.NewGuid():N}";
+        using var scope = factory.Services.CreateScope();
+        var clientService = scope.ServiceProvider.GetRequiredService<IOAuthClientService>();
+        await clientService.CreateOrUpdateClientAsync(
+            clientId,
+            clientSecret: null,
+            displayName: "Тестовый MCP-клиент",
+            redirectUris: [new Uri(RedirectUri)],
+            clientType: OAuthClientType.Public,
+            scopes: [JoinRpgScopes.Read],
+            allowRefreshToken: false);
+        return clientId;
+    }
+
+    private async Task<HttpClient> LoginAsync()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var loginPage = await client.GetAsync("/Account/Login");
+        var doc = await loginPage.AsHtmlDocument();
+        var fields = doc.GetFormFields();
+        fields["Input.Email"] = IdPortalApplicationFactory.TestUserEmail;
+        fields["Input.Password"] = IdPortalApplicationFactory.TestUserPassword;
+        await client.PostAsync(doc.GetFormAction("/Account/Login"), new FormUrlEncodedContent(fields!));
+
+        return client;
+    }
+
+    private static string BuildAuthorizeUrl(string clientId, string challenge) =>
+        $"/connect/authorize?client_id={clientId}" +
+        "&response_type=code" +
+        $"&scope={Uri.EscapeDataString(JoinRpgScopes.Read)}" +
+        $"&redirect_uri={Uri.EscapeDataString(RedirectUri)}" +
+        $"&code_challenge={Uri.EscapeDataString(challenge)}&code_challenge_method=S256";
+
+    private static (string Verifier, string Challenge) CreatePkcePair()
+    {
+        var verifier = Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+        var challenge = Base64UrlEncode(SHA256.HashData(System.Text.Encoding.ASCII.GetBytes(verifier)));
+        return (verifier, challenge);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/OAuthConsentPage.razor
+++ b/src/JoinRpg.IdPortal/JoinRpg.IdPortal/Components/Pages/OAuthConsentPage.razor
@@ -1,0 +1,126 @@
+@page "/oauth/consent"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using JoinRpg.Data.Interfaces
+@using JoinRpg.IdPortal.OAuthServer
+@using JoinRpg.Interfaces
+@using Microsoft.AspNetCore.WebUtilities
+@using OpenIddict.Abstractions
+@inject IOpenIddictApplicationManager ApplicationManager
+@inject IProjectRepository ProjectRepository
+@inject ICurrentUserAccessor CurrentUserAccessor
+@inject NavigationManager NavigationManager
+
+<PageTitle>Запрос доступа — id.joinrpg.ru</PageTitle>
+
+@if (notFound)
+{
+    <JoinAlert Variation="VariationStyleEnum.Danger">Приложение не найдено.</JoinAlert>
+}
+else
+{
+    <h3>«@clientDisplayName» запрашивает доступ</h3>
+
+    <p>Запрошенные права:</p>
+    <ul>
+        @if (requestsRead)
+        {
+            <li>Чтение данных ваших проектов (список проектов, персонажи, группы, поля)</li>
+        }
+        @if (requestsCharactersWrite)
+        {
+            <li>Создание и правка персонажей в выбранных проектах</li>
+        }
+    </ul>
+
+    @if (requestsRead)
+    {
+        <p>Выберите проекты, к которым приложение получит доступ:</p>
+        @if (projects.Count == 0)
+        {
+            <JoinAlert Variation="VariationStyleEnum.Warning">
+                У вас нет проектов с правами мастера — доступ открывать не к чему.
+            </JoinAlert>
+        }
+        else
+        {
+            @foreach (var project in projects)
+            {
+                <div class="checkbox">
+                    <label><CheckboxInput @bind-Value="project.Selected" /> @project.Name.Value</label>
+                </div>
+            }
+        }
+    }
+
+    <p>
+        <JoinButton Label="Разрешить" OnClick="() => Submit(grant: true)" Preset="ButtonPreset.Save" />
+        <JoinButton Label="Отклонить" OnClick="() => Submit(grant: false)" Preset="ButtonPreset.Cancel" />
+    </p>
+}
+
+@code {
+    private bool notFound;
+    private string clientDisplayName = "";
+    private bool requestsRead;
+    private bool requestsCharactersWrite;
+    private readonly List<ProjectChoice> projects = [];
+    private string originalQueryString = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        originalQueryString = uri.Query;
+
+        var clientId = query.TryGetValue("client_id", out var clientIdValues) ? clientIdValues.ToString() : null;
+        var application = clientId is null ? null : await ApplicationManager.FindByClientIdAsync(clientId);
+        if (application is null)
+        {
+            notFound = true;
+            return;
+        }
+
+        clientDisplayName = await ApplicationManager.GetDisplayNameAsync(application) ?? clientId!;
+
+        var scopeValue = query.TryGetValue("scope", out var scopeValues) ? scopeValues.ToString() : "";
+        var scopes = scopeValue.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        requestsRead = scopes.Contains(JoinRpgScopes.Read);
+        requestsCharactersWrite = scopes.Contains(JoinRpgScopes.CharactersWrite);
+
+        if (requestsRead)
+        {
+            var myProjects = await ProjectRepository.GetPersonalizedProjectsBySpecification(
+                ProjectListSpecification.ActiveWithMyMasterAccess(CurrentUserAccessor.UserIdentification));
+
+            projects.AddRange(myProjects
+                .Where(p => p.HasMyMasterAccess)
+                .Select(p => new ProjectChoice(p.ProjectId.Value, p.ProjectName)));
+        }
+    }
+
+    private void Submit(bool grant)
+    {
+        if (!grant)
+        {
+            NavigationManager.NavigateTo(
+                $"/connect/authorize{originalQueryString}&{OAuthConsent.ConsentParameter}={OAuthConsent.Denied}",
+                forceLoad: true);
+            return;
+        }
+
+        var selectedProjectIds = projects.Where(p => p.Selected).Select(p => p.ProjectId).ToList();
+        var redirectUri = $"/connect/authorize{originalQueryString}" +
+            $"&{OAuthConsent.ConsentParameter}={OAuthConsent.Granted}" +
+            $"&{OAuthConsent.ProjectsParameter}={Uri.EscapeDataString(OAuthConsent.FormatProjectIds(selectedProjectIds))}";
+
+        NavigationManager.NavigateTo(redirectUri, forceLoad: true);
+    }
+
+    private sealed class ProjectChoice(int projectId, JoinRpg.DomainTypes.ProjectMetadata.ProjectName name)
+    {
+        public int ProjectId { get; } = projectId;
+        public JoinRpg.DomainTypes.ProjectMetadata.ProjectName Name { get; } = name;
+        public bool Selected { get; set; }
+    }
+}


### PR DESCRIPTION
## Что сделано

- Реализован экран согласия (`/oauth/consent`) для OAuth-клиентов, запрашивающих `joinrpg.*` scope (ADR012 §4): мастер выбирает, к каким своим проектам открыть доступ.
- Выбор проектов сохраняется как `IOpenIddictAuthorizationManager`-авторизация (permanent) и попадает в access-token отдельным claim `projects` (только access token, не id_token).
- Повторный заход того же клиента с уже согласованными scope пропускает экран согласия.
- Отказ («Отклонить») возвращает клиенту стандартный `error=access_denied`.
- Обычный OIDC-логин на сайт (`openid`/`email`/`profile`/...) поведения не меняет — согласие запускается только при наличии `joinrpg.*` scope в запросе.
- Актуализирован `docs/adr012-llm-mcp-access.md` §3: регистрация OAuth-клиентов сейчас идёт через admin UI IdPortal (`OAuthClientCreate/Edit/List.razor` + `IOAuthClientService`), а не через ранее удалённый config-based pre-registration (`OAuthServer:Clients[]`/`OAuthRegistrator`); CIMD помечен как нереализованный целевой план, а не факт.

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes --severity warn` — чисто
- [x] `dotnet test src/JoinRpg.IdPortal/JoinRpg.IdPortal.Test` — 30 passed, 1 skipped (не связан с изменением)
- [x] Новый сценарий `OAuthConsentScenario`: редирект на экран согласия при первом заходе, `access_denied` при отказе, создание авторизации с claim `projects` при согласии, пропуск экрана при повторном заходе
- [x] Регрессия: существующие `OAuthServerScenario`/`OAuthClientCreateScenario`/`OAuthClientEditScenario` — без изменений в поведении

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxaGjv2KktWZWTsXcjEpYE