### PR TITLE
refactor: перевести проверку паспорта/адреса на UserProfileItemType

### DIFF
--- a/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/AddClaimValidationRulesTest.cs
@@ -174,6 +174,20 @@ public class AddClaimValidationRulesTest
         Mock.Character.ValidateIfCanAddClaim(playerWithRealName, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
     }
 
+    /// <summary>
+    /// На момент подачи заявки согласия на чувствительные данные ещё не существует
+    /// (claim.PlayerAllowedSenstiveData — факт уже созданной заявки, а не профиля), поэтому
+    /// паспорт/адрес регистрации не должны блокировать подачу заявки — их спрашивают уже после,
+    /// см. ClaimContactsMissingFilter.
+    /// </summary>
+    [Fact]
+    public void CanSendClaimEvenIfPassportRequiredAndMissing()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequirePassport = MandatoryStatus.Required });
+        Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
+    }
+
     private void ShouldBeAllowed(Character mockCharacter, ProjectInfo projectInfo)
         => mockCharacter.ValidateIfCanAddClaim(Mock.PlayerInfo, projectInfo, ClaimOperation.AddByPlayer).ShouldBeEmpty();
 

--- a/src/JoinRpg.Domain.Test/Problems/ClaimContactsMissingFilterTest.cs
+++ b/src/JoinRpg.Domain.Test/Problems/ClaimContactsMissingFilterTest.cs
@@ -73,4 +73,67 @@ public class ClaimContactsMissingFilterTest
 
         Filter.GetProblems(claim, projectInfo).ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingRealname);
     }
+
+    [Fact]
+    public void PassportMissingWhenAllowedButNotFilled()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequirePassport = MandatoryStatus.Required });
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+        claim.PlayerAllowedSenstiveData = true;
+
+        Filter.GetProblems(claim, projectInfo).ShouldContain(p => p.ProblemType == ClaimProblemType.MissingPassport);
+    }
+
+    [Fact]
+    public void PassportNotMissingWhenAllowedAndFilled()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequirePassport = MandatoryStatus.Required });
+        Mock.Player.Extra = new UserExtra { PassportData = "1234 567890" };
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+        claim.PlayerAllowedSenstiveData = true;
+
+        Filter.GetProblems(claim, projectInfo).ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingPassport);
+    }
+
+    [Fact]
+    public void RegistrationAddressMissingWhenAllowedButNotFilled()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequireRegistrationAddress = MandatoryStatus.Required });
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+        claim.PlayerAllowedSenstiveData = true;
+
+        Filter.GetProblems(claim, projectInfo).ShouldContain(p => p.ProblemType == ClaimProblemType.MissingRegistrationAddress);
+    }
+
+    [Fact]
+    public void SensitiveDataNotAllowedWhenConsentNotGiven()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(
+            ProjectProfileRequirementSettings.AllNotRequired with { RequirePassport = MandatoryStatus.Required });
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+        claim.PlayerAllowedSenstiveData = false;
+
+        var problems = Filter.GetProblems(claim, projectInfo);
+
+        problems.ShouldContain(p => p.ProblemType == ClaimProblemType.SensitiveDataNotAllowed);
+        problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingPassport);
+        problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingRegistrationAddress);
+    }
+
+    [Fact]
+    public void NoSensitiveDataProblemsWhenNotRequiredAtAllRegardlessOfConsent()
+    {
+        var projectInfo = Mock.ProjectInfo.WithProfileRequirementSettings(ProjectProfileRequirementSettings.AllNotRequired);
+        var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
+        claim.PlayerAllowedSenstiveData = false;
+
+        var problems = Filter.GetProblems(claim, projectInfo);
+
+        problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.SensitiveDataNotAllowed);
+        problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingPassport);
+        problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingRegistrationAddress);
+    }
 }

--- a/src/JoinRpg.Domain/Problems/ClaimProblemFilters/ClaimContactsMissingFilter.cs
+++ b/src/JoinRpg.Domain/Problems/ClaimProblemFilters/ClaimContactsMissingFilter.cs
@@ -1,6 +1,5 @@
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Users;
-using JoinRpg.Helpers;
 
 namespace JoinRpg.Domain.Problems.ClaimProblemFilters;
 
@@ -16,14 +15,29 @@ internal class ClaimContactsMissingFilter : IProblemFilter<Claim>
             hasTelegram: !string.IsNullOrWhiteSpace(claim.Player.Extra?.Telegram),
             hasVerifiedVkontakte: claim.Player.Extra?.VkVerified == true && !string.IsNullOrWhiteSpace(claim.Player.Extra.Vk),
             claim.Player.Extra?.PhoneNumber,
-            claim.Player.FullName);
+            claim.Player.FullName,
+            claim.Player.Extra?.PassportData,
+            claim.Player.Extra?.RegistrationAddress);
 
-        var contactProblems = UserProfileProblemsCalculator.GetProblems(missingItems, projectInfo.ProfileRequirementSettings)
+        // Доступ к паспорту/адресу — согласие на уровне заявки (claim.PlayerAllowedSenstiveData),
+        // а не факт о профиле, поэтому не входит в UserProfileItemType и передаётся в калькулятор
+        // отдельно: пока доступа нет, он не считает паспорт/адрес недостающими.
+        var sensitiveDataAllowed = !projectInfo.ProfileRequirementSettings.SensitiveDataRequired
+            || claim.PlayerAllowedSenstiveData;
+
+        var problems = UserProfileProblemsCalculator
+            .GetProblems(missingItems, projectInfo.ProfileRequirementSettings, sensitiveDataAllowed)
             .Select(ToClaimProblem);
 
-        return contactProblems
-            .Union(CheckSensitiveDataAccess(claim, projectInfo))
-            .WhereNotNull();
+        if (!sensitiveDataAllowed)
+        {
+            // ClaimProblemType.SensitiveDataNotAllowed не привязан к UserProfileItemType (это не
+            // поле профиля, а отказ в доступе), поэтому калькулятор его не производит — добавляем
+            // здесь, единственном месте, знающем про ClaimProblemType.
+            problems = problems.Append(new ProfileRelatedProblem(ClaimProblemType.SensitiveDataNotAllowed, ProblemSeverity.Warning));
+        }
+
+        return problems;
     }
 
     private static ProfileRelatedProblem ToClaimProblem(UserProfileProjectProblem problem)
@@ -35,38 +49,8 @@ internal class ClaimContactsMissingFilter : IProblemFilter<Claim>
         UserProfileItemType.Vkontakte => ClaimProblemType.MissingVkontakte,
         UserProfileItemType.Phone => ClaimProblemType.MissingPhone,
         UserProfileItemType.RealName => ClaimProblemType.MissingRealname,
+        UserProfileItemType.Passport => ClaimProblemType.MissingPassport,
+        UserProfileItemType.RegistrationAddress => ClaimProblemType.MissingRegistrationAddress,
         _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
     };
-
-    // TODO(#4763) паспорт/адрес регистрации ещё не переведены на UserProfileItemType +
-    // UserProfileProblemsCalculator — они не входят в UserInfo и дополнительно зависят от
-    // claim.PlayerAllowedSenstiveData (факт про заявку, а не про профиль пользователя).
-    private static IEnumerable<ClaimProblem?> CheckSensitiveDataAccess(Claim claim, ProjectInfo projectInfo)
-    {
-        if (projectInfo.ProfileRequirementSettings.SensitiveDataRequired)
-        {
-            if (claim.PlayerAllowedSenstiveData)
-            {
-                yield return CheckContact(claim.Player.Extra?.PassportData, projectInfo.ProfileRequirementSettings.RequirePassport, ClaimProblemType.MissingPassport);
-                yield return CheckContact(claim.Player.Extra?.RegistrationAddress, projectInfo.ProfileRequirementSettings.RequireRegistrationAddress, ClaimProblemType.MissingRegistrationAddress);
-
-            }
-            else
-            {
-                yield return new ProfileRelatedProblem(ClaimProblemType.SensitiveDataNotAllowed, ProblemSeverity.Warning);
-            }
-        }
-    }
-
-    private static ProfileRelatedProblem? CheckContact(string? contact, MandatoryStatus requirement, ClaimProblemType problemType)
-    {
-        if (!string.IsNullOrWhiteSpace(contact))
-        {
-            return null;
-        }
-
-        return UserProfileProblemsCalculator.ToSeverity(requirement) is { } severity
-            ? new ProfileRelatedProblem(problemType, severity)
-            : null;
-    }
 }

--- a/src/JoinRpg.Domain/UserExtensions.cs
+++ b/src/JoinRpg.Domain/UserExtensions.cs
@@ -29,7 +29,9 @@ public static class UserExtensions
             user.VerifiedProfileFlag,
             user.Extra?.PhoneNumber,
             user.PasswordHash != null,
-            user.Extra?.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null
+            user.Extra?.BirthDate is DateTime birthDate ? DateOnly.FromDateTime(birthDate) : null,
+            user.Extra?.PassportData,
+            user.Extra?.RegistrationAddress
             );
     }
 

--- a/src/JoinRpg.DomainTypes.Test/Characters/ClaimForbiddenReasonTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/Characters/ClaimForbiddenReasonTest.cs
@@ -33,6 +33,8 @@ public class ClaimForbiddenReasonTest
                 AddClaimForbideReason.PhoneMissing,
                 AddClaimForbideReason.TelegramMissing,
                 AddClaimForbideReason.VkontakteMissing,
+                AddClaimForbideReason.PassportMissing,
+                AddClaimForbideReason.RegistrationAddressMissing,
             ],
             ignoreOrder: true);
     }

--- a/src/JoinRpg.DomainTypes.Test/Users/UserProfileProblemsCalculatorTest.cs
+++ b/src/JoinRpg.DomainTypes.Test/Users/UserProfileProblemsCalculatorTest.cs
@@ -22,13 +22,33 @@ public class UserProfileProblemsCalculatorTest
             RequireTelegram: MandatoryStatus.Required,
             RequireVkontakte: MandatoryStatus.Required,
             RequirePhone: MandatoryStatus.Required,
-            RequirePassport: MandatoryStatus.Optional,
-            RequireRegistrationAddress: MandatoryStatus.Optional);
+            RequirePassport: MandatoryStatus.Required,
+            RequireRegistrationAddress: MandatoryStatus.Required);
 
         var missingItems = Enum.GetValues<UserProfileItemType>();
 
         var problems = Should.NotThrow(() => UserProfileProblemsCalculator.GetProblems(missingItems, allRequired));
 
         problems.Select(p => p.ItemType).ShouldBe(missingItems, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void GetProblemsSkipsSensitiveItemsWhenAccessNotAllowed()
+    {
+        var allRequired = new ProjectProfileRequirementSettings(
+            RequireRealName: MandatoryStatus.Required,
+            RequireTelegram: MandatoryStatus.Required,
+            RequireVkontakte: MandatoryStatus.Required,
+            RequirePhone: MandatoryStatus.Required,
+            RequirePassport: MandatoryStatus.Required,
+            RequireRegistrationAddress: MandatoryStatus.Required);
+
+        var missingItems = Enum.GetValues<UserProfileItemType>();
+
+        var problems = UserProfileProblemsCalculator.GetProblems(missingItems, allRequired, sensitiveDataAccessAllowed: false);
+
+        problems.ShouldNotContain(p => p.ItemType == UserProfileItemType.Passport);
+        problems.ShouldNotContain(p => p.ItemType == UserProfileItemType.RegistrationAddress);
+        problems.ShouldContain(p => p.ItemType == UserProfileItemType.RealName);
     }
 }

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimEnums.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimEnums.cs
@@ -40,6 +40,8 @@ public enum AddClaimForbideReason
     PhoneMissing,
     TelegramMissing,
     VkontakteMissing,
+    PassportMissing,
+    RegistrationAddressMissing,
 }
 
 // Более широкий вариант статуса, подразумевает комбинацию нескольких статусов.

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimForbiddenReason.cs
@@ -60,6 +60,7 @@ public record class ClaimForbiddenReason(
         // профиль потом.
         AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing
             or AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing
+            or AddClaimForbideReason.PassportMissing or AddClaimForbideReason.RegistrationAddressMissing
             => new(kind, MasterCanOverride: true, ProblemSeverity.Warning),
 
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimValidator.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimValidator.cs
@@ -127,7 +127,13 @@ public static class ClaimValidator
 
     private static IEnumerable<AddClaimForbideReason> ValidateContacts(ProjectInfo projectInfo, UserInfo userInfo)
     {
-        var problems = UserProfileProblemsCalculator.GetProblems(userInfo, projectInfo.ProfileRequirementSettings);
+        // На этапе подачи/переноса заявки согласия на чувствительные данные ещё не существует —
+        // claim.PlayerAllowedSenstiveData появляется только у уже созданной заявки, а спрашивать
+        // его на этом шаге не у чего. Поэтому паспорт/адрес регистрации здесь не проверяются
+        // (sensitiveDataAccessAllowed: false) — это не факт "доступа нет", а факт "вопрос ещё не
+        // задавался". Missing-паспорт может заблокировать отображение уже поданной заявки
+        // (см. ClaimContactsMissingFilter), но не подачу новой.
+        var problems = UserProfileProblemsCalculator.GetProblems(userInfo, projectInfo.ProfileRequirementSettings, sensitiveDataAccessAllowed: false);
 
         // Заявку блокируют только обязательные (Required => Warning) требования — Recommended (Hint) не мешает подать заявку.
         foreach (var problem in problems.Where(p => p.Severity == ProblemSeverity.Warning))
@@ -136,12 +142,19 @@ public static class ClaimValidator
         }
     }
 
+    // Passport/RegistrationAddress сюда на практике не долетают — ValidateContacts зовёт
+    // GetProblems с sensitiveDataAccessAllowed: false, так что эти два варианта недостижимы.
+    // Ветки оставлены ради полноты (см. тест ...IsDefinedForEveryUserProfileItemType) — как и
+    // остальные exhaustive-switch'и в этом файле, на случай если UserProfileItemType когда-нибудь
+    // будет собираться откуда-то ещё.
     internal static AddClaimForbideReason ToAddClaimForbideReason(UserProfileItemType itemType) => itemType switch
     {
         UserProfileItemType.Telegram => AddClaimForbideReason.TelegramMissing,
         UserProfileItemType.Vkontakte => AddClaimForbideReason.VkontakteMissing,
         UserProfileItemType.Phone => AddClaimForbideReason.PhoneMissing,
         UserProfileItemType.RealName => AddClaimForbideReason.RealNameMissing,
+        UserProfileItemType.Passport => AddClaimForbideReason.PassportMissing,
+        UserProfileItemType.RegistrationAddress => AddClaimForbideReason.RegistrationAddressMissing,
         _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
     };
 
@@ -177,7 +190,8 @@ public static class ClaimValidator
                 => new ClaimWrongStatusException(claim!.ClaimId, claim.Status),
 
             AddClaimForbideReason.RealNameMissing or AddClaimForbideReason.PhoneMissing or
-            AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing => new InsufficientContactsException(),
+            AddClaimForbideReason.TelegramMissing or AddClaimForbideReason.VkontakteMissing or
+            AddClaimForbideReason.PassportMissing or AddClaimForbideReason.RegistrationAddressMissing => new InsufficientContactsException(),
 
             _ => new ArgumentOutOfRangeException(nameof(reason), reason.Kind, message: null),
         };

--- a/src/JoinRpg.DomainTypes/Users/UserInfo.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserInfo.cs
@@ -17,7 +17,9 @@ public record class UserInfo(
     bool VerifiedProfileFlag,
     string? PhoneNumber,
     bool HasPassword,
-    DateOnly? BirthDate = null)
+    DateOnly? BirthDate = null,
+    string? PassportData = null,
+    string? RegistrationAddress = null)
 {
     public UserDisplayName DisplayName { get; } = new UserDisplayName(UserFullName, Email);
 
@@ -33,7 +35,9 @@ public record class UserInfo(
             hasTelegram: Social.Telegram is not null,
             hasVerifiedVkontakte: Social.Vk?.IsVerified == true,
             PhoneNumber,
-            UserFullName.FullName);
+            UserFullName.FullName,
+            PassportData,
+            RegistrationAddress);
 
     /// <summary>
     /// Число полных лет на дату <paramref name="today"/>, или null, если дата рождения не указана.

--- a/src/JoinRpg.DomainTypes/Users/UserProfileItemType.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserProfileItemType.cs
@@ -9,4 +9,6 @@ public enum UserProfileItemType
     Vkontakte,
     Phone,
     RealName,
+    Passport,
+    RegistrationAddress,
 }

--- a/src/JoinRpg.DomainTypes/Users/UserProfileItemsCalculator.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserProfileItemsCalculator.cs
@@ -25,7 +25,9 @@ public static class UserProfileItemsCalculator
         bool hasTelegram,
         bool hasVerifiedVkontakte,
         string? phoneNumber,
-        string? fullName)
+        string? fullName,
+        string? passportData = null,
+        string? registrationAddress = null)
     {
         List<UserProfileItemType> missing = [];
 
@@ -44,6 +46,14 @@ public static class UserProfileItemsCalculator
         if (!IsCorrectContact(fullName))
         {
             missing.Add(UserProfileItemType.RealName);
+        }
+        if (!IsCorrectContact(passportData))
+        {
+            missing.Add(UserProfileItemType.Passport);
+        }
+        if (!IsCorrectContact(registrationAddress))
+        {
+            missing.Add(UserProfileItemType.RegistrationAddress);
         }
 
         return missing;

--- a/src/JoinRpg.DomainTypes/Users/UserProfileProjectProblem.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserProfileProjectProblem.cs
@@ -19,12 +19,21 @@ public static class UserProfileProblemsCalculator
 {
     public static IReadOnlyCollection<UserProfileProjectProblem> GetProblems(
         UserInfo userInfo,
-        ProjectProfileRequirementSettings requirementSettings)
-        => GetProblems(userInfo.GetMissingItems(), requirementSettings);
+        ProjectProfileRequirementSettings requirementSettings,
+        bool sensitiveDataAccessAllowed = true)
+        => GetProblems(userInfo.GetMissingItems(), requirementSettings, sensitiveDataAccessAllowed);
 
+    /// <param name="sensitiveDataAccessAllowed">
+    /// Разрешён ли доступ к паспорту/адресу регистрации — это факт о заявке
+    /// (<c>claim.PlayerAllowedSenstiveData</c>), а не о профиле, поэтому не входит в
+    /// <see cref="UserProfileItemType"/> и передаётся отдельно. Пока доступа нет, паспорт/адрес
+    /// не считаются недостающими — вызывающая сторона показывает вместо этого отдельную проблему
+    /// про отсутствие доступа (см. <c>ClaimContactsMissingFilter</c>).
+    /// </param>
     public static IReadOnlyCollection<UserProfileProjectProblem> GetProblems(
         IReadOnlyCollection<UserProfileItemType> missingItems,
-        ProjectProfileRequirementSettings requirementSettings)
+        ProjectProfileRequirementSettings requirementSettings,
+        bool sensitiveDataAccessAllowed = true)
     {
         List<UserProfileProjectProblem> problems = [];
 
@@ -32,6 +41,12 @@ public static class UserProfileProblemsCalculator
         AddIfMissing(UserProfileItemType.Vkontakte, requirementSettings.RequireVkontakte);
         AddIfMissing(UserProfileItemType.Phone, requirementSettings.RequirePhone);
         AddIfMissing(UserProfileItemType.RealName, requirementSettings.RequireRealName);
+
+        if (sensitiveDataAccessAllowed)
+        {
+            AddIfMissing(UserProfileItemType.Passport, requirementSettings.RequirePassport);
+            AddIfMissing(UserProfileItemType.RegistrationAddress, requirementSettings.RequireRegistrationAddress);
+        }
 
         return problems;
 

--- a/src/JoinRpg.DomainTypes/Users/UserProfileProjectProblem.cs
+++ b/src/JoinRpg.DomainTypes/Users/UserProfileProjectProblem.cs
@@ -23,6 +23,8 @@ public static class UserProfileProblemsCalculator
         bool sensitiveDataAccessAllowed = true)
         => GetProblems(userInfo.GetMissingItems(), requirementSettings, sensitiveDataAccessAllowed);
 
+    /// <param name="missingItems">Незаполненные элементы профиля (<see cref="UserProfileItemsCalculator.GetMissingItems"/>).</param>
+    /// <param name="requirementSettings">Требования конкретного проекта к профилю.</param>
     /// <param name="sensitiveDataAccessAllowed">
     /// Разрешён ли доступ к паспорту/адресу регистрации — это факт о заявке
     /// (<c>claim.PlayerAllowedSenstiveData</c>), а не о профиле, поэтому не входит в

--- a/src/JoinRpg.IntegrationTests/Scenarios/PassportSensitiveDataScenario.cs
+++ b/src/JoinRpg.IntegrationTests/Scenarios/PassportSensitiveDataScenario.cs
@@ -1,0 +1,95 @@
+using JoinRpg.Common.PrimitiveTypes;
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Claims;
+using JoinRpg.DataModel;
+using JoinRpg.Domain.Problems;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Characters;
+using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.IntegrationTest.TestInfrastructure;
+using JoinRpg.IntegrationTests.TestInfrastructure;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.Services.Interfaces.Characters;
+using JoinRpg.Services.Interfaces.Projects;
+
+namespace JoinRpg.IntegrationTest.Scenarios;
+
+/// <summary>
+/// Регрессия на #4763: даже если проект требует паспорт/адрес регистрации, игрок,
+/// не разрешивший доступ к чувствительным данным, всё равно должен иметь возможность
+/// подать заявку — согласие спрашивается на уровне заявки, а не блокирует её подачу.
+/// Уровень проблемы (Warning на SensitiveDataNotAllowed) при этом не меняется.
+/// </summary>
+public class PassportSensitiveDataScenario(JoinApplicationFactory factory) : IClassFixture<JoinApplicationFactory>
+{
+    [Fact]
+    public async Task PlayerCanSendClaim_WhenSensitiveDataNotAllowed_EvenIfPassportRequired()
+    {
+        // 1. Мастер, проект с обязательным паспортом, игрок
+        UserIdentification masterId;
+        ProjectIdentification projectId;
+        UserIdentification playerId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            masterId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+            projectId = await TestUserProjectHelpers.CreateProjectAsync(scope.ServiceProvider, masterId);
+            playerId = await TestUserProjectHelpers.CreateTestUserAsync(scope.ServiceProvider);
+        }
+
+        var characterId = await factory.Services.RunAsAsync(masterId, async sp =>
+        {
+            var projectService = sp.GetRequiredService<IProjectService>();
+            var metadataRepository = sp.GetRequiredService<IProjectMetadataRepository>();
+            var projectInfo = await metadataRepository.GetProjectMetadata(projectId);
+
+            await projectService.SetClaimSettings(
+                projectId,
+                projectInfo.ClaimSettings with { AutoAcceptClaims = false, IsAcceptingClaims = true });
+
+            await projectService.SetContactSettings(
+                projectId,
+                ProjectProfileRequirementSettings.AllNotRequired with { RequirePassport = MandatoryStatus.Required });
+
+            var characterService = sp.GetRequiredService<ICharacterService>();
+            return await characterService.AddCharacter(new AddCharacterRequest(
+                projectId,
+                ParentCharacterGroupIds: [],
+                new CharacterTypeInfo(CharacterType.Player, IsHot: false, SlotLimit: null, SlotName: null, CharacterVisibility.Public),
+                FieldValues: FieldLayerContainer.Empty(projectInfo)));
+        });
+
+        // 2. Игрок подаёт заявку, явно не разрешая доступ к чувствительным данным
+        // (у игрока и так не заполнены ни паспорт, ни адрес регистрации).
+        var claimId = await factory.Services.RunAsAsync(playerId, async sp =>
+        {
+            var claimService = sp.GetRequiredService<IClaimService>();
+            var projectInfo = await sp.GetRequiredService<IProjectMetadataRepository>().GetProjectMetadata(projectId);
+            return await claimService.AddClaimFromUser(
+                characterId, "Хочу эту роль", FieldLayerContainer.Empty(projectInfo), sensitiveDataAllowed: false);
+        });
+
+        // 3. Заявка должна быть создана (сам факт того, что до сюда дошли без исключения,
+        // уже подтверждает, что подача не заблокирована отсутствием паспорта/согласия).
+        using (var scope = factory.Services.CreateScope())
+        {
+            var claimsRepository = scope.ServiceProvider.GetRequiredService<IClaimsRepository>();
+            var claim = await claimsRepository.GetClaim(claimId)
+                ?? throw new InvalidOperationException("Claim not found");
+            claim.ClaimStatus.ShouldBe(ClaimStatus.AddedByUser);
+            claim.PlayerAllowedSenstiveData.ShouldBeFalse();
+
+            // 4. Проблема "нет доступа к чувствительным данным" должна быть ровно одна,
+            // с той же severity (Warning), что была до перевода на UserProfileItemType —
+            // а не MissingPassport/MissingRegistrationAddress по отдельности.
+            var problemValidator = scope.ServiceProvider.GetRequiredService<IProblemValidator<Claim>>();
+            var metadataRepository = scope.ServiceProvider.GetRequiredService<IProjectMetadataRepository>();
+            var projectInfo = await metadataRepository.GetProjectMetadata(projectId);
+
+            var problems = problemValidator.Validate(claim, projectInfo).ToList();
+
+            problems.ShouldContain(p => p.ProblemType == ClaimProblemType.SensitiveDataNotAllowed && p.Severity == ProblemSeverity.Warning);
+            problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingPassport);
+            problems.ShouldNotContain(p => p.ProblemType == ClaimProblemType.MissingRegistrationAddress);
+        }
+    }
+}

--- a/src/JoinRpg.Web.Claims/AddClaimForbideReasonMessage.razor
+++ b/src/JoinRpg.Web.Claims/AddClaimForbideReasonMessage.razor
@@ -66,6 +66,18 @@
             <br /><JoinProfileButton />
     </JoinAlert>
         break;
+    case AddClaimForbideReason.PassportMissing:
+    <JoinAlert Variation="VariationStyleEnum.Warning">
+            Мастера требуют заполнить паспортные данные, чтобы подать заявку на проект.
+            <br /><JoinProfileButton />
+    </JoinAlert>
+        break;
+    case AddClaimForbideReason.RegistrationAddressMissing:
+    <JoinAlert Variation="VariationStyleEnum.Warning">
+            Мастера требуют заполнить адрес регистрации, чтобы подать заявку на проект.
+            <br /><JoinProfileButton />
+    </JoinAlert>
+        break;
     case AddClaimForbideReason.ApprovedClaimMovedToSlot:
         <JoinAlert Variation="VariationStyleEnum.Warning">
             Утверждённую заявку нельзя перенести в слот «@CharacterName». Выберите конкретного персонажа.


### PR DESCRIPTION
## Что сделано

Паспорт/адрес регистрации теперь проходят через общий пайплайн
`UserProfileItemType` → `UserProfileItemsCalculator` → `UserProfileProblemsCalculator`,
как и телеграм/вк/телефон/ФИО (#4760), вместо отдельного switch по `MandatoryStatus`
в `ClaimContactsMissingFilter.CheckSensitiveDataAccess`/`CheckContact`.

- `UserProfileItemType` получил значения `Passport`, `RegistrationAddress`.
- `UserProfileItemsCalculator.GetMissingItems` и `UserInfo` теперь несут
  `PassportData`/`RegistrationAddress`.
- `UserProfileProblemsCalculator.GetProblems` получил параметр
  `sensitiveDataAccessAllowed` — согласие на чувствительные данные
  (`claim.PlayerAllowedSenstiveData`) это факт о заявке, а не о профиле, поэтому
  не стало значением `UserProfileItemType`, а передаётся отдельно; калькулятор сам
  решает, считать ли паспорт/адрес недостающими.
- `ClaimContactsMissingFilter.CheckSensitiveDataAccess`/`CheckContact` убраны —
  паспорт/адрес идут через общий `GetMissingItems → GetProblems → ToClaimProblem`,
  согласие проверяется отдельным флагом.
- На этапе подачи/переноса заявки (`ClaimValidator.ValidateContacts`) согласия ещё
  не существует — явно передаём `sensitiveDataAccessAllowed: false`, чтобы
  отсутствие паспорта не могло заблокировать подачу заявки раньше, чем игрока
  вообще спросили про доступ.
- Довёл экзостивные switch'и (`ToAddClaimForbideReason`, `ClaimForbiddenReason.Create`,
  `ThrowForReason`, `AddClaimForbideReasonMessage.razor`) до новых значений enum —
  большинство из них форсируются существующими completeness-тестами
  (`Enum.GetValues<T>()`).

## Test plan

- [x] `dotnet build` — 0 ошибок
- [x] `dotnet test src/JoinRpg.Domain.Test` — 318/318
- [x] `dotnet test src/JoinRpg.DomainTypes.Test` — 456/456
- [x] `dotnet test src/JoinRpg.Web.Claims.Test` — 16/16
- [x] `dotnet format --verify-no-changes --severity warn` — чисто
- [x] Новый тест `CanSendClaimEvenIfPassportRequiredAndMissing` пинит, что подача
      заявки не блокируется отсутствием паспорта
- [x] Новые тесты на `ClaimContactsMissingFilter` покрывают согласие
      (`SensitiveDataNotAllowed` vs `MissingPassport`/`MissingRegistrationAddress`)

Closes #4763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7bJgdbDLU3qxhDazkofzg