### PR TITLE
refactor: общий слой Managers над персонажами/проектами для x-api (ADR012)

### DIFF
--- a/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
@@ -1,32 +1,14 @@
 using System.Text.Json;
-using JoinRpg.Data.Interfaces;
-using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.Domain;
-using JoinRpg.Domain.Access;
-using JoinRpg.DomainTypes.Characters;
-using JoinRpg.Interfaces;
 using JoinRpg.Portal.Infrastructure.Authorization;
-using JoinRpg.Services.Interfaces.Characters;
-using JoinRpg.Web.Models.Characters;
+using JoinRpg.WebPortal.Managers.Characters;
 using JoinRpg.XGameApi.Contract;
 using Microsoft.AspNetCore.Mvc;
-using CharacterHeader = JoinRpg.XGameApi.Contract.CharacterHeader;
-// Не путать с доменным CharacterInfo (ADR013): здесь CharacterInfo — DTO внешнего API,
-// а доменный агрегат называется DomainCharacterInfo.
-using CharacterInfo = JoinRpg.XGameApi.Contract.CharacterInfo;
-using DomainCharacterInfo = JoinRpg.DomainTypes.Characters.CharacterInfo;
 
 namespace JoinRpg.Portal.Controllers.XGameApi;
 
 [Route("x-game-api/{projectId}/characters"), XGameMasterAuthorize()]
-public class CharacterApiController(
-    ICharacterRepository characterRepository,
-    ICharacterInfoRepository characterInfoRepository,
-    IUserRepository userRepository,
-    ICharacterService characterService,
-    IProjectMetadataRepository projectMetadataRepository,
-    ICurrentUserAccessor currentUserAccessor
-        ) : XGameApiController()
+public class CharacterApiController(ICharacterApiViewService characterApiViewService) : XGameApiController()
 {
 
     /// <summary>
@@ -39,18 +21,8 @@ public class CharacterApiController(
         [FromQuery]
         DateTime? modifiedSince = null)
     {
-        return (await characterRepository.GetCharacterHeaders(projectId, modifiedSince))
-            .Select(character => BuildCharacterHeader(projectId, character.CharacterId, character.UpdatedAt, character.IsActive));
+        return await characterApiViewService.GetCharacterHeaders(new ProjectIdentification(projectId), modifiedSince);
     }
-
-    private static CharacterHeader BuildCharacterHeader(int projectId, int characterId, DateTime updatedAt, bool isActive) =>
-        new CharacterHeader
-        {
-            CharacterId = characterId,
-            UpdatedAt = updatedAt,
-            IsActive = isActive,
-            CharacterLink = $"/x-game-api/{projectId}/characters/{characterId}/",
-        };
 
     /// <summary>
     /// Character details
@@ -59,43 +31,7 @@ public class CharacterApiController(
     [Route("{characterId}/")]
     public async Task<CharacterInfo> GetOne(int projectId, int characterId)
     {
-        var character = await characterInfoRepository.GetCharacterInfo(
-            new CharacterIdentification(new ProjectIdentification(projectId), characterId));
-
-        // ProjectInfo несёт сам агрегат — отдельный запрос метаданных не нужен.
-        var access = AccessArgumentsFactory.Create(character, currentUserAccessor);
-        var fields = character.GetFieldLayers(access);
-
-        return
-            new CharacterInfo
-            {
-                CharacterId = character.Id.CharacterId,
-                UpdatedAt = character.UpdatedAt,
-                IsActive = character.IsActive,
-                InGame = character.InGame,
-                BusyStatus = (CharacterBusyStatus)character.GetBusyStatus(),
-                Groups = ApiInfoBuilder.ToGroupHeaders([.. character.DirectGroups]),
-                AllGroups = ApiInfoBuilder.ToGroupHeaders([.. character.ParentGroupsToTop]),
-                Fields = [.. fields.GetSortedFieldsForView().Select(ApiInfoBuilder.ToFieldValue)],
-#pragma warning disable CS0612 // Type or member is obsolete
-                PlayerUserId = character.ApprovedClaim?.PlayerId.Value,
-#pragma warning restore CS0612 // Type or member is obsolete
-                CharacterDescription = character.Description.Value,
-                CharacterName = character.CharacterName,
-                PlayerInfo = await CreatePlayerInfo(character),
-            };
-    }
-
-    private async Task<CharacterPlayerInfo?> CreatePlayerInfo(
-        DomainCharacterInfo character)
-    {
-        if (character.ApprovedClaim is not { } approvedClaim)
-        {
-            return null;
-        }
-
-        var player = await userRepository.GetRequiredUserInfo(approvedClaim.PlayerId);
-        return ApiInfoBuilder.CreatePlayerInfo(character, approvedClaim, player);
+        return await characterApiViewService.GetCharacterInfo(new CharacterIdentification(new ProjectIdentification(projectId), characterId));
     }
 
     /// <summary>
@@ -108,24 +44,10 @@ public class CharacterApiController(
     [ProducesDefaultResponseType]
     public async Task<ActionResult<CharacterHeader>> CreateCharacter(int projectId, [FromBody] CreateCharacterRequest request)
     {
-        CharacterTypeInfo characterTypeInfo;
+        CharacterHeader character;
         try
         {
-            characterTypeInfo = CreateCharacterRequestMapper.ToCharacterTypeInfo(request);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(ex.Message);
-        }
-
-        var projectInfo = await projectMetadataRepository.GetProjectMetadata(new ProjectIdentification(projectId));
-
-        FieldLayerContainer fieldsToSet;
-        try
-        {
-            fieldsToSet = new FieldLayerContainer(
-                projectInfo,
-                FieldValueConverter.ConvertToStringValues(request.FieldValues));
+            character = await characterApiViewService.CreateCharacter(new ProjectIdentification(projectId), request);
         }
         catch (ArgumentException ex)
         {
@@ -137,17 +59,7 @@ public class CharacterApiController(
             return BadRequest(ex.Message);
         }
 
-        var characterId = await characterService.AddCharacter(new AddCharacterRequest(
-            new ProjectIdentification(projectId),
-            [],
-            characterTypeInfo,
-            fieldsToSet));
-
-        var character = await characterInfoRepository.GetCharacterInfo(characterId);
-        return CreatedAtAction(
-            nameof(GetOne),
-            new { projectId, characterId = characterId.CharacterId },
-            BuildCharacterHeader(projectId, character.Id.CharacterId, character.UpdatedAt, character.IsActive));
+        return CreatedAtAction(nameof(GetOne), new { projectId, characterId = character.CharacterId }, character);
     }
 
     /// <summary>
@@ -165,14 +77,9 @@ public class CharacterApiController(
     [ProducesDefaultResponseType]
     public async Task<ActionResult<string>> SetCharacterFields(int projectId, int characterId, [FromBody] Dictionary<int, JsonElement> fieldValues)
     {
-        var projectInfo = await projectMetadataRepository.GetProjectMetadata(new ProjectIdentification(projectId));
-
-        FieldLayerContainer fieldsToSet;
         try
         {
-            fieldsToSet = new FieldLayerContainer(
-                projectInfo,
-                FieldValueConverter.ConvertToStringValues(fieldValues));
+            await characterApiViewService.SetCharacterFields(new CharacterIdentification(projectId, characterId), fieldValues);
         }
         catch (ArgumentException ex)
         {
@@ -182,10 +89,6 @@ public class CharacterApiController(
         {
             // Поля, которого нет в проекте, раньше хватало на 500 из глубины домена.
             return BadRequest(ex.Message);
-        }
-        try
-        {
-            await characterService.SetFields(new CharacterIdentification(projectId, characterId), fieldsToSet);
         }
         catch (FieldCannotHaveValueException ex)
         {

--- a/src/JoinRpg.Portal/Controllers/XGameApi/ClaimsController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/ClaimsController.cs
@@ -1,5 +1,6 @@
 using JoinRpg.Data.Interfaces.Claims;
 using JoinRpg.Portal.Infrastructure.Authorization;
+using JoinRpg.WebPortal.Managers.Characters;
 using JoinRpg.XGameApi.Contract;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/JoinRpg.Portal/Controllers/XGameApi/MetaDataApicontroller.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/MetaDataApicontroller.cs
@@ -1,13 +1,12 @@
-using JoinRpg.Data.Interfaces;
-using JoinRpg.Markdown;
 using JoinRpg.Portal.Infrastructure.Authorization;
+using JoinRpg.WebPortal.Managers.Projects;
 using JoinRpg.XGameApi.Contract;
 using Microsoft.AspNetCore.Mvc;
 
 namespace JoinRpg.Portal.Controllers.XGameApi;
 
 [Route("x-game-api/{projectId}/metadata"), XGameMasterAuthorize]
-public class MetaDataApiController(IProjectMetadataRepository projectMetadataRepository) : XGameApiController
+public class MetaDataApiController(IProjectApiViewService projectApiViewService) : XGameApiController
 {
 
     /// <summary>
@@ -17,32 +16,6 @@ public class MetaDataApiController(IProjectMetadataRepository projectMetadataRep
     [Route("fields")]
     public async Task<ProjectFieldsMetadata> GetFieldsList(int projectId)
     {
-        var project = await projectMetadataRepository.GetProjectMetadata(new(projectId));
-        return
-            new ProjectFieldsMetadata
-            {
-                ProjectId = project.ProjectId,
-                ProjectName = project.ProjectName,
-                Fields = project.SortedFields.Select(field =>
-                    new JoinRpg.XGameApi.Contract.ProjectFieldInfo
-                    {
-                        FieldName = field.Name,
-                        ProjectFieldId = field.Id.ProjectFieldId,
-                        IsActive = field.IsActive,
-                        FieldType = field.Type.ToString(),
-                        ProgrammaticValue = field.ProgrammaticValue,
-                        ValueList = field.SortedVariants.Select(variant =>
-                            new JoinRpg.XGameApi.Contract.ProjectFieldVariant
-                            {
-                                ProjectFieldVariantId = variant.Id.ProjectFieldVariantId,
-                                Label = variant.Label,
-                                IsActive = variant.IsActive,
-                                Description = variant.Description.ToHtmlString().Value,
-                                MasterDescription =
-                                    variant.MasterDescription.ToHtmlString().Value,
-                                ProgrammaticValue = variant.ProgrammaticValue,
-                            }),
-                    }),
-            };
+        return await projectApiViewService.GetFieldsMetadata(new ProjectIdentification(projectId));
     }
 }

--- a/src/JoinRpg.Portal/Controllers/XGameApi/MyProfileController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/MyProfileController.cs
@@ -1,5 +1,5 @@
-using JoinRpg.Data.Interfaces;
 using JoinRpg.Interfaces;
+using JoinRpg.WebPortal.Managers.Projects;
 using JoinRpg.XGameApi.Contract;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace JoinRpg.Portal.Controllers.XGameApi;
 
 [Route("x-api/me")]
-public class MyProfileController(IProjectRepository projectRepository, ICurrentUserAccessor currentUserAccessor) : XGameApiController
+public class MyProfileController(IProjectApiViewService projectApiViewService, ICurrentUserAccessor currentUserAccessor) : XGameApiController
 {
 
     /// <summary>
@@ -16,7 +16,6 @@ public class MyProfileController(IProjectRepository projectRepository, ICurrentU
     [HttpGet, Authorize("XApiUser"), Route("projects/active")]
     public async Task<IEnumerable<ProjectHeader>> GetActiveProjects()
     {
-        return (await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.MyActiveProjects(currentUserAccessor.UserIdentification)))
-            .Select(p => new ProjectHeader { ProjectId = p.ProjectId, ProjectName = p.ProjectName });
+        return await projectApiViewService.GetActiveProjects(currentUserAccessor.UserIdentification);
     }
 }

--- a/src/JoinRpg.Portal/Controllers/XGameApi/XUserInfoController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/XUserInfoController.cs
@@ -2,6 +2,7 @@ using Joinrpg.Web.Identity;
 using JoinRpg.Data.Interfaces;
 using JoinRpg.Portal.Infrastructure.XApi;
 using JoinRpg.Services.Interfaces.Avatars;
+using JoinRpg.WebPortal.Managers.Characters;
 using JoinRpg.XGameApi.Contract;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/JoinRpg.WebPortal.Managers.Test/Characters/CharacterApiViewServiceTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/Characters/CharacterApiViewServiceTests.cs
@@ -1,0 +1,140 @@
+using JoinRpg.Common.PrimitiveTypes.Users;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Characters;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.DataModel.Users;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Users;
+using JoinRpg.Interfaces;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.WebPortal.Managers.Characters;
+using CharacterInfo = JoinRpg.DomainTypes.Characters.CharacterInfo;
+
+namespace JoinRpg.WebPortal.Managers.Test.Characters;
+
+/// <summary>
+/// <see cref="CharacterApiViewService"/> — общий слой над x-api и (в будущем) MCP-инструментами
+/// (ADR012 §4). В отличие от x-api-контроллера, чей единственный барьер сегодня — атрибут
+/// <c>[XGameMasterAuthorize]</c>, сервис обязан проверять права мастера сам: MCP через этот
+/// атрибут не проходит вообще.
+/// </summary>
+public class CharacterApiViewServiceTests
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    private CharacterApiViewService CreateService(int userId) =>
+        new(
+            new FakeCharacterRepository(Mock),
+            new FakeCharacterInfoRepository(),
+            new FakeUserRepository(),
+            new FakeCharacterService(),
+            new FakeProjectMetadataRepository(Mock.ProjectInfo),
+            new FakeCurrentUserAccessor { UserIdentification = new UserIdentification(userId) });
+
+    [Fact]
+    public async Task GetCharacterHeaders_Master_ReturnsHeaders()
+    {
+        var service = CreateService(Mock.Master.UserId);
+
+        var headers = await service.GetCharacterHeaders(Mock.ProjectInfo.ProjectId, modifiedSince: null);
+
+        headers.ShouldContain(h => h.CharacterId == Mock.Character.CharacterId);
+    }
+
+    [Fact]
+    public async Task GetCharacterHeaders_NonMaster_ThrowsNoAccessToProjectException()
+    {
+        var service = CreateService(userId: 12345);
+
+        await Should.ThrowAsync<NoAccessToProjectException>(
+            () => service.GetCharacterHeaders(Mock.ProjectInfo.ProjectId, modifiedSince: null));
+    }
+
+    [Fact]
+    public async Task GetCharacterInfo_NonMaster_ThrowsBeforeLoadingCharacter()
+    {
+        // FakeCharacterInfoRepository throws NotImplementedException if actually called —
+        // seeing NoAccessToProjectException instead proves the rights check runs first.
+        var service = CreateService(userId: 12345);
+        var characterId = new CharacterIdentification(Mock.ProjectInfo.ProjectId, Mock.Character.CharacterId);
+
+        await Should.ThrowAsync<NoAccessToProjectException>(() => service.GetCharacterInfo(characterId));
+    }
+
+    private sealed class FakeCharacterRepository(MockedProject mock) : ICharacterRepository
+    {
+        public Task<IReadOnlyCollection<JoinRpg.Data.Interfaces.CharacterHeader>> GetCharacterHeaders(int projectId, DateTime? modifiedSince) =>
+            Task.FromResult<IReadOnlyCollection<JoinRpg.Data.Interfaces.CharacterHeader>>(
+                [.. mock.Project.Characters.Select(c => new JoinRpg.Data.Interfaces.CharacterHeader { CharacterId = c.CharacterId, UpdatedAt = DateTime.UtcNow, IsActive = c.IsActive })]);
+
+        public Task<IReadOnlyCollection<Character>> GetCharacters(IReadOnlyCollection<CharacterIdentification> characterIds) => throw new NotImplementedException();
+        [Obsolete]
+        public Task<Character> GetCharacterAsync(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterAsync(CharacterIdentification characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterWithGroups(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<Character> GetCharacterWithDetails(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<CharacterView> GetCharacterViewAsync(int projectId, int characterId) => throw new NotImplementedException();
+        public Task<IEnumerable<Character>> GetAvailableCharacters(ProjectIdentification projectId) => throw new NotImplementedException();
+        public Task<IEnumerable<Character>> GetAvailableNonSlotCharacters(ProjectIdentification projectId) => throw new NotImplementedException();
+        public Task<IEnumerable<Character>> GetAvailableTemplateCharacters(ProjectIdentification projectId) => throw new NotImplementedException();
+        public Task<IEnumerable<Character>> GetAllCharacters(int projectId) => throw new NotImplementedException();
+        public Task<IEnumerable<Character>> GetActiveTemplateCharacters(int projectId) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<Character>> LoadCharactersWithGroups(IReadOnlyCollection<CharacterIdentification> characterIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<Character>> LoadCharactersWithGroups(ProjectIdentification projectId) => throw new NotImplementedException();
+        public void Dispose() { }
+    }
+
+    private sealed class FakeCharacterInfoRepository : ICharacterInfoRepository
+    {
+        public Task<CharacterInfo?> GetCharacterInfoOrDefault(CharacterIdentification characterId) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<CharacterInfo>> GetCharacterInfos(IReadOnlyCollection<CharacterIdentification> characterIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<CharacterInfo>> GetCharacterInfosByGroups(ProjectIdentification projectId, IReadOnlyCollection<CharacterGroupIdentification> groupIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<CharacterInfo>> GetAllCharacterInfos(ProjectIdentification projectId) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeUserRepository : IUserRepository
+    {
+        public Task<User> GetById(int id) => throw new NotImplementedException();
+        public Task<User> WithProfile(int userId) => throw new NotImplementedException();
+        public Task<User> GetWithSubscribe(int currentUserId) => throw new NotImplementedException();
+        public Task<UserAvatar> LoadAvatar(AvatarIdentification userAvatarId) => throw new NotImplementedException();
+        public Task<UserInfo?> GetUserInfo(UserIdentification userId) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<UserInfo>> GetUserInfos(IReadOnlyCollection<UserIdentification> userIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<UserInfoHeader>> GetUserInfoHeaders(IReadOnlyCollection<UserIdentification> userIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<UserInfoHeader>> GetAdminUserInfoHeaders() => throw new NotImplementedException();
+        public Task<UserIdentification?> FindByVk(string vkId) => throw new NotImplementedException();
+        public Task<UserIdentification?> FindByTelegram(string telegramUsername) => throw new NotImplementedException();
+        public Task<UserIdentification?> FindByEmail(string email) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeCharacterService : ICharacterService
+    {
+        public Task<CharacterIdentification> AddCharacter(AddCharacterRequest addCharacterRequest) => throw new NotImplementedException();
+        public Task DeleteCharacter(DeleteCharacterRequest deleteCharacterRequest) => throw new NotImplementedException();
+        public Task EditCharacter(EditCharacterRequest editCharacterRequest) => throw new NotImplementedException();
+        public Task SetFields(CharacterIdentification characterId, FieldLayerContainer fieldsToSet) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeProjectMetadataRepository(ProjectInfo projectInfo) : IProjectMetadataRepository
+    {
+        public Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId, bool ignoreCache = false)
+            => Task.FromResult(projectInfo);
+
+        public Task<DomainTypes.ProjectMetadata.ProjectDetails> GetProjectDetails(ProjectIdentification projectId)
+            => Task.FromResult(new DomainTypes.ProjectMetadata.ProjectDetails(new MarkdownString(""), [], false));
+
+        public void PrimeCache(ProjectInfo projectInfo) { }
+    }
+
+    private sealed class FakeCurrentUserAccessor : ICurrentUserAccessor
+    {
+        public UserIdentification UserIdentification { get; set; } = new UserIdentification(0);
+        public int? UserIdOrDefault => UserIdentification.Value;
+        public UserDisplayName DisplayName => new UserDisplayName("Test", null);
+        public bool IsAdmin => false;
+        public AvatarIdentification? Avatar => null;
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers.Test/Characters/CreateCharacterRequestMapperTest.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/Characters/CreateCharacterRequestMapperTest.cs
@@ -1,8 +1,8 @@
 using JoinRpg.DomainTypes.Characters;
-using JoinRpg.Portal.Controllers.XGameApi;
+using JoinRpg.WebPortal.Managers.Characters;
 using JoinRpg.XGameApi.Contract;
 
-namespace JoinRpg.Portal.Test.XGameApi;
+namespace JoinRpg.WebPortal.Managers.Test.Characters;
 
 public class CreateCharacterRequestMapperTest
 {

--- a/src/JoinRpg.WebPortal.Managers.Test/Characters/FieldValueConverterTest.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/Characters/FieldValueConverterTest.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
-using JoinRpg.Portal.Controllers.XGameApi;
+using JoinRpg.WebPortal.Managers.Characters;
 
-namespace JoinRpg.Portal.Test.XGameApi;
+namespace JoinRpg.WebPortal.Managers.Test.Characters;
 
 public class FieldValueConverterTest
 {

--- a/src/JoinRpg.WebPortal.Managers/Characters/ApiInfoBuilder.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ApiInfoBuilder.cs
@@ -7,7 +7,7 @@ using JoinRpg.XGameApi.Contract;
 // Доменный агрегат (ADR013) и DTO внешнего API называются одинаково — разводим псевдонимом.
 using DomainCharacterInfo = JoinRpg.DomainTypes.Characters.CharacterInfo;
 
-namespace JoinRpg.Portal.Controllers.XGameApi;
+namespace JoinRpg.WebPortal.Managers.Characters;
 
 public class ApiInfoBuilder
 {

--- a/src/JoinRpg.WebPortal.Managers/Characters/CharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/CharacterApiViewService.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Characters;
+using JoinRpg.Domain;
+using JoinRpg.Domain.Access;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.Interfaces;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Web.Models.Characters;
+using JoinRpg.XGameApi.Contract;
+using CharacterHeader = JoinRpg.XGameApi.Contract.CharacterHeader;
+// Не путать с доменным CharacterInfo (ADR013): здесь CharacterInfo — DTO внешнего API,
+// а доменный агрегат называется DomainCharacterInfo.
+using CharacterInfo = JoinRpg.XGameApi.Contract.CharacterInfo;
+using DomainCharacterInfo = JoinRpg.DomainTypes.Characters.CharacterInfo;
+
+namespace JoinRpg.WebPortal.Managers.Characters;
+
+internal class CharacterApiViewService(
+    ICharacterRepository characterRepository,
+    ICharacterInfoRepository characterInfoRepository,
+    IUserRepository userRepository,
+    ICharacterService characterService,
+    IProjectMetadataRepository projectMetadataRepository,
+    ICurrentUserAccessor currentUserAccessor
+        ) : ICharacterApiViewService
+{
+    public async Task<IReadOnlyCollection<CharacterHeader>> GetCharacterHeaders(ProjectIdentification projectId, DateTime? modifiedSince)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
+        _ = projectInfo.RequestMasterAccess(currentUserAccessor);
+
+        var characters = await characterRepository.GetCharacterHeaders(projectId.Value, modifiedSince);
+        return [.. characters.Select(character => BuildCharacterHeader(projectId, character.CharacterId, character.UpdatedAt, character.IsActive))];
+    }
+
+    private static CharacterHeader BuildCharacterHeader(ProjectIdentification projectId, int characterId, DateTime updatedAt, bool isActive) =>
+        new CharacterHeader
+        {
+            CharacterId = characterId,
+            UpdatedAt = updatedAt,
+            IsActive = isActive,
+            CharacterLink = $"/x-game-api/{projectId.Value}/characters/{characterId}/",
+        };
+
+    public async Task<CharacterInfo> GetCharacterInfo(CharacterIdentification characterId)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(characterId.ProjectId);
+        _ = projectInfo.RequestMasterAccess(currentUserAccessor);
+
+        var character = await characterInfoRepository.GetCharacterInfo(characterId);
+
+        // ProjectInfo несёт сам агрегат — отдельный запрос метаданных не нужен.
+        var access = AccessArgumentsFactory.Create(character, currentUserAccessor);
+        var fields = character.GetFieldLayers(access);
+
+        return
+            new CharacterInfo
+            {
+                CharacterId = character.Id.CharacterId,
+                UpdatedAt = character.UpdatedAt,
+                IsActive = character.IsActive,
+                InGame = character.InGame,
+                BusyStatus = (CharacterBusyStatus)character.GetBusyStatus(),
+                Groups = ApiInfoBuilder.ToGroupHeaders([.. character.DirectGroups]),
+                AllGroups = ApiInfoBuilder.ToGroupHeaders([.. character.ParentGroupsToTop]),
+                Fields = [.. fields.GetSortedFieldsForView().Select(ApiInfoBuilder.ToFieldValue)],
+#pragma warning disable CS0612 // Type or member is obsolete
+                PlayerUserId = character.ApprovedClaim?.PlayerId.Value,
+#pragma warning restore CS0612 // Type or member is obsolete
+                CharacterDescription = character.Description.Value,
+                CharacterName = character.CharacterName,
+                PlayerInfo = await CreatePlayerInfo(character),
+            };
+    }
+
+    private async Task<CharacterPlayerInfo?> CreatePlayerInfo(
+        DomainCharacterInfo character)
+    {
+        if (character.ApprovedClaim is not { } approvedClaim)
+        {
+            return null;
+        }
+
+        var player = await userRepository.GetRequiredUserInfo(approvedClaim.PlayerId);
+        return ApiInfoBuilder.CreatePlayerInfo(character, approvedClaim, player);
+    }
+
+    public async Task<CharacterHeader> CreateCharacter(ProjectIdentification projectId, CreateCharacterRequest request)
+    {
+        var characterTypeInfo = CreateCharacterRequestMapper.ToCharacterTypeInfo(request);
+
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
+
+        var fieldsToSet = new FieldLayerContainer(
+            projectInfo,
+            FieldValueConverter.ConvertToStringValues(request.FieldValues));
+
+        var characterId = await characterService.AddCharacter(new AddCharacterRequest(
+            projectId,
+            [],
+            characterTypeInfo,
+            fieldsToSet));
+
+        var character = await characterInfoRepository.GetCharacterInfo(characterId);
+        return BuildCharacterHeader(projectId, character.Id.CharacterId, character.UpdatedAt, character.IsActive);
+    }
+
+    public async Task SetCharacterFields(CharacterIdentification characterId, Dictionary<int, JsonElement> fieldValues)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(characterId.ProjectId);
+
+        var fieldsToSet = new FieldLayerContainer(
+            projectInfo,
+            FieldValueConverter.ConvertToStringValues(fieldValues));
+
+        await characterService.SetFields(characterId, fieldsToSet);
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/Characters/CreateCharacterRequestMapper.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/CreateCharacterRequestMapper.cs
@@ -1,7 +1,7 @@
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.XGameApi.Contract;
 
-namespace JoinRpg.Portal.Controllers.XGameApi;
+namespace JoinRpg.WebPortal.Managers.Characters;
 
 public static class CreateCharacterRequestMapper
 {

--- a/src/JoinRpg.WebPortal.Managers/Characters/FieldValueConverter.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/FieldValueConverter.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-namespace JoinRpg.Portal.Controllers.XGameApi;
+namespace JoinRpg.WebPortal.Managers.Characters;
 
 public static class FieldValueConverter
 {

--- a/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using JoinRpg.XGameApi.Contract;
+
+namespace JoinRpg.WebPortal.Managers.Characters;
+
+/// <summary>
+/// Общий слой над персонажами для x-game-api и (в будущем) MCP-инструментов (ADR012).
+/// Каждый метод сам проверяет права мастера — вызывающая сторона может доверять результату.
+/// </summary>
+public interface ICharacterApiViewService
+{
+    Task<IReadOnlyCollection<CharacterHeader>> GetCharacterHeaders(ProjectIdentification projectId, DateTime? modifiedSince);
+
+    Task<CharacterInfo> GetCharacterInfo(CharacterIdentification characterId);
+
+    Task<CharacterHeader> CreateCharacter(ProjectIdentification projectId, CreateCharacterRequest request);
+
+    Task SetCharacterFields(CharacterIdentification characterId, Dictionary<int, JsonElement> fieldValues);
+}

--- a/src/JoinRpg.WebPortal.Managers/JoinRpg.WebPortal.Managers.csproj
+++ b/src/JoinRpg.WebPortal.Managers/JoinRpg.WebPortal.Managers.csproj
@@ -10,10 +10,12 @@
     <ProjectReference Include="..\JoinRpg.Web.CharacterGroups\JoinRpg.Web.CharacterGroups.csproj" />
     <ProjectReference Include="..\JoinRpg.Web.CheckIn\JoinRpg.Web.CheckIn.csproj" />
     <ProjectReference Include="..\JoinRpg.Interfaces\JoinRpg.Interfaces.csproj" />
+    <ProjectReference Include="..\JoinRpg.Services.Interfaces\JoinRpg.Services.Interfaces.csproj" />
     <ProjectReference Include="..\JoinRpg.Web.Plots\JoinRpg.Web.Plots.csproj" />
     <ProjectReference Include="..\JoinRpg.Web.ProjectCommon\JoinRpg.Web.ProjectCommon.csproj" />
     <ProjectReference Include="..\JoinRpg.Web.ProjectMasterTools\JoinRpg.Web.ProjectMasterTools.csproj" />
     <ProjectReference Include="..\JoinRpg.WebPortal.Models\JoinRpg.WebPortal.Models.csproj" />
+    <ProjectReference Include="..\JoinRpg.XGameApi.Contract\JoinRpg.XGameApi.Contract.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ical.Net" />

--- a/src/JoinRpg.WebPortal.Managers/Projects/IProjectApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Projects/IProjectApiViewService.cs
@@ -1,0 +1,13 @@
+using JoinRpg.XGameApi.Contract;
+
+namespace JoinRpg.WebPortal.Managers.Projects;
+
+/// <summary>
+/// Общий слой над проектами для x-game-api и (в будущем) MCP-инструментов (ADR012).
+/// </summary>
+public interface IProjectApiViewService
+{
+    Task<ProjectFieldsMetadata> GetFieldsMetadata(ProjectIdentification projectId);
+
+    Task<IEnumerable<ProjectHeader>> GetActiveProjects(UserIdentification userId);
+}

--- a/src/JoinRpg.WebPortal.Managers/Projects/ProjectApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Projects/ProjectApiViewService.cs
@@ -1,0 +1,52 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Domain;
+using JoinRpg.Interfaces;
+using JoinRpg.Markdown;
+using JoinRpg.XGameApi.Contract;
+
+namespace JoinRpg.WebPortal.Managers.Projects;
+
+internal class ProjectApiViewService(
+    IProjectMetadataRepository projectMetadataRepository,
+    IProjectRepository projectRepository,
+    ICurrentUserAccessor currentUserAccessor
+        ) : IProjectApiViewService
+{
+    public async Task<ProjectFieldsMetadata> GetFieldsMetadata(ProjectIdentification projectId)
+    {
+        var project = await projectMetadataRepository.GetProjectMetadata(projectId);
+        _ = project.RequestMasterAccess(currentUserAccessor);
+
+        return new ProjectFieldsMetadata
+        {
+            ProjectId = project.ProjectId,
+            ProjectName = project.ProjectName,
+            Fields = project.SortedFields.Select(field =>
+                new JoinRpg.XGameApi.Contract.ProjectFieldInfo
+                {
+                    FieldName = field.Name,
+                    ProjectFieldId = field.Id.ProjectFieldId,
+                    IsActive = field.IsActive,
+                    FieldType = field.Type.ToString(),
+                    ProgrammaticValue = field.ProgrammaticValue,
+                    ValueList = field.SortedVariants.Select(variant =>
+                        new JoinRpg.XGameApi.Contract.ProjectFieldVariant
+                        {
+                            ProjectFieldVariantId = variant.Id.ProjectFieldVariantId,
+                            Label = variant.Label,
+                            IsActive = variant.IsActive,
+                            Description = variant.Description.ToHtmlString().Value,
+                            MasterDescription =
+                                variant.MasterDescription.ToHtmlString().Value,
+                            ProgrammaticValue = variant.ProgrammaticValue,
+                        }),
+                }),
+        };
+    }
+
+    public async Task<IEnumerable<ProjectHeader>> GetActiveProjects(UserIdentification userId)
+    {
+        return (await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.MyActiveProjects(userId)))
+            .Select(p => new ProjectHeader { ProjectId = p.ProjectId, ProjectName = p.ProjectName });
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/Registration.cs
+++ b/src/JoinRpg.WebPortal.Managers/Registration.cs
@@ -20,6 +20,7 @@ using JoinRpg.Web.ProjectMasterTools.ProjectRolesLists;
 using JoinRpg.Web.ProjectMasterTools.ResponsibleMaster;
 using JoinRpg.Web.ProjectMasterTools.Settings;
 using JoinRpg.Web.ProjectMasterTools.Subscribe;
+using JoinRpg.WebPortal.Managers.Characters;
 using JoinRpg.WebPortal.Managers.CheckIn;
 using JoinRpg.WebPortal.Managers.Claims;
 using JoinRpg.WebPortal.Managers.ProjectMasterTools.ProjectRolesLists;
@@ -67,6 +68,8 @@ public static class Registration
         .AddScoped<IMoveClient, MoveViewService>()
         .AddScoped<IProjectFieldOperationsClient, Fields.ProjectFieldOperationsViewService>()
         .AddScoped<INotificationDashboardClient, AdminTools.NotificationDashboardManager>()
+        .AddScoped<ICharacterApiViewService, CharacterApiViewService>()
+        .AddScoped<IProjectApiViewService, ProjectApiViewService>()
 
         ;
     }


### PR DESCRIPTION
## Что сделано

Задел под ADR012: и x-api контроллеры, и будущие MCP-инструменты должны быть тонкими
обёртками (проверка прав + вызов) над одним и тем же кодом, а не дублировать логику.

- `CharacterApiController`, `MetaDataApiController`, `MyProfileController` стали тонкими
  обёртками над новым `ICharacterApiViewService`/`IProjectApiViewService` в
  `JoinRpg.WebPortal.Managers` (без отдельного `Llm`-неймспейса).
- Сервисы сами проверяют `ProjectInfo.HasMasterAccess` на read-путях — раньше единственной
  защитой был атрибут `[XGameMasterAuthorize]`, через который MCP-инструменты (в отличие от
  x-api) проходить не будут.
- DTO переиспользуются из `JoinRpg.XGameApi.Contract` — параллельных MCP-специфичных DTO нет.
- Перенесены (без изменения логики) связанные static-мапперы `ApiInfoBuilder`,
  `CreateCharacterRequestMapper`, `FieldValueConverter` вместе с их юнит-тестами.
- Добавлен `CharacterApiViewServiceTests` — проверяет, что read-методы кидают
  `NoAccessToProjectException` для не-мастера ещё до обращения к репозиторию.

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes --severity warn` — чисто
- [x] `dotnet test src/JoinRpg.WebPortal.Managers.Test` — 194 passed
- [x] `dotnet test src/JoinRpg.IntegrationTests --filter FullyQualifiedName~XApi` — 40 passed
      (существующие HTTP-уровневые тесты на все мигрируемые эндпоинты, включая
      `GetCharactersAsync`/`GetFieldsMetadataAsync`/`GetActiveProjectsAsync`/
      `CreateCharacterAsync`/`SetCharacterFieldsAsync`) — без регрессий

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxaGjv2KktWZWTsXcjEpYE