### PR TITLE
fix: передавать projectId при редиректе с выключенным поселением

### DIFF
--- a/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
+++ b/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
@@ -30,7 +30,7 @@ public class AccommodationTypeController(
 
         if (!project.AccomodationEnabled)
         {
-            return RedirectToAction("Edit", "Game");
+            return RedirectToAction("Edit", "Game", new { projectId = projectId.Value });
         }
 
         return View(new AccommodationListViewModel(project,
@@ -162,7 +162,7 @@ public class AccommodationTypeController(
 
         if (!project.AccomodationEnabled)
         {
-            return RedirectToAction("Edit", "Game");
+            return RedirectToAction("Edit", "Game", new { projectId = projectId.Value });
         }
 
         //TODO: Implement mass occupation
@@ -182,7 +182,7 @@ public class AccommodationTypeController(
 
         if (!project.AccomodationEnabled)
         {
-            return RedirectToAction("Edit", "Game");
+            return RedirectToAction("Edit", "Game", new { projectId = projectId.Value });
         }
 
         await accommodationService.UnOccupyAll(projectId);


### PR DESCRIPTION
## Проблема

В `AccommodationTypeController` три метода (`Index`, `OccupyAll`, `UnOccupyAll`) при выключенной у проекта настройке «система поселения» (`project.AccomodationEnabled == false`) делали:

```csharp
return RedirectToAction("Edit", "Game");
```

`GameController.Edit` замаплен на `[HttpGet("/{projectId}/project/settings")]`, то есть требует `projectId` в маршруте. Без него редирект вёл на несуществующий `/game/edit` и пользователь получал 404 вместо страницы настроек проекта, где можно включить поселение.

## Исправление

Передаём `projectId` явно:

```csharp
return RedirectToAction("Edit", "Game", new { projectId = projectId.Value });
```

## Проверка

- `dotnet build src/JoinRpg.Portal/JoinRpg.Portal.csproj` — успешно.
- Вручную через headless-браузер: залогинился под `master@example.com`, временно выключил «Систему поселения» в настройках проекта «Тестовая песочница» и открыл `/1/rooms/` — до фикса это давало 404 на `/game/edit`, после фикса корректно перенаправляет на `/1/project/settings` с отрендеренной страницей настроек. После проверки настройка поселения возвращена в исходное состояние (включено).

Generated with [Claude Code](https://claude.com/claude-code)