### PR TITLE
test: интеграционные тесты на XUserInfoController.GetUser

### DIFF
--- a/src/JoinRpg.IntegrationTests/Scenarios/XApi/XApiUserInfoTests.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/XApi/XApiUserInfoTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using JoinRpg.Dal.Impl;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+
+namespace JoinRpg.IntegrationTest.Scenarios.XApi;
+
+/// <summary>
+/// Ручка GET x-api/users/{userId}/ — доступна только сайт-администраторам ([XAdminAuthorize]),
+/// раньше не имела ни одного интеграционного теста.
+/// </summary>
+[Collection("XApi")]
+public class XApiUserInfoTests(XApiMasterFixture fixture)
+{
+    [Fact]
+    public async Task WithoutAuth_Returns401()
+    {
+        await Should.ThrowAsync<HttpRequestException>(
+            () => fixture.AnonymousXApiClient.GetUserInfoAsync(fixture.MasterUserId.Value));
+    }
+
+    [Fact]
+    public async Task MasterIsNotSiteAdmin_Returns403()
+    {
+        // MasterClient — обычный мастер проекта (роль в рамках проекта), а не сайт-администратор,
+        // поэтому [XAdminAuthorize] должен его отклонить.
+        var statusCode = await fixture.MasterClient.GetUserInfoRawAsync(fixture.MasterUserId.Value);
+
+        statusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Admin_ReturnsPlayerInfo()
+    {
+        var (playerId, playerEmail) = await TestUserProjectHelpers.CreateTestUserWithEmailAsync(fixture.Factory.Services);
+        var adminClient = await CreateSiteAdminClientAsync();
+
+        var result = await adminClient.GetUserInfoAsync(playerId.Value);
+
+        result.PlayerId.ShouldBe(playerId.Value);
+        result.PlayerContacts.Email.ShouldBe(playerEmail);
+        result.NickName.ShouldNotBeNullOrEmpty();
+        result.AvatarUrl.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task UnknownUser_Returns410()
+    {
+        var adminClient = await CreateSiteAdminClientAsync();
+
+        var statusCode = await adminClient.GetUserInfoRawAsync(int.MaxValue);
+
+        statusCode.ShouldBe(HttpStatusCode.Gone);
+    }
+
+    /// <summary>
+    /// Создаёт пользователя, вручную выставляет ему флаг Auth.IsAdmin (сайт-администратор)
+    /// и возвращает уже залогиненный под ним XApiClient.
+    /// </summary>
+    private async Task<XApiClient> CreateSiteAdminClientAsync()
+    {
+        const string password = "Password123!";
+        var (_, adminEmail) = await TestUserProjectHelpers.CreateTestUserWithEmailAsync(fixture.Factory.Services, password: password);
+
+        using (var scope = fixture.Factory.Services.CreateScope())
+        {
+            var myDb = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            var dbAdmin = myDb.Set<JoinRpg.DataModel.User>().Include("Auth").Single(u => u.Email == adminEmail);
+            dbAdmin.Auth.IsAdmin = true;
+            await myDb.SaveChangesAsync();
+        }
+
+        return await XApiClient.CreateXApiClient(fixture.Factory.CreateClient(), adminEmail, password);
+    }
+}

--- a/src/JoinRpg.IntegrationTests/TestInfrastructure/XApiClient.cs
+++ b/src/JoinRpg.IntegrationTests/TestInfrastructure/XApiClient.cs
@@ -79,6 +79,21 @@ public class XApiClient(HttpClient httpClient)
         return (await response.Content.ReadFromJsonAsync<ClaimInfo>())!;
     }
 
+    /// <summary>GET /x-api/users/{userId}/ — player info by user id (site admin only)</summary>
+    public async Task<PlayerInfo> GetUserInfoAsync(int userId)
+    {
+        var response = await httpClient.GetAsync($"/x-api/users/{userId}/");
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<PlayerInfo>())!;
+    }
+
+    /// <summary>Like GetUserInfoAsync but returns the HTTP status code instead of throwing</summary>
+    public async Task<System.Net.HttpStatusCode> GetUserInfoRawAsync(int userId)
+    {
+        var response = await httpClient.GetAsync($"/x-api/users/{userId}/");
+        return response.StatusCode;
+    }
+
     /// <summary>POST /x-game-api/{projectId}/characters — create new character</summary>
     public async Task<CharacterHeader> CreateCharacterAsync(int projectId, CreateCharacterRequest request)
     {


### PR DESCRIPTION
## Что сделано

`GET x-api/users/{userId}/` (`XUserInfoController.GetUser`, `[XAdminAuthorize]`, только сайт-администраторы) был без единого интеграционного теста, а `XApiClient` — тестовая типизированная обёртка над x-api — не имел метода для этой ручки.

- `src/JoinRpg.IntegrationTests/TestInfrastructure/XApiClient.cs` — добавлены `GetUserInfoAsync(int userId)` и `GetUserInfoRawAsync(int userId)` (аналогично уже существующим методам-обёрткам, второй нужен для проверки конкретных статус-кодов без исключения).
- `src/JoinRpg.IntegrationTests/Scenarios/XApi/XApiUserInfoTests.cs` — новые сценарии:
  - без токена → 401;
  - обычный мастер проекта (не сайт-администратор) → 403;
  - сайт-администратор получает корректный `PlayerInfo` (PlayerId/email/ник/аватар) для существующего пользователя;
  - несуществующий userId → 410.

Для теста роли администратора пользователь создаётся через существующий тестовый хелпер, после чего у него вручную выставляется `Auth.IsAdmin = true` — по образцу уже применяемого в `KogdaIgraMissingGamesScenario`.

## Проверено

- `dotnet build src/JoinRpg.IntegrationTests/JoinRpg.IntegrationTest.csproj` — 0 ошибок.
- `dotnet format src/JoinRpg.IntegrationTests/JoinRpg.IntegrationTest.csproj --verify-no-changes --severity warn` — чисто.
- `dotnet test src/JoinRpg.IntegrationTests/JoinRpg.IntegrationTest.csproj --filter "FullyQualifiedName~XApi"` — 44/44 пройдено (все существующие тесты коллекции XApi + 4 новых), регрессий нет.

Generated with [Claude Code](https://claude.ai/code)