### PR TITLE
refactor: отметка WasEverUsed через ProjectPropsService

### DIFF
--- a/src/JoinRpg.Domain.Test/FieldSaveHelperTest.cs
+++ b/src/JoinRpg.Domain.Test/FieldSaveHelperTest.cs
@@ -19,8 +19,6 @@ public class FieldSaveHelperTest
 
     private class MockedFieldSaveHelper(ITestOutputHelper testOutputHelper) : FieldSaveHelper(new MockedFieldDefaultValueGenerator(), new XUnitLogger<FieldSaveHelper>(testOutputHelper))
     {
-        protected override void MarkAsUsed(IReadOnlyCollection<FieldWithPreviousAndNewValue> updatedFields, Project project) { }
-
         // Тестам удобно задавать поля словарём — в проде его превращает в слой граница
         // (форма портала, XGameApi). Перегрузки держат тесты неизменными, чтобы они остались
         // честным оракулом поведения при переходе на FieldLayerContainer.

--- a/src/JoinRpg.Domain/CharacterFields/FieldSaveHelper.cs
+++ b/src/JoinRpg.Domain/CharacterFields/FieldSaveHelper.cs
@@ -6,6 +6,13 @@ namespace JoinRpg.Domain.CharacterFields;
 /// <summary>
 /// Saves fields either to character or to claim
 /// </summary>
+/// <remarks>
+/// Помимо самих значений, сохранение полей меняет и метаданные проекта: впервые заполненное поле
+/// надо отметить как использованное (<c>WasEverUsed</c>). Такие изменения делаются только через
+/// <c>IProjectPropsService</c> (ADR009), который лежит в сервисном слое и отсюда недоступен, —
+/// поэтому сервисы вызывают не этот класс напрямую, а обёртку
+/// <c>JoinRpg.Services.Impl.CharacterFields.CharacterFieldsSaveService</c>.
+/// </remarks>
 public class FieldSaveHelper(IFieldDefaultValueGenerator generator, ILogger<FieldSaveHelper> logger)
 {
 
@@ -72,7 +79,6 @@ public class FieldSaveHelper(IFieldDefaultValueGenerator generator, ILogger<Fiel
 
         Apply(result, character, claim);
 
-        MarkAsUsed(result.UpdatedFields, character.Project);
         return result.UpdatedFields;
     }
 
@@ -105,28 +111,6 @@ public class FieldSaveHelper(IFieldDefaultValueGenerator generator, ILogger<Fiel
 
     private static string Serialize(FieldLayerContainer layer) => layer.LayerData.Values.SerializeFields();
 
-
-    private static void MarkUsed(FieldWithValue field, Project project)
-    {
-        var entityField = project.ProjectFields.Single(f => f.ProjectFieldId == field.Field.Id.ProjectFieldId);
-        entityField.WasEverUsed = true;
-
-        if (field.Field.HasValueList)
-        {
-            foreach (var val in field.GetDropdownValues())
-            {
-                entityField.DropdownValues.Single(v => v.ProjectFieldDropdownValueId == val.Id.ProjectFieldVariantId).WasEverUsed = true;
-            }
-        }
-    }
-
-    protected virtual void MarkAsUsed(IReadOnlyCollection<FieldWithPreviousAndNewValue> updatedFields, Project project)
-    {
-        foreach (var field in updatedFields)
-        {
-            MarkUsed(field.New, project);
-        }
-    }
 
     private FieldSaveStrategyBase CreateStrategy(UserIdentification currentUserId, Character character, Claim? claim, ProjectInfo projectInfo)
     {

--- a/src/JoinRpg.Services.Impl.Test/CharacterFields/CharacterFieldsSaveServiceTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/CharacterFields/CharacterFieldsSaveServiceTest.cs
@@ -1,0 +1,151 @@
+using JoinRpg.DataModel;
+using JoinRpg.Domain.CharacterFields;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.ProjectMetadata;
+using JoinRpg.Services.Impl.CharacterFields;
+using JoinRpg.Services.Impl.Test.Projects;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JoinRpg.Services.Impl.Test.CharacterFields;
+
+/// <summary>
+/// Отметка полей как использованных (<see cref="ProjectField.WasEverUsed"/>) — изменение
+/// метаданных проекта, поэтому идёт через <c>IProjectPropsService</c> (ADR009). Проверяем, что
+/// отметка ставится, попадает в пересобранный <see cref="ProjectInfo"/>, доступна игроку без
+/// мастерских прав и не приводит к записи, когда менять нечего.
+/// </summary>
+public class CharacterFieldsSaveServiceTest : ProjectMetadataServiceTestBase
+{
+    private const int VariantId = 100;
+
+    private CharacterFieldsSaveService CreateService(int currentUserId)
+        => new(
+            new FieldSaveHelper(new FieldSaveHelperFakes.NoDefaults(), NullLogger<FieldSaveHelper>.Instance),
+            CreatePropsService(CreateCurrentUser(currentUserId)));
+
+    private ProjectFieldInfo AddPlayerEditableField()
+        => mock.AddField(f =>
+        {
+            f.FieldName = "Поле игрока";
+            f.FieldType = ProjectFieldType.String;
+            f.FieldBoundTo = FieldBoundTo.Character;
+            f.CanPlayerEdit = true;
+            f.CanPlayerView = true;
+            f.ShowOnUnApprovedClaims = true;
+            f.Description = new MarkdownDbValue();
+            f.MasterDescription = new MarkdownDbValue();
+        });
+
+    private ProjectFieldInfo AddDropdownField()
+        => mock.AddField(f =>
+        {
+            f.FieldName = "Поле с вариантами";
+            f.FieldType = ProjectFieldType.Dropdown;
+            f.FieldBoundTo = FieldBoundTo.Character;
+            f.CanPlayerEdit = true;
+            f.CanPlayerView = true;
+            f.ShowOnUnApprovedClaims = true;
+            f.Description = new MarkdownDbValue();
+            f.MasterDescription = new MarkdownDbValue();
+            f.DropdownValues =
+            [
+                new ProjectFieldDropdownValue
+                {
+                    ProjectFieldDropdownValueId = VariantId,
+                    Label = "Вариант 1",
+                    IsActive = true,
+                    PlayerSelectable = true,
+                    Description = new MarkdownDbValue(),
+                    MasterDescription = new MarkdownDbValue(),
+                },
+            ];
+        });
+
+    private Task<IReadOnlyCollection<FieldWithPreviousAndNewValue>> Save(
+        int currentUserId,
+        ProjectFieldInfo field,
+        string? value)
+        => CreateService(currentUserId).SaveCharacterFields(
+            currentUserId,
+            mock.Character,
+            new FieldLayerContainer(
+                mock.ProjectInfo,
+                new Dictionary<int, string?> { { field.Id.ProjectFieldId, value } }),
+            mock.ProjectInfo);
+
+    private ProjectField Entity(ProjectFieldInfo field)
+        => mock.Project.ProjectFields.Single(f => f.ProjectFieldId == field.Id.ProjectFieldId);
+
+    [Fact]
+    public async Task FirstFill_MarksFieldAsUsed()
+    {
+        var field = AddPlayerEditableField();
+        Entity(field).WasEverUsed.ShouldBeFalse();
+
+        _ = await Save(mock.Master.UserId, field, "какое-то значение");
+
+        Entity(field).WasEverUsed.ShouldBeTrue();
+        unitOfWork.SaveChangesCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task FirstFill_MarkIsVisibleInRebuiltProjectInfo()
+    {
+        var field = AddPlayerEditableField();
+
+        _ = await Save(mock.Master.UserId, field, "какое-то значение");
+
+        // Снимок, который ProjectPropsService положил в кэш, уже содержит отметку.
+        Result.GetFieldById(field.Id).WasEverUsed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AlreadyMarkedField_DoesNotTouchMetadata()
+    {
+        var field = AddPlayerEditableField();
+        Entity(field).WasEverUsed = true;
+        mock.ReInitProjectInfo();
+
+        _ = await Save(mock.Master.UserId, field, "какое-то значение");
+
+        // Отмечать нечего — в БД не идём вовсе, это самый горячий путь записи.
+        unitOfWork.SaveChangesCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task PlayerWithoutMasterAccess_CanMarkFieldAsUsed()
+    {
+        var field = AddPlayerEditableField();
+        _ = mock.CreateApprovedClaim(mock.Character, mock.Player);
+        mock.ReInitProjectInfo();
+
+        // Отметку ставит тот, кто заполнил поле. Мастерских прав у игрока нет, и требовать их
+        // здесь нельзя — иначе сохранение своей заявки падало бы с NoAccessToProjectException.
+        _ = await Save(mock.Player.UserId, field, "значение от игрока");
+
+        Entity(field).WasEverUsed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task FirstFill_MarksSelectedVariantAsUsed()
+    {
+        var field = AddDropdownField();
+        var variant = Entity(field).DropdownValues.Single();
+        variant.WasEverUsed.ShouldBeFalse();
+
+        _ = await Save(mock.Master.UserId, field, VariantId.ToString());
+
+        Entity(field).WasEverUsed.ShouldBeTrue();
+        Entity(field).DropdownValues.Single().WasEverUsed.ShouldBeTrue();
+    }
+}
+
+internal static class FieldSaveHelperFakes
+{
+    /// <summary>Генератор значений по умолчанию, который ничего не подставляет.</summary>
+    internal sealed class NoDefaults : IFieldDefaultValueGenerator
+    {
+        public string? CreateDefaultValue(Claim? claim, FieldWithValue field) => null;
+        public string? CreateDefaultValue(Character? character, FieldWithValue field) => null;
+    }
+}

--- a/src/JoinRpg.Services.Impl/CharacterFields/CharacterFieldsSaveService.cs
+++ b/src/JoinRpg.Services.Impl/CharacterFields/CharacterFieldsSaveService.cs
@@ -1,0 +1,144 @@
+using JoinRpg.DataModel;
+using JoinRpg.Domain.CharacterFields;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.Services.Impl.Projects;
+
+namespace JoinRpg.Services.Impl.CharacterFields;
+
+/// <summary>
+/// Точка входа сервисного слоя для сохранения полей персонажа или заявки: сохраняет значения
+/// через <see cref="FieldSaveHelper"/> и доводит до метаданных проекта побочный эффект этого
+/// сохранения — отметку впервые заполненных полей как использованных.
+/// </summary>
+/// <remarks>
+/// Отметка живёт здесь, а не в <see cref="FieldSaveHelper"/>, потому что это изменение метаданных
+/// проекта, а такие изменения идут только через <see cref="IProjectPropsService"/> (ADR009) —
+/// сервисный тип, недоступный из <c>JoinRpg.Domain</c>.
+/// </remarks>
+internal class CharacterFieldsSaveService(
+    FieldSaveHelper fieldSaveHelper,
+    IProjectPropsService projectPropsService)
+{
+    /// <summary>
+    /// Сохраняет поля заявки.
+    /// </summary>
+    /// <returns>Изменившиеся поля.</returns>
+    /// <param name="fieldsToSet">
+    /// Поля, которые надо изменить, — дельта, а не полный слой. Пустой слой — не менять ничего.
+    /// </param>
+    public async Task<IReadOnlyCollection<FieldWithPreviousAndNewValue>> SaveCharacterFields(
+        int currentUserId,
+        Claim claim,
+        FieldLayerContainer fieldsToSet,
+        ProjectInfo projectInfo)
+    {
+        var updatedFields = fieldSaveHelper.SaveCharacterFields(currentUserId, claim, fieldsToSet, projectInfo);
+        await MarkAsUsed(updatedFields, projectInfo);
+        return updatedFields;
+    }
+
+    /// <summary>
+    /// Сохраняет поля персонажа.
+    /// </summary>
+    /// <returns>Изменившиеся поля.</returns>
+    /// <param name="fieldsToSet">
+    /// Поля, которые надо изменить, — дельта, а не полный слой. Пустой слой — не менять ничего.
+    /// </param>
+    public async Task<IReadOnlyCollection<FieldWithPreviousAndNewValue>> SaveCharacterFields(
+        int currentUserId,
+        Character character,
+        FieldLayerContainer fieldsToSet,
+        ProjectInfo projectInfo)
+    {
+        var updatedFields = fieldSaveHelper.SaveCharacterFields(currentUserId, character, fieldsToSet, projectInfo);
+        await MarkAsUsed(updatedFields, projectInfo);
+        return updatedFields;
+    }
+
+    /// <summary>
+    /// Поля и варианты, которые надо впервые отметить как использованные. Логируются
+    /// <see cref="IProjectPropsService"/> вместе с именем операции.
+    /// </summary>
+    private sealed record FieldsToMarkAsUsed(
+        IReadOnlyCollection<int> FieldIds,
+        IReadOnlyCollection<int> VariantIds)
+    {
+        public bool IsEmpty => FieldIds.Count == 0 && VariantIds.Count == 0;
+    }
+
+    /// <summary>
+    /// Отмечает заполненные поля и выбранные варианты как использованные
+    /// (<see cref="ProjectField.WasEverUsed"/>). Флаг входит в <see cref="ProjectInfo"/> и
+    /// запрещает окончательное удаление поля, то есть это изменение метаданных проекта.
+    /// </summary>
+    private async Task MarkAsUsed(
+        IReadOnlyCollection<FieldWithPreviousAndNewValue> updatedFields,
+        ProjectInfo projectInfo)
+    {
+        var toMark = CollectNotYetMarked(updatedFields);
+        if (toMark.IsEmpty)
+        {
+            // Обычный случай: всё давно отмечено. В БД не идём вовсе — иначе на самом горячем
+            // пути записи получили бы лишнюю загрузку проекта и лишний SaveChanges.
+            return;
+        }
+
+        await projectPropsService.ChangeProjectPropertiesAsSideEffect(
+            projectInfo.ProjectId,
+            // Отметка — бухгалтерия, а не намерение пользователя. Уронить из-за неё сохранение
+            // заявки на закрытом проекте было бы хуже, чем отметить поле в закрытом проекте.
+            ProjectActiveRequirement.AllowInactive,
+            toMark,
+            ctx =>
+            {
+                foreach (var field in ctx.Project.ProjectFields)
+                {
+                    if (ctx.Request.FieldIds.Contains(field.ProjectFieldId))
+                    {
+                        field.WasEverUsed = true;
+                    }
+
+                    foreach (var variant in field.DropdownValues)
+                    {
+                        if (ctx.Request.VariantIds.Contains(variant.ProjectFieldDropdownValueId))
+                        {
+                            variant.WasEverUsed = true;
+                        }
+                    }
+                }
+            },
+            operationName: nameof(MarkAsUsed));
+    }
+
+    /// <summary>
+    /// Отбирает из изменившихся полей те, что ещё не отмечены. Отметка монотонна (только
+    /// <c>false → true</c>), поэтому по снимку метаданных видно, есть ли вообще что менять, —
+    /// без обращения к БД.
+    /// </summary>
+    private static FieldsToMarkAsUsed CollectNotYetMarked(
+        IReadOnlyCollection<FieldWithPreviousAndNewValue> updatedFields)
+    {
+        var fieldIds = new HashSet<int>();
+        var variantIds = new HashSet<int>();
+
+        foreach (var updated in updatedFields)
+        {
+            var field = updated.New.Field;
+
+            if (!field.WasEverUsed)
+            {
+                _ = fieldIds.Add(field.Id.ProjectFieldId);
+            }
+
+            if (field.HasValueList)
+            {
+                foreach (var variant in updated.New.GetDropdownValues().Where(v => !v.WasEverUsed))
+                {
+                    _ = variantIds.Add(variant.Id.ProjectFieldVariantId);
+                }
+            }
+        }
+
+        return new FieldsToMarkAsUsed(fieldIds, variantIds);
+    }
+}

--- a/src/JoinRpg.Services.Impl/CharacterServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/CharacterServiceImpl.cs
@@ -2,9 +2,9 @@ using System.Data.Entity.Validation;
 using JoinRpg.Data.Write.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
-using JoinRpg.Domain.CharacterFields;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.Services.Impl.CharacterFields;
 using JoinRpg.Services.Interfaces.Characters;
 using JoinRpg.Services.Interfaces.Notification;
 
@@ -12,7 +12,7 @@ namespace JoinRpg.Services.Impl;
 
 internal class CharacterServiceImpl(
     IUnitOfWork unitOfWork,
-    FieldSaveHelper fieldSaveHelper,
+    CharacterFieldsSaveService fieldSaveService,
     ICurrentUserAccessor currentUserAccessor,
     IProjectMetadataRepository projectMetadataRepository) : DbServiceImplBase(unitOfWork, currentUserAccessor), ICharacterService
 {
@@ -42,7 +42,7 @@ internal class CharacterServiceImpl(
         Create(character);
 
         //TODO we do not send message for creating character
-        _ = fieldSaveHelper.SaveCharacterFields(CurrentUserId,
+        _ = await fieldSaveService.SaveCharacterFields(CurrentUserId,
             character,
             addCharacterRequest.FieldValues,
             projectInfo);
@@ -87,7 +87,7 @@ internal class CharacterServiceImpl(
 
         character.ParentCharacterGroupIds = ValidateGroupListForCharacter(projectInfo, editCharacterRequest.ParentCharacterGroupIds);
 
-        var changedFields = fieldSaveHelper.SaveCharacterFields(CurrentUserId,
+        var changedFields = await fieldSaveService.SaveCharacterFields(CurrentUserId,
             character,
             editCharacterRequest.FieldValues,
             projectInfo);
@@ -146,7 +146,7 @@ internal class CharacterServiceImpl(
         var character = await LoadCharacter(characterId);
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(characterId.ProjectId);
 
-        var changedFields = fieldSaveHelper.SaveCharacterFields(CurrentUserId,
+        var changedFields = await fieldSaveService.SaveCharacterFields(CurrentUserId,
             character,
             fieldsToSet,
             projectInfo);

--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -5,6 +5,7 @@ using JoinRpg.Domain.CharacterFields;
 using JoinRpg.Domain.Problems;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.Services.Impl.CharacterFields;
 using JoinRpg.Services.Interfaces.Notification;
 
 namespace JoinRpg.Services.Impl.Claims;
@@ -12,7 +13,7 @@ namespace JoinRpg.Services.Impl.Claims;
 internal class ClaimServiceImpl(
     IUnitOfWork unitOfWork,
     IEmailService emailService,
-    FieldSaveHelper fieldSaveHelper,
+    CharacterFieldsSaveService fieldSaveService,
     IAccommodationInviteService accommodationInviteService,
     ICurrentUserAccessor currentUserAccessor,
     IProjectMetadataRepository projectMetadataRepository,
@@ -130,7 +131,7 @@ internal class ClaimServiceImpl(
 
         _ = UnitOfWork.GetDbSet<Claim>().Add(claim);
 
-        _ = fieldSaveHelper.SaveCharacterFields(CurrentUserId, claim, FieldLayerContainer.Empty(projectInfo), projectInfo);
+        _ = await fieldSaveService.SaveCharacterFields(CurrentUserId, claim, FieldLayerContainer.Empty(projectInfo), projectInfo);
 
         await UnitOfWork.SaveChangesAsync();
 
@@ -174,7 +175,7 @@ internal class ClaimServiceImpl(
         };
 
         // Т.к. CreateClaimCommentWithNotification ожидает, что комментарий уже существует
-        _ = fieldSaveHelper.SaveCharacterFields(CurrentUserId, claim, fields, projectInfo);
+        _ = await fieldSaveService.SaveCharacterFields(CurrentUserId, claim, fields, projectInfo);
         _ = UnitOfWork.GetDbSet<Claim>().Add(claim);
         await UnitOfWork.SaveChangesAsync();
 
@@ -331,7 +332,7 @@ internal class ClaimServiceImpl(
         // 2. M.b. we need to move some field values from Claim to Characters
         // 3. (2) Could activate changing of special groups
         // we don't need send to show updated fields in email here, so ignore return result. 
-        _ = fieldSaveHelper.SaveCharacterFields(CurrentUserId, claim, FieldLayerContainer.Empty(projectInfo), projectInfo);
+        _ = await fieldSaveService.SaveCharacterFields(CurrentUserId, claim, FieldLayerContainer.Empty(projectInfo), projectInfo);
 
         await UnitOfWork.SaveChangesAsync();
 
@@ -787,7 +788,7 @@ internal class ClaimServiceImpl(
     {
         var (claim, projectInfo) = await LoadClaimAsMaster(claimId, Permission.None, ExtraAccessReason.Player);
 
-        var updatedFields = fieldSaveHelper.SaveCharacterFields(CurrentUserId, claim, fieldsToSet, projectInfo);
+        var updatedFields = await fieldSaveService.SaveCharacterFields(CurrentUserId, claim, fieldsToSet, projectInfo);
         if (updatedFields.Any(f => f.Field.BoundTo == FieldBoundTo.Character) && claim.Character != null)
         {
             MarkChanged(claim.Character);
@@ -1015,7 +1016,7 @@ internal class ClaimServiceImpl(
             CommentDiscussion = new CommentDiscussion() { CommentDiscussionId = -1, ProjectId = characterId.ProjectId },
         };
 
-        _ = fieldSaveHelper.SaveCharacterFields(CurrentUserId, claim, fields, projectInfo);
+        _ = await fieldSaveService.SaveCharacterFields(CurrentUserId, claim, fields, projectInfo);
         _ = UnitOfWork.GetDbSet<Claim>().Add(claim);
         await UnitOfWork.SaveChangesAsync();
 

--- a/src/JoinRpg.Services.Impl/Projects/IProjectPropsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/IProjectPropsService.cs
@@ -62,6 +62,33 @@ internal interface IProjectPropsService
         [CallerMemberName] string operationName = "");
 
     /// <summary>
+    /// Изменяет метаданные проекта как побочный эффект операции, права на которую вызывающий
+    /// проверил сам (сейчас — отметка <c>WasEverUsed</c> при сохранении полей заявки или персонажа).
+    /// Мастерские права здесь НЕ проверяются: отметку ставит тот, кто заполнил поле, — в том числе
+    /// игрок в своей заявке, а мастерских прав у него нет. Всё остальное — как в
+    /// <see cref="ChangeProjectProperties{TArgs}"/>: своя <c>SaveChanges</c>, пересборка
+    /// <see cref="ProjectInfo"/>, обновление кэша и логирование.
+    /// </summary>
+    /// <remarks>
+    /// Обратная сторона собственной <c>SaveChanges</c>: репозитории работают с тем же
+    /// <c>DbContext</c>, что и вызывающий сценарий, поэтому вызов досрочно сбрасывает в БД и его
+    /// незакоммиченные изменения. Поэтому вызывать только тогда, когда менять действительно есть
+    /// что — см. <c>FieldSaveHelper.MarkAsUsed</c>.
+    /// </remarks>
+    /// <typeparam name="TArgs">Тип аргументов операции; логируется вместе с именем операции.</typeparam>
+    /// <param name="projectId">Проект, метаданные которого меняются.</param>
+    /// <param name="activeRequirement">Допустима ли операция над неактивным проектом.</param>
+    /// <param name="arguments">Аргументы операции; передаются в <paramref name="action"/> и логируются.</param>
+    /// <param name="action">Мутация EF-сущности проекта. Второй параметр — снимок метаданных ДО изменения.</param>
+    /// <param name="operationName">Имя операции для лога; по умолчанию — имя вызывающего метода.</param>
+    Task ChangeProjectPropertiesAsSideEffect<TArgs>(
+        ProjectIdentification projectId,
+        ProjectActiveRequirement activeRequirement,
+        TArgs arguments,
+        Action<ProjectMutationContext<TArgs>> action,
+        [CallerMemberName] string operationName = "");
+
+    /// <summary>
     /// Создаёт новый проект: <paramref name="factory"/> строит EF-сущность <see cref="Project"/>
     /// (используя <see cref="ProjectCreationContext{TArgs}"/> для аудита), сервис добавляет её в БД
     /// и сохраняет. Единственная точка создания <see cref="Project"/>.

--- a/src/JoinRpg.Services.Impl/Projects/ProjectPropsService.cs
+++ b/src/JoinRpg.Services.Impl/Projects/ProjectPropsService.cs
@@ -34,6 +34,15 @@ internal class ProjectPropsService(
         => ChangeProjectPropertiesCore(projectId, requiredPermission, activeRequirement, arguments,
             action, operationName);
 
+    public Task ChangeProjectPropertiesAsSideEffect<TArgs>(
+        ProjectIdentification projectId,
+        ProjectActiveRequirement activeRequirement,
+        TArgs arguments,
+        Action<ProjectMutationContext<TArgs>> action,
+        [CallerMemberName] string operationName = "")
+        => ChangeProjectPropertiesCore(projectId, requiredPermission: null, activeRequirement, arguments,
+            AsFunc(action), operationName);
+
     private static Func<ProjectMutationContext<TArgs>, bool> AsFunc<TArgs>(Action<ProjectMutationContext<TArgs>> action)
         => ctx =>
         {
@@ -41,9 +50,13 @@ internal class ProjectPropsService(
             return true;
         };
 
+    /// <param name="requiredPermission">
+    /// Право, которым должен обладать текущий пользователь; <c>null</c> — проверки нет, права
+    /// проверил вызывающий сценарий (см. <see cref="ChangeProjectPropertiesAsSideEffect"/>).
+    /// </param>
     private async Task<TResult> ChangeProjectPropertiesCore<TArgs, TResult>(
         ProjectIdentification projectId,
-        Permission requiredPermission,
+        Permission? requiredPermission,
         ProjectActiveRequirement activeRequirement,
         TArgs arguments,
         Func<ProjectMutationContext<TArgs>, TResult> action,
@@ -58,9 +71,9 @@ internal class ProjectPropsService(
             var handle = await unitOfWork.GetProjectMetadataWriteRepository().LoadProjectForUpdate(projectId);
 
             // Админ (в т.ч. робот, под которым выполняются фоновые джобы) проходит проверку прав.
-            if (!currentUserAccessor.IsAdmin)
+            if (requiredPermission is Permission permission && !currentUserAccessor.IsAdmin)
             {
-                _ = handle.ProjectInfo.RequestMasterAccess(currentUserAccessor, requiredPermission);
+                _ = handle.ProjectInfo.RequestMasterAccess(currentUserAccessor, permission);
             }
 
             if (activeRequirement == ProjectActiveRequirement.MustBeActive)

--- a/src/JoinRpg.Services.Impl/Services.cs
+++ b/src/JoinRpg.Services.Impl/Services.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using JoinRpg.Services.Email;
+using JoinRpg.Services.Impl.CharacterFields;
 using JoinRpg.Services.Impl.Claims;
 using JoinRpg.Services.Impl.Projects;
 using JoinRpg.Services.Impl.Projects.Create;
@@ -52,6 +53,7 @@ public static class Services
             .AddDailyJob<BastiliaGamesSyncDailyJob>()
             .AddTransient<ICharacterGroupService, CharacterGroupService>()
             .AddTransient<IProjectPropsService, ProjectPropsService>()
+            .AddScoped<CharacterFieldsSaveService>()
             .AddTransient<ICaptainRuleService, CaptainRuleService>()
             .AddTransient<IProjectRolesListService, ProjectRolesListService>()
             .AddTransient<IProjectAccessService, ProjectAccessService>()


### PR DESCRIPTION
## Зачем

`WasEverUsed` входит в `ProjectInfo` (`ProjectFieldInfo.WasEverUsed`, `ProjectFieldVariant.WasEverUsed`) и запрещает окончательное удаление поля — то есть это метаданные проекта. Но отметка ставилась прямой мутацией `ProjectField`/`ProjectFieldDropdownValue` в `FieldSaveHelper.MarkUsed`, а сохранялась чужим `SaveChanges` из `ClaimServiceImpl`/`CharacterServiceImpl`, в обход [ADR009](../blob/master/docs/adr009-project-props-service.md). Это единственное найденное нарушение инварианта «метаданные меняются только через `ProjectPropsService`» по полям и вариантам.

## Что сделано

- `FieldSaveHelper` больше не трогает метаданные — он только сохраняет значения. Стратегии сохранения (`FieldSaveStrategyBase` и три реализации) `internal` внутри `JoinRpg.Domain`, поэтому перенести хелпер целиком в `Services.Impl` можно было бы только сделав их публичными — то есть раскрыв наружу специально спрятанное. Вместо этого хелпер остался в Domain.
- Новый `CharacterFieldsSaveService` (`Services.Impl`) — точка входа сервисного слоя: сохраняет значения через `FieldSaveHelper`, затем доводит отметку через `IProjectPropsService`. `ClaimServiceImpl`/`CharacterServiceImpl` зовут его (8 мест).
- `IProjectPropsService.ChangeProjectPropertiesAsSideEffect` — то же, что `ChangeProjectProperties`, но без проверки мастерских прав. Требовать их здесь нельзя: отметку ставит тот, кто заполнил поле, в том числе игрок в своей заявке (`SaveFieldsFromClaim` грузит заявку как `Permission.None` + `ExtraAccessReason.Player`).
- `ProjectActiveRequirement.AllowInactive`: отметка — бухгалтерия, а не намерение пользователя, и ронять из-за неё сохранение заявки на закрытом проекте хуже, чем отметить поле в закрытом проекте.

## Цена на горячем пути — нулевая в обычном случае

Отметка монотонна (`false → true`), поэтому нужные поля видно по снимку метаданных без обращения в БД. Если всё уже отмечено — а это подавляющее большинство сохранений — `CollectNotYetMarked` возвращает пусто и в БД не идём вовсе. Тяжёлая часть (`LoadProjectForUpdate` с девятью `Include` + `SaveChanges`) срабатывает только при первом заполнении поля или первом выборе варианта.

## Что стоит знать при ревью

`ChangeProjectPropertiesAsSideEffect` делает свой `SaveChanges` на том же `DbContext`, что и вызывающий сценарий, — значит в тот редкий раз, когда отметка реально ставится, досрочно сбрасываются и незакоммиченные изменения вызывающего. Для `ApproveByMaster` это означает, что отклонение прочих заявок закоммитится до конца метода. Осознанный компромисс: альтернатива — отметка мимо `ProjectPropsService` (как было) либо второй `DbContext`. Написано в `<remarks>` метода.

## Тесты

`CharacterFieldsSaveServiceTest` (6 тестов) поверх реального `ProjectPropsService` и фейков: первое заполнение ставит отметку, отметка видна в пересобранном `ProjectInfo`, уже отмеченное поле не вызывает записи вовсе, игрок без мастерских прав отметку поставить может, выбранный вариант дропдауна отмечается. В `FieldSaveHelperTest` убран no-op override `MarkAsUsed` — переопределять больше нечего.

Полный прогон зелёный, включая 159 интеграционных тестов.

Generated with [Claude Code](https://claude.ai/code)