### PR TITLE
fix: SQL-префильтр доступности персонажа смотрит на CharacterType, не на легаси-колонку

### DIFF
--- a/src/JoinRpg.Dal.Impl.Tests/CharacterPredicatesConsistencyTest.cs
+++ b/src/JoinRpg.Dal.Impl.Tests/CharacterPredicatesConsistencyTest.cs
@@ -1,0 +1,133 @@
+using JoinRpg.Dal.Impl.Repositories;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+using Shouldly;
+using Xunit;
+
+namespace JoinRpg.Dal.Impl.Tests;
+
+/// <summary>
+/// Тест на согласованность из issue #4766: <see cref="CharacterPredicates.IsAvailable"/> —
+/// грубый SQL-префильтр, а точный ответ на вопрос "можно ли сюда заявиться" даёт доменный движок
+/// правил (<see cref="ClaimAcceptOrMoveValidationExtensions.ValidateIfCanAddClaim"/>).
+/// </summary>
+/// <remarks>
+/// Инвариант ровно такой, какой описан в issue: префильтр не должен быть строже правил. Он вправе
+/// пропускать лишнее (например, слот без мест — это известное расхождение, см.
+/// <c>JoinRpg.WebPortal.Managers.CharacterGroupList.CharacterListViewService</c>, который досеивает
+/// результат доменными правилами), но не вправе отсекать то, что правила разрешают — иначе персонаж
+/// молча пропадёт из списка ещё до того, как до него доберутся доменные правила.
+/// </remarks>
+public class CharacterPredicatesConsistencyTest
+{
+    private readonly MockedProject _mock = new();
+
+    private bool SqlPrefilterAllows(Character character)
+        => CharacterPredicates.IsAvailable(_mock.ProjectInfo.ProjectId).Compile()(character);
+
+    private bool DomainRulesAllow(Character character)
+        => character.ValidateIfCanAddClaim(userInfo: null, _mock.ProjectInfo, ClaimOperation.AddByMaster).Count == 0;
+
+    private void AssertPrefilterNotStricterThanRules(Character character)
+    {
+        if (DomainRulesAllow(character))
+        {
+            SqlPrefilterAllows(character).ShouldBeTrue(
+                $"Доменные правила разрешают заявку на '{character.CharacterName}', а SQL-префильтр её отсёк бы — расхождение из issue #4766.");
+        }
+    }
+
+    [Fact]
+    public void OrdinaryCharacter_PrefilterMatchesRules()
+        => AssertPrefilterNotStricterThanRules(_mock.Character);
+
+    [Fact]
+    public void InactiveCharacter_PrefilterMatchesRules()
+    {
+        var character = _mock.CreateCharacter("inactive");
+        character.IsActive = false;
+
+        AssertPrefilterNotStricterThanRules(character);
+    }
+
+    [Fact]
+    public void NpcCharacter_PrefilterMatchesRules()
+    {
+        var character = _mock.CreateCharacter("npc");
+        character.CharacterType = CharacterType.NonPlayer;
+
+        AssertPrefilterNotStricterThanRules(character);
+    }
+
+    [Fact]
+    public void BusyCharacterWithApprovedClaim_PrefilterMatchesRules()
+    {
+        var character = _mock.CreateCharacter("busy-approved");
+        _ = _mock.CreateApprovedClaim(character, _mock.Player);
+
+        AssertPrefilterNotStricterThanRules(character);
+    }
+
+    [Fact]
+    public void BusyCharacterWithCheckedInClaim_PrefilterMatchesRules()
+    {
+        var character = _mock.CreateCharacter("busy-checkedin");
+        _ = _mock.CreateCheckedInClaim(character, _mock.Player);
+
+        AssertPrefilterNotStricterThanRules(character);
+    }
+
+    [Fact]
+    public void SlotWithFreePlaces_PrefilterMatchesRules()
+    {
+        var slot = _mock.CreateCharacter("slot-with-places");
+        slot.CharacterType = CharacterType.Slot;
+        slot.CharacterSlotLimit = 3;
+
+        AssertPrefilterNotStricterThanRules(slot);
+    }
+
+    /// <summary>
+    /// Заведомое расхождение из issue: SQL-префильтр про лимит слота не знает и пропускает
+    /// исчерпанный слот, доменные правила его отсекают. Префильтру можно быть шире правил — это не
+    /// нарушение инварианта, фиксируем явно, чтобы не потерять из виду.
+    /// </summary>
+    [Fact]
+    public void ExhaustedSlot_PrefilterIsWiderThanRules_KnownDivergence()
+    {
+        var slot = _mock.CreateCharacter("slot-exhausted");
+        slot.CharacterType = CharacterType.Slot;
+        slot.CharacterSlotLimit = 0;
+
+        DomainRulesAllow(slot).ShouldBeFalse();
+        SqlPrefilterAllows(slot).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Регресс на риск из issue #4766: легаси-колонка <c>Character.IsAcceptingClaims</c> (см.
+    /// <c>[Obsolete]</c> у неё) у старых записей могла разъехаться с
+    /// <see cref="Character.CharacterType"/>. Опасное направление — когда она ошибочно выставлена
+    /// в <c>false</c> у обычного игрового персонажа: доменные правила такого персонажа не отсекают,
+    /// а старый SQL-префильтр, глядя только на легаси-флаг, отсёк бы его молча.
+    /// </summary>
+    /// <remarks>
+    /// Поэтому <see cref="CharacterPredicates.IsAvailable"/> смотрит на
+    /// <see cref="Character.CharacterType"/>, а не на легаси-флаг — здесь тест намеренно
+    /// выставляет флаг в заведомо рассинхронизированное значение и проверяет, что префильтр его
+    /// игнорирует.
+    /// </remarks>
+    [Fact]
+    public void StaleLegacyFlag_PlayerCharacterMarkedAsNotAccepting_PrefilterMustNotHideIt()
+    {
+        var character = _mock.CreateCharacter("stale-legacy-flag");
+        character.CharacterType = CharacterType.Player;
+#pragma warning disable CS0618 // намеренно рассинхронизированный легаси-флаг — так выглядели старые записи
+        character.IsAcceptingClaims = false;
+#pragma warning restore CS0618
+
+        AssertPrefilterNotStricterThanRules(character);
+    }
+}

--- a/src/JoinRpg.Dal.Impl/Repositories/CharacterPredicates.cs
+++ b/src/JoinRpg.Dal.Impl/Repositories/CharacterPredicates.cs
@@ -11,7 +11,10 @@ internal static class CharacterPredicates
 
     internal static Expression<Func<Character, bool>> IsAvailable(ProjectIdentification projectId)
         => character => character.ProjectId == projectId.Value
-            && character.IsAcceptingClaims
+            // Не character.IsAcceptingClaims ([Obsolete]-легаси-колонка): у старых записей она
+            // может разъехаться с CharacterType (см. issue #4766). CharacterType — источник истины,
+            // с ним же сверяется CharacterTypeInfo.IsAcceptingClaims в доменных правилах.
+            && character.CharacterType != CharacterType.NonPlayer
             && character.IsActive
             && !character.Project.Claims.Any(claim =>
                 (claim.ClaimStatus == ClaimStatus.Approved || claim.ClaimStatus == ClaimStatus.CheckedIn)


### PR DESCRIPTION
Часть [#4766](https://github.com/joinrpg/joinrpg-net/issues/4766). Issue **не закрывает** — см. «Что осталось».

## Проблема

`CharacterPredicates.IsAvailable` — SQL-префильтр, который наполняет выпадашки выбора персонажа, — читал `[Obsolete]`-колонку `Character.IsAcceptingClaims`. Она поддерживается в `CharacterServiceImpl.SetCharacterSettings` (пишется деконструкцией `CharacterTypeInfo`), но у старых записей может разойтись с `CharacterType`.

Опасное направление — когда у обычного игрового персонажа флаг ошибочно стоит в `false`: доменные правила такого персонажа пропускают, а префильтр отсекает его **молча**, ещё до того, как до него доберутся правила. Персонаж просто исчезает из списка без объяснений.

Теперь префильтр смотрит на `CharacterType` — источник истины, с которым сверяется и `CharacterTypeInfo.IsAcceptingClaims` в доменных правилах.

## Тест на согласованность

Это тот «минимум, который стоит сделать в любом случае» из issue. Инвариант: **префильтр не должен быть строже доменных правил**. Шире — можно: он вправе пропускать лишнее, потому что `CharacterListViewService` досеивает результат правилами (#4768). А вот отсекать разрешённое нельзя.

`CharacterPredicatesConsistencyTest` проверяет инвариант на наборе персонажей: обычный, неактивный, NPC, занятый утверждённой заявкой, занятый заехавшей, слот с местами. Плюс два именованных теста:

- `ExhaustedSlot_PrefilterIsWiderThanRules_KnownDivergence` — фиксирует известное расхождение (префильтр про лимит слота не знает), чтобы оно не потерялось из виду;
- `StaleLegacyFlag_PlayerCharacterMarkedAsNotAccepting_PrefilterMustNotHideIt` — регресс ровно на тот сценарий, ради которого менялся предикат.

## Что осталось от #4766

Третья реализация — `CharacterApplyViewModel.IsAvailable` (`src/JoinRpg.Web.ProjectCommon/Characters/`) — **не тронута**. Она считает доступность из `BusyStatus` и `SlotCount` и не учитывает статус проекта; в `ProjectRoleGridPlayerCell.razor` есть TODO, признающий этот пробел. Это игроцкий UI, там нужна операция `DisplayForPlayer`, и правка вероятно тянет за собой сетку ролей (ADR011). Отдельной задачей.

## Проверка

`dotnet build` — 0 ошибок, полный `dotnet test` — все проекты зелёные, `dotnet format --verify-no-changes --severity warn` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY