### PR TITLE
feat: объединить «Мест»/«Свободных» в «Места», выделить «Нерасселено»

### DIFF
--- a/src/JoinRpg.Dal.Impl/Repositories/AccommodationRepositoryImpl.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/AccommodationRepositoryImpl.cs
@@ -43,6 +43,7 @@ public class AccommodationRepositoryImpl(MyDbContext ctx) : IAccommodationReposi
 
         return await ctx.Set<ProjectAccommodationType>().Where(a => a.ProjectId == project)
             .Include(x => x.Project)
+            .Include(x => x.Desirous.Select(ar => ar.Subjects.Select(c => c.FinanceOperations)))
             .Select(x => new RoomTypeInfoRow()
             {
                 RoomType = x,
@@ -50,6 +51,8 @@ public class AccommodationRepositoryImpl(MyDbContext ctx) : IAccommodationReposi
                 Occupied = x.ProjectAccommodations.Sum(room => room.Inhabitants.Sum(ar => (int?)ar.Subjects.Count)) ?? 0,
                 RoomsCount = x.ProjectAccommodations.Count,
                 ApprovedClaims = x.Desirous.Sum(ar => (int?)ar.Subjects.Count) ?? 0,
+                FullyFreeRoomsCount = x.ProjectAccommodations.Count(room => (room.Inhabitants.Sum(ar => (int?)ar.Subjects.Count) ?? 0) == 0),
+                FullyOccupiedRoomsCount = x.ProjectAccommodations.Count(room => (room.Inhabitants.Sum(ar => (int?)ar.Subjects.Count) ?? 0) == x.Capacity),
             })
             .ToListAsync()
             .ConfigureAwait(false);

--- a/src/JoinRpg.Data.Interfaces/IAccommodationRepository.cs
+++ b/src/JoinRpg.Data.Interfaces/IAccommodationRepository.cs
@@ -19,6 +19,16 @@ public class RoomTypeInfoRow
     public int Occupied { get; set; }
     public int RoomsCount { get; set; }
     public int ApprovedClaims { get; set; }
+
+    /// <summary>
+    /// Number of rooms of this type that have nobody living in them
+    /// </summary>
+    public int FullyFreeRoomsCount { get; set; }
+
+    /// <summary>
+    /// Number of rooms of this type that are filled to capacity
+    /// </summary>
+    public int FullyOccupiedRoomsCount { get; set; }
 }
 
 public class ClaimAccommodationInfoRow

--- a/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
@@ -58,26 +58,24 @@
       <td>Итого</td>
       <td class="visible-lg">&nbsp;</td>
       <td class="price-value">&nbsp;</td>
-      @if (Model.TotalCapacity != null)
-      {
-        <td class="price-value">
-          @Model.TotalCapacity
-          @if (Model.IsInfinite)
-          {
-            <text> + ∞</text>
-          }
-        </td>
-      }
-      else
-      {
-        <td class="price-value">∞</td>
-      }
       <td class="price-value">
         <div>Свободно: @(Model.FreeCapacity)</div>
         <div>Занято: @(Model.TotalOccupied)</div>
       </td>
       <td class="price-value">
-        <span title="@Model.TotalUnsettledTooltip">@(Model.TotalPending)</span>
+        @if (Model.TotalPaid != 0 || Model.TotalAcceptedNotPaid == 0)
+        {
+          <span title="@RoomTypeListItemViewModel.PaidTooltip">@Model.TotalPaid</span>
+        }
+        @if (Model.TotalAcceptedNotPaid != 0)
+        {
+          @if (Model.TotalPaid != 0 || Model.TotalAcceptedNotPaid == 0)
+          {
+            <text>+</text>
+          }
+          <span title="@RoomTypeListItemViewModel.AcceptedNotPaidTooltip">@Model.TotalAcceptedNotPaid</span>
+        }
+        = <span title="@RoomTypeListItemViewModel.TotalUnsettledTooltip">@(Model.TotalPending)</span>
         <a class="btn btn-sm btn-default disabled" href="#"><join-icon icon="MenuHorizontal" /></a>
       </td>
       <td colspan="2">

--- a/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
@@ -39,9 +39,8 @@
       <th>Название</th>
       <th class="visible-lg">Описание</th>
       <th class="price-table" style="min-width: 10em; width: 10em;">Цена</th>
-      <th class="price-table">Мест</th>
-      <th class="price-table">Свободных</th>
-      <th class="price-table">Заявки<br />(не&nbsp;заселено&nbsp;/&nbsp;заселено)</th>
+      <th class="price-table">Места</th>
+      <th class="price-table">Нерасселено</th>
       <th>Флаги</th>
       <th style="min-width: 9em; width: 9em;"></th>
     </tr>
@@ -73,9 +72,12 @@
       {
         <td class="price-value">∞</td>
       }
-      <td class="price-value">@(Model.FreeCapacity)</td>
       <td class="price-value">
-        @(Model.TotalPending) / @(Model.TotalOccupied)
+        <div>Свободно: @(Model.FreeCapacity)</div>
+        <div>Занято: @(Model.TotalOccupied)</div>
+      </td>
+      <td class="price-value">
+        <span title="@Model.TotalUnsettledTooltip">@(Model.TotalPending)</span>
         <a class="btn btn-sm btn-default disabled" href="#"><join-icon icon="MenuHorizontal" /></a>
       </td>
       <td colspan="2">

--- a/src/JoinRpg.Portal/Views/AccommodationType/_RoomTypeDetails.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/_RoomTypeDetails.cshtml
@@ -18,18 +18,57 @@
         {
             <td class="price-value">
                 <div>@Model.Capacity &#x2715; ∞ = ∞</div>
-                <div><span title="@Model.OccupiedTooltip">Занято: @(Model.Occupied)</span></div>
+                <div>
+                    Занято:
+                    <span title="@RoomTypeListItemViewModel.CapacityTooltip">@Model.Capacity</span>
+                    &#x2715; <span title="@RoomTypeListItemViewModel.FullyOccupiedRoomsTooltip">@Model.FullyOccupiedRoomsCount</span>
+                    @if (Model.PartialRoomsCount > 0)
+                    {
+                        <text>+ <span title="@RoomTypeListItemViewModel.PartialOccupiedSeatsTooltip">@Model.PartialOccupiedSeats</span></text>
+                    }
+                    = <span title="@RoomTypeListItemViewModel.TotalOccupiedTooltip">@Model.Occupied</span>
+                </div>
             </td>
         }
         else
         {
             <td class="price-value">
-                <div><span title="@Model.FreeTooltip">Свободно: @(Model.FreeCapacity)</span></div>
-                <div><span title="@Model.OccupiedTooltip">Занято: @(Model.Occupied)</span></div>
+                <div>
+                    Свободно:
+                    <span title="@RoomTypeListItemViewModel.CapacityTooltip">@Model.Capacity</span>
+                    &#x2715; <span title="@RoomTypeListItemViewModel.FullyFreeRoomsTooltip">@Model.FullyFreeRoomsCount</span>
+                    @if (Model.PartialRoomsCount > 0)
+                    {
+                        <text>+ <span title="@RoomTypeListItemViewModel.PartialFreeSeatsTooltip">@Model.PartialFreeSeats</span></text>
+                    }
+                    = <span title="@RoomTypeListItemViewModel.TotalFreeTooltip">@Model.FreeCapacity</span>
+                </div>
+                <div>
+                    Занято:
+                    <span title="@RoomTypeListItemViewModel.CapacityTooltip">@Model.Capacity</span>
+                    &#x2715; <span title="@RoomTypeListItemViewModel.FullyOccupiedRoomsTooltip">@Model.FullyOccupiedRoomsCount</span>
+                    @if (Model.PartialRoomsCount > 0)
+                    {
+                        <text>+ <span title="@RoomTypeListItemViewModel.PartialOccupiedSeatsTooltip">@Model.PartialOccupiedSeats</span></text>
+                    }
+                    = <span title="@RoomTypeListItemViewModel.TotalOccupiedTooltip">@Model.Occupied</span>
+                </div>
             </td>
         }
         <td class="price-value">
-            <span title="@Model.UnsettledTooltip">@(Model.PendingRequests)</span>
+            @if (Model.PaidCount != 0 || Model.AcceptedNotPaidCount == 0)
+            {
+                <span title="@RoomTypeListItemViewModel.PaidTooltip">@Model.PaidCount</span>
+            }
+            @if (Model.AcceptedNotPaidCount != 0)
+            {
+                @if (Model.PaidCount != 0 || Model.AcceptedNotPaidCount == 0)
+                {
+                    <text>+</text>
+                }
+                <span title="@RoomTypeListItemViewModel.AcceptedNotPaidTooltip">@Model.AcceptedNotPaidCount</span>
+            }
+            = <span title="@RoomTypeListItemViewModel.TotalUnsettledTooltip">@Model.PendingRequests</span>
             <a title="Показать список заявок на тип поселения «@Model.Name»" class="btn btn-sm btn-default" href="@Url.Action("ListForRoomType", "ClaimList", new { Model.ProjectId, RoomTypeId = Model.Id })"><join-icon icon="MenuHorizontal" /></a>
         </td>
         <td>

--- a/src/JoinRpg.Portal/Views/AccommodationType/_RoomTypeDetails.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/_RoomTypeDetails.cshtml
@@ -16,15 +16,20 @@
         <td class="price-value">@(await Html.RenderComponentAsync<PriceElement>(RenderMode.Static, new { Price = Model.Cost }))</td>
         @if (Model.IsInfinite)
         {
-            <td class="price-value">@Model.Capacity &#x2715; ∞ = ∞</td>
+            <td class="price-value">
+                <div>@Model.Capacity &#x2715; ∞ = ∞</div>
+                <div><span title="@Model.OccupiedTooltip">Занято: @(Model.Occupied)</span></div>
+            </td>
         }
         else
         {
-            <td class="price-value">@Model.Capacity &#x2715; @Model.RoomsCount = @Model.TotalCapacity</td>
+            <td class="price-value">
+                <div><span title="@Model.FreeTooltip">Свободно: @(Model.FreeCapacity)</span></div>
+                <div><span title="@Model.OccupiedTooltip">Занято: @(Model.Occupied)</span></div>
+            </td>
         }
-        <td class="price-value">@(Model.FreeCapacity)</td>
         <td class="price-value">
-            @(Model.PendingRequests) / @(Model.Occupied)
+            <span title="@Model.UnsettledTooltip">@(Model.PendingRequests)</span>
             <a title="Показать список заявок на тип поселения «@Model.Name»" class="btn btn-sm btn-default" href="@Url.Action("ListForRoomType", "ClaimList", new { Model.ProjectId, RoomTypeId = Model.Id })"><join-icon icon="MenuHorizontal" /></a>
         </td>
         <td>

--- a/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
@@ -28,7 +28,9 @@ public class AccommodationListViewModel
 
     public bool IsInfinite { get; set; }
 
-    public string TotalUnsettledTooltip { get; }
+    public int TotalPaid { get; }
+
+    public int TotalAcceptedNotPaid { get; }
 
     public AccommodationListViewModel(ProjectInfo project,
         IReadOnlyCollection<RoomTypeInfoRow> roomTypes,
@@ -49,9 +51,8 @@ public class AccommodationListViewModel
         TotalOccupied = RoomTypes.Sum(x => x.Occupied);
         TotalPending = RoomTypes.Sum(x => x.PendingRequests);
 
-        TotalUnsettledTooltip = RoomTypeListItemViewModel.BuildUnsettledTooltip(
-            RoomTypes.Sum(rt => rt.PaidCount),
-            RoomTypes.Sum(rt => rt.AcceptedNotPaidCount));
+        TotalPaid = RoomTypes.Sum(rt => rt.PaidCount);
+        TotalAcceptedNotPaid = RoomTypes.Sum(rt => rt.AcceptedNotPaidCount);
     }
 }
 
@@ -123,29 +124,15 @@ public class RoomTypeListItemViewModel : RoomTypeViewModelBase
     public int ApprovedClaims { get; set; }
     public int FreeCapacity { get; }
 
-    public string FreeTooltip
-        => PartialRoomsCount > 0
-            ? $"{Capacity} (это вместимость номера) х {FullyFreeRoomsCount} (это кол-во полностью свободных номеров) + {PartialFreeSeats} (количество свободных мест в частично занятых номерах) = {FreeCapacity} (всего свободных мест в этой категории)"
-            : $"{Capacity} (это вместимость номера) х {FullyFreeRoomsCount} (это кол-во полностью свободных номеров) = {FreeCapacity} (всего свободных мест в этой категории)";
-
-    public string OccupiedTooltip
-        => PartialRoomsCount > 0
-            ? $"{Capacity} (это вместимость номера) х {FullyOccupiedRoomsCount} (это кол-во полностью занятых номеров) + {PartialOccupiedSeats} (количество занятых мест в частично занятых номерах) = {Occupied} (всего занятых мест в этой категории)"
-            : $"{Capacity} (это вместимость номера) х {FullyOccupiedRoomsCount} (это кол-во полностью занятых номеров) = {Occupied} (всего занятых мест в этой категории)";
-
-    public string UnsettledTooltip => BuildUnsettledTooltip(PaidCount, AcceptedNotPaidCount);
-
-    public static string BuildUnsettledTooltip(int paidCount, int acceptedNotPaidCount)
-    {
-        var parts = new List<string>();
-        if (paidCount != 0 || acceptedNotPaidCount == 0)
-        {
-            parts.Add($"{paidCount} (оплаченных)");
-        }
-        if (acceptedNotPaidCount != 0)
-        {
-            parts.Add($"{acceptedNotPaidCount} (принятых, не оплаченных)");
-        }
-        return $"{string.Join(" + ", parts)} = {paidCount + acceptedNotPaidCount} (всего)";
-    }
+    // Подписи для tooltip-ов над отдельными цифрами формул в разметке (Index.cshtml, _RoomTypeDetails.cshtml)
+    public const string CapacityTooltip = "это вместимость номера";
+    public const string FullyFreeRoomsTooltip = "это кол-во полностью свободных номеров";
+    public const string PartialFreeSeatsTooltip = "количество свободных мест в частично занятых номерах";
+    public const string TotalFreeTooltip = "всего свободных мест в этой категории";
+    public const string FullyOccupiedRoomsTooltip = "это кол-во полностью занятых номеров";
+    public const string PartialOccupiedSeatsTooltip = "количество занятых мест в частично занятых номерах";
+    public const string TotalOccupiedTooltip = "всего занятых мест в этой категории";
+    public const string PaidTooltip = "оплаченных";
+    public const string AcceptedNotPaidTooltip = "принятых, не оплаченных";
+    public const string TotalUnsettledTooltip = "всего";
 }

--- a/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
@@ -28,6 +28,8 @@ public class AccommodationListViewModel
 
     public bool IsInfinite { get; set; }
 
+    public string TotalUnsettledTooltip { get; }
+
     public AccommodationListViewModel(ProjectInfo project,
         IReadOnlyCollection<RoomTypeInfoRow> roomTypes,
         ICurrentUserAccessor userId)
@@ -36,7 +38,7 @@ public class AccommodationListViewModel
         ProjectName = project.ProjectName;
         CanManageRooms = project.HasMasterAccess(userId, Permission.CanManageAccommodation);
         CanAssignRooms = project.HasMasterAccess(userId, Permission.CanSetPlayersAccommodations);
-        RoomTypes = roomTypes.Select(rt => new RoomTypeListItemViewModel(rt, userId)).ToList();
+        RoomTypes = roomTypes.Select(rt => new RoomTypeListItemViewModel(rt, userId, project)).ToList();
 
         IsInfinite = RoomTypes.Any(rt => rt.IsInfinite);
 
@@ -46,6 +48,10 @@ public class AccommodationListViewModel
 
         TotalOccupied = RoomTypes.Sum(x => x.Occupied);
         TotalPending = RoomTypes.Sum(x => x.PendingRequests);
+
+        TotalUnsettledTooltip = RoomTypeListItemViewModel.BuildUnsettledTooltip(
+            RoomTypes.Sum(rt => rt.PaidCount),
+            RoomTypes.Sum(rt => rt.AcceptedNotPaidCount));
     }
 }
 
@@ -58,7 +64,16 @@ public class RoomTypeListItemViewModel : RoomTypeViewModelBase
 
     public override int RoomsCount { get; }
 
-    public RoomTypeListItemViewModel(RoomTypeInfoRow row, ICurrentUserAccessor userId)
+    public int FullyFreeRoomsCount { get; }
+    public int FullyOccupiedRoomsCount { get; }
+    public int PartialRoomsCount { get; }
+    public int PartialFreeSeats { get; }
+    public int PartialOccupiedSeats { get; }
+
+    public int PaidCount { get; }
+    public int AcceptedNotPaidCount { get; }
+
+    public RoomTypeListItemViewModel(RoomTypeInfoRow row, ICurrentUserAccessor userId, ProjectInfo projectInfo)
     {
         var entity = row.RoomType;
         var project = row.RoomType.Project;
@@ -85,8 +100,52 @@ public class RoomTypeListItemViewModel : RoomTypeViewModelBase
 
         FreeCapacity = TotalCapacity - Occupied;
         PendingRequests = ApprovedClaims - Occupied;
+
+        FullyFreeRoomsCount = row.FullyFreeRoomsCount;
+        FullyOccupiedRoomsCount = row.FullyOccupiedRoomsCount;
+        PartialRoomsCount = RoomsCount - FullyFreeRoomsCount - FullyOccupiedRoomsCount;
+        PartialFreeSeats = FreeCapacity - (Capacity * FullyFreeRoomsCount);
+        PartialOccupiedSeats = Occupied - (Capacity * FullyOccupiedRoomsCount);
+
+        var unsettledClaims = entity.Desirous
+            .Where(ar => ar.AccommodationId == null)
+            .SelectMany(ar => ar.Subjects);
+
+        PaidCount = unsettledClaims.Count(claim =>
+        {
+            var balance = claim.CalculateClaimBalance(projectInfo);
+            var status = FinanceExtensions.GetClaimPaymentStatus(balance.TotalFee, balance.FeePaid);
+            return status is ClaimPaymentStatus.Paid or ClaimPaymentStatus.Overpaid;
+        });
+        AcceptedNotPaidCount = PendingRequests - PaidCount;
     }
 
     public int ApprovedClaims { get; set; }
     public int FreeCapacity { get; }
+
+    public string FreeTooltip
+        => PartialRoomsCount > 0
+            ? $"{Capacity} (это вместимость номера) х {FullyFreeRoomsCount} (это кол-во полностью свободных номеров) + {PartialFreeSeats} (количество свободных мест в частично занятых номерах) = {FreeCapacity} (всего свободных мест в этой категории)"
+            : $"{Capacity} (это вместимость номера) х {FullyFreeRoomsCount} (это кол-во полностью свободных номеров) = {FreeCapacity} (всего свободных мест в этой категории)";
+
+    public string OccupiedTooltip
+        => PartialRoomsCount > 0
+            ? $"{Capacity} (это вместимость номера) х {FullyOccupiedRoomsCount} (это кол-во полностью занятых номеров) + {PartialOccupiedSeats} (количество занятых мест в частично занятых номерах) = {Occupied} (всего занятых мест в этой категории)"
+            : $"{Capacity} (это вместимость номера) х {FullyOccupiedRoomsCount} (это кол-во полностью занятых номеров) = {Occupied} (всего занятых мест в этой категории)";
+
+    public string UnsettledTooltip => BuildUnsettledTooltip(PaidCount, AcceptedNotPaidCount);
+
+    public static string BuildUnsettledTooltip(int paidCount, int acceptedNotPaidCount)
+    {
+        var parts = new List<string>();
+        if (paidCount != 0 || acceptedNotPaidCount == 0)
+        {
+            parts.Add($"{paidCount} (оплаченных)");
+        }
+        if (acceptedNotPaidCount != 0)
+        {
+            parts.Add($"{acceptedNotPaidCount} (принятых, не оплаченных)");
+        }
+        return $"{string.Join(" + ", parts)} = {paidCount + acceptedNotPaidCount} (всего)";
+    }
 }


### PR DESCRIPTION
## Что сделано

На странице `<projectId>/rooms`:

- Колонки «Мест» и «Свободных» объединены в одну колонку **«Места»** с двумя строками — «Свободно: N» и «Занято: N».
- Колонка «Заявки (не заселено / заселено)» заменена на **«Нерасселено»** — показывает только количество одобренных, но не расселённых заявок (сколько из них расселено, теперь видно в колонке «Места» → «Занято»).
- При наведении на числа показывается tooltip с формулой:
  - «Свободно»/«Занято»: `вместимость х кол-во полностью свободных/занятых номеров + места в частично занятых = итого`. Если частично занятых номеров нет, слагаемое `+ N` в формуле не показывается.
  - «Нерасселено»: `N (оплаченных) + M (принятых, не оплаченных) = итого (всего)`, с тем же правилом пропуска нулевого слагаемого.
- Подсчёт полностью свободных/занятых номеров добавлен в `AccommodationRepositoryImpl.GetRoomTypesForProject` (новые поля `FullyFreeRoomsCount`/`FullyOccupiedRoomsCount` в `RoomTypeInfoRow`).
- Статус оплаты нерасселённых заявок считается через `CalculateClaimBalance`/`GetClaimPaymentStatus` (тот же доменный расчёт, что и в остальном проекте).

## Скриншоты

Локальную БД поднять и накатить миграции не удалось (падает не связанный с этой правкой инструмент миграций на постгресовых DbContext'ах — DataProtection/Notifications/JobService/IdPortal), поэтому вместо скриншотов из реального приложения приложены статичные HTML-мокапы «до» и «после» с примерными данными, повторяющие вёрстку и классы страницы.

## Test plan

- [ ] `dotnet build` — 0 ошибок (проверено)
- [ ] Вручную открыть `<projectId>/rooms` на локальной БД с несколькими типами размещения (полностью свободные/занятые/частично занятые номера, часть заявок оплачена) и свериться с tooltip-формулами

🤖 Generated with [Claude Code](https://claude.com/claude-code)