### PR TITLE
fix: пользователь дублировался в поиске при совпадении по VK id

### DIFF
--- a/src/JoinRpg.Services.Impl.Test/SearchServiceImplTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/SearchServiceImplTest.cs
@@ -1,0 +1,87 @@
+using JoinRpg.DataModel;
+using JoinRpg.Services.Impl.Search;
+using JoinRpg.Services.Interfaces.Search;
+
+namespace JoinRpg.Services.Impl.Test;
+
+public class SearchServiceImplTest
+{
+    private sealed class FakeSearchProvider(params SearchResult[] results) : ISearchProvider
+    {
+        public Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+            => Task.FromResult<IReadOnlyCollection<SearchResult>>(results);
+    }
+
+    private static SearchResult UserResult(int userId, string description, bool isPerfectMatch = false) => new()
+    {
+        LinkType = LinkType.ResultUser,
+        Name = "Test User",
+        Description = new MarkdownDbValue(description),
+        Identification = userId.ToString(),
+        ProjectId = null,
+        IsPublic = true,
+        IsActive = true,
+        IsPerfectMatch = isPerfectMatch,
+    };
+
+    [Fact]
+    public async Task SameUserFoundByTwoProviders_IsReturnedOnce()
+    {
+        // Как при поиске по "id123456": UserSearchByIdProvider и UserSearchBySocialProvider
+        // находят одного и того же пользователя и раньше отдавали два разных SearchResult
+        // (с разным Description), которые Distinct() не считал дубликатами.
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(UserResult(42, "ID: 42")),
+            new FakeSearchProvider(UserResult(42, "")),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "id42");
+
+        results.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SameUserFoundByTwoProviders_DescriptionsAreMerged()
+    {
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(UserResult(42, "ID: 42")),
+            new FakeSearchProvider(UserResult(42, "Найден в контактах")),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "id42");
+
+        var result = results.ShouldHaveSingleItem();
+        result.Description.Contents.ShouldBe("ID: 42, Найден в контактах");
+    }
+
+    [Fact]
+    public async Task SameUserFoundByTwoProviders_WithSameDescription_IsNotDuplicated()
+    {
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(UserResult(42, "ID: 42")),
+            new FakeSearchProvider(UserResult(42, "ID: 42")),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "id42");
+
+        var result = results.ShouldHaveSingleItem();
+        result.Description.Contents.ShouldBe("ID: 42");
+    }
+
+    [Fact]
+    public async Task DifferentUsers_AreBothReturned()
+    {
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(UserResult(1, "ID: 1")),
+            new FakeSearchProvider(UserResult(2, "ID: 2")),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "test");
+
+        results.Count.ShouldBe(2);
+    }
+}

--- a/src/JoinRpg.Services.Impl/Search/Providers/UserSearchByIdProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/UserSearchByIdProvider.cs
@@ -35,7 +35,6 @@ internal class UserSearchByIdProvider(IUnitOfWork unitOfWork) : ISearchProvider
         {
             predicateBuilder = predicateBuilder.Or(user => user.Extra != null && user.Extra!.Vk == "id" + idToFind);
             predicateBuilder = predicateBuilder.Or(user => user.ExternalLogins.Any(el => el.Key == idToFind.ToString()));
-            predicateBuilder = predicateBuilder.Or(user => user.Extra != null && user.Extra.Vk! == "id" + idToFind);
         }
 
         var results = await unitOfWork

--- a/src/JoinRpg.Services.Impl/Search/SearchServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Search/SearchServiceImpl.cs
@@ -1,3 +1,4 @@
+using JoinRpg.DataModel;
 using JoinRpg.Services.Interfaces.Search;
 
 namespace JoinRpg.Services.Impl.Search;
@@ -21,15 +22,44 @@ internal class SearchServiceImpl(IEnumerable<ISearchProvider> searchProviders) :
             //TODO: We can stop here when we have X results.
             results.AddRange(rGroup);
 
-            // If there're results that perfectly match the search string - return them only. 
+            // If there're results that perfectly match the search string - return them only.
             // e.g. контакты123 should return only useer with ID=123
             if (rGroup.Any(r => r.IsPerfectMatch))
             {
-                return [.. results.Where(r => r.IsPerfectMatch).Distinct()];
+                return Deduplicate(results.Where(r => r.IsPerfectMatch));
             }
         }
 
 
-        return [.. results.Distinct()];
+        return Deduplicate(results);
+    }
+
+    /// <summary>
+    /// Разные провайдеры могут найти один и тот же объект (пользователя, персонажа, заявку)
+    /// по разным признакам (например по id и по ссылке на VK) и заполнить Description
+    /// по-разному. Схлопываем такие результаты по бизнес-ключу (LinkType, Identification)
+    /// вместо Distinct() по всему record, объединяя все найденные Description, а не выбрасывая
+    /// часть из них.
+    /// </summary>
+    private static IReadOnlyCollection<SearchResult> Deduplicate(IEnumerable<SearchResult> results)
+        => [.. results
+            .GroupBy(r => (r.LinkType, r.Identification))
+            .Select(g => g.Count() == 1
+                ? g.First()
+                : g.First() with
+                {
+                    Description = MergeDescriptions(g),
+                    IsPerfectMatch = g.Any(r => r.IsPerfectMatch),
+                })];
+
+    private static MarkdownDbValue MergeDescriptions(IEnumerable<SearchResult> group)
+    {
+        var parts = group
+            .Select(r => r.Description.Contents)
+            .Where(contents => !string.IsNullOrWhiteSpace(contents))
+            .Distinct()
+            .ToArray();
+
+        return parts.Length == 0 ? new MarkdownDbValue() : new MarkdownDbValue(string.Join(", ", parts));
     }
 }


### PR DESCRIPTION
## Проблема

При поиске пользователя строкой вида `id123456` (характерный формат VK id) одного и того же пользователя находили сразу два независимых провайдера поиска — `UserSearchByIdProvider` (по числовому id) и `UserSearchBySocialProvider` (по точному совпадению `Extra.Vk`). Каждый заполнял `Description` по-своему.

`SearchResult` — `record`, а `Distinct()` в `SearchServiceImpl.SearchAsync` сравнивает все поля целиком. Из-за разного `Description` два результата для одного пользователя не считались дубликатами, и он показывался в выдаче дважды.

## Что сделано

- В `SearchServiceImpl` дедупликация теперь идёт по бизнес-ключу `(LinkType, Identification)`, а не по всему record.
- При совпадении по ключу `Description` от разных провайдеров объединяются (уникальные непустые части через запятую), а не теряются и не задваиваются.
- Заодно убрано случайно задвоенное условие в предикате `UserSearchByIdProvider`.
- Добавлены юнит-тесты на `SearchServiceImpl` с фейковыми `ISearchProvider`, покрывающие: схлопывание дубля, объединение разных `Description`, отсутствие задвоения при одинаковом `Description`, и что разные пользователи по-прежнему возвращаются оба.

## Test plan

- [x] `dotnet test src/JoinRpg.Services.Impl.Test` — новые тесты `SearchServiceImplTest` проходят (4/4)
- [x] `dotnet build` без новых ошибок/предупреждений