### PR TITLE
refactor: перенести ClaimWrongStatusException в DomainTypes

### DIFF
--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -72,7 +72,7 @@ public static class ClaimAcceptOrMoveValidationExtensions
             AddClaimForbideReason.AlreadySent => new ClaimAlreadyPresentException(),
             AddClaimForbideReason.OnlyOneCharacter => new OnlyOneApprovedClaimException(),
 
-            AddClaimForbideReason.ApprovedClaimMovedToSlot or AddClaimForbideReason.CheckedInClaimCantBeMoved => new ClaimWrongStatusException(claim!),
+            AddClaimForbideReason.ApprovedClaimMovedToSlot or AddClaimForbideReason.CheckedInClaimCantBeMoved => new ClaimWrongStatusException(claim!.GetId(), claim.ClaimStatus),
             AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing or
             AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing => new InsufficientContactsException(),
             _ => new ArgumentOutOfRangeException(nameof(reason), reason.Kind, message: null),

--- a/src/JoinRpg.Domain/ClaimExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimExtensions.cs
@@ -37,7 +37,7 @@ public static class ClaimExtensions
     {
         if (!possibleStatus.Contains(claim.ClaimStatus))
         {
-            throw new ClaimWrongStatusException(claim, possibleStatus);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus, possibleStatus);
         }
     }
 
@@ -83,7 +83,7 @@ public static class ClaimExtensions
     {
         if (!claim.ClaimStatus.CanChangeTo(targetStatus))
         {
-            throw new ClaimWrongStatusException(claim);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus);
         }
     }
 

--- a/src/JoinRpg.Domain/Exceptions.cs
+++ b/src/JoinRpg.Domain/Exceptions.cs
@@ -1,4 +1,3 @@
-using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.Interfaces;
 using JoinRpg.Helpers;
 
@@ -124,19 +123,6 @@ public class ProjectEntityDeactivatedException : JoinRpgProjectEntityException
     public ProjectEntityDeactivatedException(IProjectEntity entity) : base(entity, $"This operation can't be performed on deactivated entity")
     {
 
-    }
-}
-
-public class ClaimWrongStatusException : JoinRpgProjectEntityException
-{
-    public ClaimWrongStatusException(Claim entity, IEnumerable<ClaimStatus> possible)
-      : base(entity, $"This operation can be performed only on claims with status {string.Join(", ", possible.Select(s => s.ToString()))}, but current status is {entity.ClaimStatus}")
-    {
-    }
-
-    public ClaimWrongStatusException(Claim entity)
-      : base(entity, $"This operation can not be performed on claim with status = {entity.ClaimStatus}.")
-    {
     }
 }
 

--- a/src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs
@@ -1,3 +1,4 @@
+using JoinRpg.DomainTypes.ProjectMetadata;
 using JoinRpg.Helpers;
 
 namespace JoinRpg.DomainTypes.Characters.Claims;
@@ -18,3 +19,20 @@ public class ClaimTargetIsNotAcceptingClaims : JoinRpgBaseException
 }
 
 public class InsufficientContactsException() : JoinRpgBaseException("Для отправки заявки необходимы контакты");
+
+public class ClaimWrongStatusException : JoinRpgProjectException
+{
+    public ClaimWrongStatusException(ClaimIdentification claimId, ClaimStatus currentStatus, IEnumerable<ClaimStatus> possible)
+      : base(claimId.ProjectId, $"This operation can be performed only on claims with status {string.Join(", ", possible.Select(s => s.ToString()))}, but current status is {currentStatus}")
+    {
+        ClaimId = claimId;
+    }
+
+    public ClaimWrongStatusException(ClaimIdentification claimId, ClaimStatus currentStatus)
+      : base(claimId.ProjectId, $"This operation can not be performed on claim with status = {currentStatus}.")
+    {
+        ClaimId = claimId;
+    }
+
+    public ClaimIdentification ClaimId { get; }
+}

--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -32,7 +32,7 @@ internal class ClaimServiceImpl(
         var validator = new ClaimCheckInValidator(claim, claimValidator, projectInfo);
         if (!validator.CanCheckInInPrinciple)
         {
-            throw new ClaimWrongStatusException(claim);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus);
         }
 
         ClaimSimpleChangedNotification? financeEmail = null;
@@ -50,7 +50,7 @@ internal class ClaimServiceImpl(
 
         if (!validator.CanCheckInNow)
         {
-            throw new ClaimWrongStatusException(claim);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus);
         }
 
         claim.ClaimStatus = ClaimStatus.CheckedIn;
@@ -283,7 +283,7 @@ internal class ClaimServiceImpl(
 
         if (claim.ClaimStatus == ClaimStatus.CheckedIn)
         {
-            throw new ClaimWrongStatusException(claim);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus);
         }
 
         commentText ??= "";
@@ -880,7 +880,7 @@ internal class ClaimServiceImpl(
         // Принять можно только приглашение от мастера
         if (claim.ClaimStatus != ClaimStatus.AddedByMaster)
         {
-            throw new ClaimWrongStatusException(claim);
+            throw new ClaimWrongStatusException(claim.GetId(), claim.ClaimStatus);
         }
 
         claim.PlayerAllowedSenstiveData = sensitiveDataAllowed && projectInfo.ProfileRequirementSettings.SensitiveDataRequired;


### PR DESCRIPTION
## Что сделано

`ClaimWrongStatusException` принимал EF-сущность `Claim` и потому не мог уехать вместе с остальными исключениями заявки в #4748. Теперь он принимает `ClaimIdentification` + `ClaimStatus` и лежит в `src/JoinRpg.DomainTypes/Characters/Claims/Exceptions.cs` рядом с `ClaimAlreadyPresentException`, `OnlyOneApprovedClaimException`, `ClaimTargetIsNotAcceptingClaims` и `InsufficientContactsException`.

Базовый класс сменился с `JoinRpgProjectEntityException` на `JoinRpgProjectException`. Обновлены все 7 мест, которые его бросают: `ClaimExtensions` ×2, `ClaimServiceImpl` ×4 и `ThrowForReason` в `ClaimAcceptOrMoveValidationExtensions`.

## Почему смена базового класса безопасна

Проверено по коду:

- свойство `Entity` у `JoinRpgProjectEntityException` **не читается нигде**;
- сам тип `JoinRpgProjectEntityException` **нигде не ловится**;
- `ClaimWrongStatusException` ловится только конкретно — в `JoinMvcControllerBase` — и только ради `exception.Message`.

Сообщения об ошибках сохранены дословно: они видны пользователю через ModelState.

## Информации не убавилось, а прибавилось

`ProjectId` для базового класса берётся из `ClaimIdentification`, а сам id заявки теперь доступен явным свойством `ClaimId` — по образцу соседнего `PlayerOnlyException`. Раньше он лежал в `Entity`, который никто не читал, так что в логах его фактически не было.

## Проверка

`dotnet build` — 0 ошибок, `dotnet format --verify-no-changes --severity warn` — чисто, полный `dotnet test` — все 25 проектов проходят (`JoinRpg.IntegrationTest` пришлось перезапустить: контейнер SQL Server периодически не поднимается, к изменению отношения не имеет).

## Что дальше

После этого PR **все** исключения, которые транслирует `ThrowForReason`, окажутся в `DomainTypes` — значит и сам `ThrowForReason` сможет туда переехать, поменяв параметр `Claim?` на `UserClaimInfo?`. Это отдельный шаг: он опирается на `ClaimValidator` из #4772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY
