### PR TITLE
refactor: CharacterNavigationViewModel работает поверх CharacterInfo

### DIFF
--- a/src/JoinRpg.DomainTypes/Characters/Claims/CharacterClaimInfoExtensions.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/CharacterClaimInfoExtensions.cs
@@ -1,0 +1,31 @@
+namespace JoinRpg.DomainTypes.Characters.Claims;
+
+public static class CharacterClaimInfoExtensions
+{
+    /// <summary>
+    /// Единственная заявка, которую разумно показать пользователю, если их несколько.
+    /// </summary>
+    /// <remarks>
+    /// Зеркало <c>ClaimExtensions.TrySelectSingleClaim</c> для EF-сущностей (ADR013). Порядок
+    /// предпочтений тот же: утверждённая, затем обсуждаемая, затем единственная какая есть.
+    /// Если однозначного кандидата нет — <c>null</c>.
+    /// </remarks>
+    public static CharacterClaimInfo? TrySelectSingleClaim(this IReadOnlyCollection<CharacterClaimInfo> claims)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+
+        if (claims.Count(c => c.IsApproved) == 1)
+        {
+            return claims.Single(c => c.IsApproved);
+        }
+        if (claims.Count(c => c.IsInDiscussion) == 1)
+        {
+            return claims.Single(c => c.IsInDiscussion);
+        }
+        if (claims.Count == 1)
+        {
+            return claims.Single();
+        }
+        return null;
+    }
+}

--- a/src/JoinRpg.Portal/Controllers/CharacterController.cs
+++ b/src/JoinRpg.Portal/Controllers/CharacterController.cs
@@ -1,5 +1,6 @@
 using Joinrpg.AspNetCore.Helpers;
 using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.Domain.Access;
@@ -20,6 +21,7 @@ namespace JoinRpg.Portal.Controllers;
 public class CharacterController(
     IProjectRepository projectRepository,
     ICharacterRepository characterRepository,
+    ICharacterInfoRepository characterInfoRepository,
     ICharacterService characterService,
     IProjectMetadataRepository projectMetadataRepository,
     ICurrentUserAccessor currentUser,
@@ -53,6 +55,7 @@ public class CharacterController(
         return View("Details",
             new CharacterDetailsViewModel(currentUser,
                 character,
+                await characterInfoRepository.GetCharacterInfo(character.GetId()),
                 plots,
                 projectInfo));
     }
@@ -71,7 +74,7 @@ public class CharacterController(
             CharacterTypeInfo = view.CharacterTypeInfo,
             Name = field.CharacterName,
             ParentCharacterGroupIds = [.. field.GetDirectNonSpecialGroupIds(projectInfo)],
-        }.Fill(field, currentUser.UserIdentification, projectInfo));
+        }.Fill(field, await characterInfoRepository.GetCharacterInfo(field.GetId()), currentUser.UserIdentification, projectInfo));
     }
 
     [HttpPost, MasterAuthorize(Permission.CanEditRoles), ValidateAntiForgeryToken]
@@ -85,7 +88,7 @@ public class CharacterController(
         {
             if (!ModelState.IsValid)
             {
-                return View(viewModel.Fill(field, currentUser.UserIdentification, projectInfo));
+                return View(viewModel.Fill(field, await characterInfoRepository.GetCharacterInfo(field.GetId()), currentUser.UserIdentification, projectInfo));
             }
 
             await characterService.EditCharacter(
@@ -102,7 +105,7 @@ public class CharacterController(
         catch (Exception exception)
         {
             AddModelException(exception);
-            return View(viewModel.Fill(field, currentUser.UserIdentification, projectInfo));
+            return View(viewModel.Fill(field, await characterInfoRepository.GetCharacterInfo(field.GetId()), currentUser.UserIdentification, projectInfo));
         }
     }
 

--- a/src/JoinRpg.Portal/Controllers/CheckInController.cs
+++ b/src/JoinRpg.Portal/Controllers/CheckInController.cs
@@ -1,4 +1,5 @@
 using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.Data.Interfaces.Claims;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
@@ -20,6 +21,7 @@ namespace JoinRpg.Portal.Controllers;
 public class CheckInController(
     IProjectService projectService,
     IClaimsRepository claimsRepository,
+    ICharacterInfoRepository characterInfoRepository,
     IClaimService claimService,
     IUserRepository userRepository,
     IProjectMetadataRepository projectMetadataRepository,
@@ -89,6 +91,7 @@ public class CheckInController(
 
         return View("CheckIn",
             new CheckInClaimModel(claim,
+            await characterInfoRepository.GetCharacterInfo(characterId),
             await userRepository.GetRequiredUserInfo(currentUserAccessor.UserIdentification),
             handouts[characterId],
             claimValidator,
@@ -143,7 +146,12 @@ public class CheckInController(
 
         var playerUserInfo = await userRepository.GetRequiredUserInfo(claim.GetPlayerId());
 
-        return View(new SecondRoleViewModel(claim, currentUserAccessor, projectInfo, playerUserInfo));
+        return View(new SecondRoleViewModel(
+            claim,
+            await characterInfoRepository.GetCharacterInfo(claim.GetCharacterId()),
+            currentUserAccessor,
+            projectInfo,
+            playerUserInfo));
     }
 
     [ValidateAntiForgeryToken]

--- a/src/JoinRpg.Portal/Controllers/ClaimController.cs
+++ b/src/JoinRpg.Portal/Controllers/ClaimController.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Joinrpg.AspNetCore.Helpers;
 using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.Data.Interfaces.Claims;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
@@ -25,6 +26,7 @@ public class ClaimController(
     IClaimsRepository claimsRepository,
     IFinanceService financeService,
     ICharacterRepository characterRepository,
+    ICharacterInfoRepository characterInfoRepository,
     IUserRepository UserRepository,
     IPaymentsService paymentsService,
     IProjectMetadataRepository projectMetadataRepository,
@@ -116,6 +118,7 @@ public class ClaimController(
 
         var claimViewModel = new ClaimViewModel(currentUserAccessor,
             claim,
+            await characterInfoRepository.GetCharacterInfo(claim.GetCharacterId()),
             plots,
             projectInfo,
             claimValidator,

--- a/src/JoinRpg.WebPortal.Models/Characters/CharacterDetailsViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Characters/CharacterDetailsViewModel.cs
@@ -3,6 +3,7 @@ using JoinRpg.Data.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.Domain.Access;
+using JoinRpg.DomainTypes.Characters;
 using JoinRpg.Interfaces;
 using JoinRpg.Web.Models.Plot;
 
@@ -46,6 +47,7 @@ public class CharacterDetailsViewModel : ICreatedUpdatedTracked
     public CharacterDetailsViewModel(
         ICurrentUserAccessor currentUserId,
         Character character,
+        CharacterInfo characterInfo,
         IReadOnlyCollection<PlotTextDto> plots,
         ProjectInfo projectInfo)
     {
@@ -56,8 +58,8 @@ public class CharacterDetailsViewModel : ICreatedUpdatedTracked
 
         ParentGroups = new CharacterParentGroupsViewModel(character, accessArguments.MasterAccess, projectInfo);
         Navigation =
-          CharacterNavigationViewModel.FromCharacter(character, CharacterNavigationPage.Character,
-            currentUserId.UserIdentificationOrDefault, projectInfo);
+          CharacterNavigationViewModel.FromCharacter(characterInfo, CharacterNavigationPage.Character,
+            currentUserId.UserIdentificationOrDefault);
 
         Fields = new CustomFieldsViewModel(
             character,

--- a/src/JoinRpg.WebPortal.Models/Characters/CharacterNavigationViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Characters/CharacterNavigationViewModel.cs
@@ -1,5 +1,3 @@
-using JoinRpg.DataModel;
-using JoinRpg.Domain;
 using JoinRpg.Domain.Access;
 using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
@@ -9,81 +7,83 @@ using JoinRpg.Web.Models.UserProfile;
 namespace JoinRpg.Web.Models.Characters;
 
 /// <summary>
-/// TODO: LEO describe the meaning of this tricky class properly
+/// Шапка страниц персонажа и заявки: кто это, что с ним можно сделать и на какую из заявок
+/// переключиться.
 /// </summary>
-public class CharacterNavigationViewModel(Character character, UserIdentification? currentUserId, ProjectInfo projectInfo)
+public class CharacterNavigationViewModel
 {
+    private readonly CharacterInfo character;
+
+    private CharacterNavigationViewModel(CharacterInfo character, UserIdentification? currentUserId)
+    {
+        this.character = character;
+        var projectInfo = character.ProjectInfo;
+
+        AccessArguments = AccessArgumentsFactory.Create(character, currentUserId);
+        CanEditRoles = projectInfo.HasEditRolesAccess(currentUserId);
+        CanManageClaims = projectInfo.HasMasterAccess(currentUserId, Permission.CanManageClaims);
+        CharacterId = character.Id.CharacterId;
+        ProjectId = character.Id.ProjectId.Value;
+        Name = character.CharacterName;
+        IsActive = character.IsActive;
+
+        DiscussedClaims = SelectClaims(claim => claim.IsInDiscussion, currentUserId);
+        RejectedClaims = SelectClaims(claim => !claim.IsActive, currentUserId);
+    }
+
     public CharacterNavigationPage Page { get; private set; }
-    private AccessArguments AccessArguments { get; } = AccessArgumentsFactory.Create(character, currentUserId, projectInfo);
+    private AccessArguments AccessArguments { get; }
     public bool HasMasterAccess => AccessArguments.MasterAccess;
-    public bool CanEditRoles { get; } = projectInfo.HasEditRolesAccess(currentUserId);
-    public bool CanManageClaims { get; } = projectInfo.HasMasterAccess(currentUserId, Permission.CanManageClaims);
+    public bool CanEditRoles { get; }
+    public bool CanManageClaims { get; }
 
     public bool CanAddClaim { get; private set; }
     public int? ClaimId { get; private set; }
-    public int CharacterId { get; } = character.CharacterId;
-    public int ProjectId { get; } = character.ProjectId;
+    public int CharacterId { get; }
+    public int ProjectId { get; }
 
-    public string Name { get; } = character.CharacterName;
+    public string Name { get; }
 
-    public bool IsActive { get; } = character.IsActive;
+    public bool IsActive { get; }
 
-    public IEnumerable<ClaimShortListItemViewModel> DiscussedClaims { get; } = LoadClaimsWithCondition(character, currentUserId, claim => claim.IsInDiscussion, projectInfo);
-    public IEnumerable<ClaimShortListItemViewModel> RejectedClaims { get; } = LoadClaimsWithCondition(character, currentUserId, claim => !claim.ClaimStatus.IsActive(), projectInfo);
+    public IEnumerable<ClaimShortListItemViewModel> DiscussedClaims { get; }
+    public IEnumerable<ClaimShortListItemViewModel> RejectedClaims { get; }
 
-    public static CharacterNavigationViewModel FromCharacter(Character character,
+    public static CharacterNavigationViewModel FromCharacter(
+        CharacterInfo character,
         CharacterNavigationPage page,
-        UserIdentification? currentUserId, ProjectInfo projectInfo)
+        UserIdentification? currentUserId)
     {
-        int? claimId;
+        ArgumentNullException.ThrowIfNull(character);
 
-        if (currentUserId is null)
+        return new CharacterNavigationViewModel(character, currentUserId)
         {
-            claimId = null;
-        }
-        else if (character.ApprovedClaim?.HasAccess(currentUserId, Permission.None, ExtraAccessReason.Player) == true
-        ) //If Approved Claim exists and we have access to it, so be it.
-        {
-            claimId = character.ApprovedClaim.ClaimId;
-        }
-        else // if we have My claims, try select single one. We may fail to do so.
-        {
-            claimId = character.Claims.Where(c => c.PlayerUserId == currentUserId).ToList()
-                .TrySelectSingleClaim()?.ClaimId;
-        }
-
-        var vm = new CharacterNavigationViewModel(character, currentUserId, projectInfo)
-        {
-            CanAddClaim = character.IsAcceptingClaims(projectInfo),
-            ClaimId = claimId,
+            // Показ считается глазами игрока, кто бы страницу ни открыл: мастерские послабления
+            // здесь дали бы «заявиться можно» в проекте с закрытым приёмом заявок.
+            CanAddClaim = ClaimValidator
+                .Validate(character, userInfo: null, movedClaim: null, character.ProjectInfo, ClaimOperation.DisplayForPlayer)
+                .Count == 0,
+            ClaimId = SelectClaimToShow(character, currentUserId)?.ClaimId.ClaimId,
             Page = page,
         };
-
-        return vm;
-    }
-
-    private static IEnumerable<ClaimShortListItemViewModel> LoadClaimsWithCondition(Character field, UserIdentification? currentUserId,
-        Func<Claim, bool> predicate, ProjectInfo projectInfo)
-    {
-        return projectInfo.HasMasterAccess(currentUserId)
-            ? field.Claims.Where(predicate).Select(claim => new ClaimShortListItemViewModel(claim.Character.CharacterName, claim.GetId(), UserLinks.Create(claim.Player.ToUserInfoHeader())))
-            : [];
     }
 
     public static CharacterNavigationViewModel FromClaim(
-        Claim claim,
+        CharacterInfo character,
+        ClaimIdentification claimId,
         UserIdentification currentUserId,
-        CharacterNavigationPage characterNavigationPage, ProjectInfo projectInfo)
+        CharacterNavigationPage characterNavigationPage)
     {
-        ArgumentNullException.ThrowIfNull(claim);
+        ArgumentNullException.ThrowIfNull(character);
 
-        var vm = new CharacterNavigationViewModel(claim.Character, currentUserId, projectInfo)
+        var vm = new CharacterNavigationViewModel(character, currentUserId)
         {
             CanAddClaim = false,
-            ClaimId = claim.ClaimId,
+            ClaimId = claimId.ClaimId,
             Page = characterNavigationPage,
         };
-        if (vm.RejectedClaims.Any(c => c.ClaimId == claim.ClaimId))
+
+        if (vm.RejectedClaims.Any(c => c.ClaimId == claimId.ClaimId))
         {
             vm.Page = CharacterNavigationPage.RejectedClaim;
             vm.ClaimId = null;
@@ -91,4 +91,39 @@ public class CharacterNavigationViewModel(Character character, UserIdentificatio
 
         return vm;
     }
+
+    /// <summary>
+    /// На какую заявку вести с карточки персонажа: на утверждённую, если она видна этому
+    /// пользователю, иначе на его собственную — если её удаётся выбрать однозначно.
+    /// </summary>
+    private static CharacterClaimInfo? SelectClaimToShow(CharacterInfo character, UserIdentification? currentUserId)
+    {
+        if (currentUserId is null)
+        {
+            return null;
+        }
+
+        if (character.ApprovedClaim is { } approvedClaim && HasAccessToClaim(approvedClaim, character, currentUserId))
+        {
+            return approvedClaim;
+        }
+
+        return character.Claims.Where(c => c.PlayerId == currentUserId).ToList().TrySelectSingleClaim();
+    }
+
+    /// <summary>
+    /// Эквивалент <c>ClaimAcccessExtensions.HasAccess(claim, userId, Permission.None,
+    /// ExtraAccessReason.Player)</c> для агрегата: свою заявку игрок видит всегда, чужую — только
+    /// с мастерским доступом.
+    /// </summary>
+    private static bool HasAccessToClaim(CharacterClaimInfo claim, CharacterInfo character, UserIdentification currentUserId)
+        => claim.PlayerId == currentUserId || character.ProjectInfo.HasMasterAccess(currentUserId);
+
+    private IEnumerable<ClaimShortListItemViewModel> SelectClaims(
+        Func<CharacterClaimInfo, bool> predicate,
+        UserIdentification? currentUserId)
+        => character.ProjectInfo.HasMasterAccess(currentUserId)
+            ? [.. character.Claims.Where(predicate).Select(claim =>
+                new ClaimShortListItemViewModel(character.CharacterName, claim.ClaimId, UserLinks.Create(claim.Player)))]
+            : [];
 }

--- a/src/JoinRpg.WebPortal.Models/Characters/EditCharacterViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Characters/EditCharacterViewModel.cs
@@ -1,5 +1,6 @@
 using JoinRpg.DataModel;
 using JoinRpg.DataModel.Extensions;
+using JoinRpg.DomainTypes.Characters;
 using JoinRpg.DomainTypes.Characters.Claims;
 
 namespace JoinRpg.Web.Models.Characters;
@@ -23,11 +24,11 @@ public class EditCharacterViewModel : CharacterViewModelBase, ICreatedUpdatedTra
     [ReadOnly(true)]
     public bool IsDefaultTemplate { get; private set; }
 
-    public EditCharacterViewModel Fill(Character field, UserIdentification currentUserId, ProjectInfo projectInfo)
+    public EditCharacterViewModel Fill(Character field, CharacterInfo characterInfo, UserIdentification currentUserId, ProjectInfo projectInfo)
     {
-        Navigation = CharacterNavigationViewModel.FromCharacter(field,
+        Navigation = CharacterNavigationViewModel.FromCharacter(characterInfo,
             CharacterNavigationPage.Editing,
-            currentUserId, projectInfo);
+            currentUserId);
         FillFields(field, currentUserId, projectInfo);
 
         ActiveClaimsCount = field.Claims.Count(claim => claim.ClaimStatus.IsActive());

--- a/src/JoinRpg.WebPortal.Models/CheckIn/CheckInClaimModel.cs
+++ b/src/JoinRpg.WebPortal.Models/CheckIn/CheckInClaimModel.cs
@@ -13,6 +13,7 @@ namespace JoinRpg.Web.Models.CheckIn;
 public class CheckInClaimModel : IProjectIdAware
 {
     public CheckInClaimModel(Claim claim,
+        CharacterInfo characterInfo,
         UserInfo currentUser,
         IReadOnlyCollection<PlotTextDto> plotElements,
         IProblemValidator<Claim> claimValidator,
@@ -28,7 +29,7 @@ public class CheckInClaimModel : IProjectIdAware
         CheckInTime = claim.CheckInDate;
         ClaimStatus = (ClaimStatusView)claim.ClaimStatus;
         PlayerDetails = new UserProfileDetailsViewModel(claim.GetUserInfo(), projectInfo, currentUserAccessor);
-        Navigation = CharacterNavigationViewModel.FromClaim(claim, currentUserAccessor.UserIdentification, CharacterNavigationPage.None, projectInfo);
+        Navigation = CharacterNavigationViewModel.FromClaim(characterInfo, claim.GetId(), currentUserAccessor.UserIdentification, CharacterNavigationPage.None);
 
         CanAcceptFee = projectInfo.ProjectFinanceSettings.CanAcceptCash(currentUserAccessor.UserIdentification);
         ClaimId = claim.ClaimId;

--- a/src/JoinRpg.WebPortal.Models/CheckIn/SecondRoleViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/CheckIn/SecondRoleViewModel.cs
@@ -1,4 +1,6 @@
 using JoinRpg.DataModel;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes.Characters;
 using JoinRpg.Interfaces;
 using JoinRpg.Web.Models.Characters;
 
@@ -6,10 +8,10 @@ namespace JoinRpg.Web.Models.CheckIn;
 
 public class SecondRoleViewModel
 {
-    public SecondRoleViewModel(Claim claim, ICurrentUserAccessor currentUser, ProjectInfo projectInfo, UserInfo playerUserInfo)
+    public SecondRoleViewModel(Claim claim, CharacterInfo characterInfo, ICurrentUserAccessor currentUser, ProjectInfo projectInfo, UserInfo playerUserInfo)
     {
         Master = claim.ResponsibleMasterUser;
-        Navigation = CharacterNavigationViewModel.FromClaim(claim, currentUser.UserIdentification, CharacterNavigationPage.None, projectInfo);
+        Navigation = CharacterNavigationViewModel.FromClaim(characterInfo, claim.GetId(), currentUser.UserIdentification, CharacterNavigationPage.None);
         PlayerDetails = new UserProfileDetailsViewModel(playerUserInfo, projectInfo, currentUser);
         ClaimId = claim.ClaimId;
         ProjectId = projectInfo.ProjectId.Value;

--- a/src/JoinRpg.WebPortal.Models/Claims/ClaimViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Claims/ClaimViewModel.cs
@@ -4,6 +4,7 @@ using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.Domain.Access;
 using JoinRpg.Domain.Problems;
+using JoinRpg.DomainTypes.Characters;
 using JoinRpg.Interfaces;
 using JoinRpg.Web.Claims;
 using JoinRpg.Web.Models.Accommodation;
@@ -92,6 +93,7 @@ public class ClaimViewModel : IEntityWithCommentsViewModel
 
     public ClaimViewModel(ICurrentUserAccessor currentUser,
         Claim claim,
+      CharacterInfo characterInfo,
       IReadOnlyCollection<PlotTextDto> plotElements,
       ProjectInfo projectInfo,
       IProblemValidator<Claim> problemValidator,
@@ -131,9 +133,10 @@ public class ClaimViewModel : IEntityWithCommentsViewModel
         ResponsibleMaster = claim.ResponsibleMasterUser;
         Fields = new CustomFieldsViewModel(currentUser.UserId, claim, projectInfo);
         Navigation =
-            CharacterNavigationViewModel.FromClaim(claim,
+            CharacterNavigationViewModel.FromClaim(characterInfo,
+                claim.GetId(),
                 currentUser.UserIdentification,
-                CharacterNavigationPage.Claim, projectInfo);
+                CharacterNavigationPage.Claim);
         Problems = problemValidator.Validate(claim, projectInfo).Select(p => new ProblemViewModel(p)).ToList();
         PlayerDetails = new UserProfileDetailsViewModel(claim.GetUserInfo(), projectInfo, currentUser);
         ProjectActive = claim.Project.Active;


### PR DESCRIPTION
Шаг миграции по ADR013. Шапка страниц персонажа и заявки строилась из EF-сущности `Character` и была одним из трёх мест, державших `LegacyClaimTarget` — `[Obsolete]`-адаптер, ради которого правила заявки до сих пор умеют ходить через EF.

## Что сделано

Модель переведена на агрегат **целиком**, а не только в части правил заявки:

- **Права** — через уже существовавшую перегрузку `AccessArgumentsFactory.Create(CharacterInfo, …)`.
- **Списки обсуждаемых и отклонённых заявок** — из `CharacterInfo.Claims`. Здесь агрегат подошёл без переходников: `CharacterClaimInfo.Player` уже `UserInfoHeader`, и `UserLinks.Create` принимает его как есть, а предикаты сводятся к готовым `IsInDiscussion` / `IsActive`.
- **`CanAddClaim`** — `ClaimValidator` с операцией `DisplayForPlayer`. Не `AddByMaster`: показ считается глазами игрока, кто бы страницу ни открыл, иначе шапка утверждала бы «заявиться можно» в проекте с закрытым приёмом заявок.

`ProjectInfo` отдельным параметром больше не нужен — агрегат несёт его в себе.

## Две вещи, которые пришлось перенести руками

**`TrySelectSingleClaim`** — выбор заявки, на которую вести с карточки персонажа. Добавлен `CharacterClaimInfoExtensions.TrySelectSingleClaim`, зеркало одноимённого метода для EF-сущностей: утверждённая → обсуждаемая → единственная какая есть.

**Проверка доступа к утверждённой заявке.** Раньше звался `HasAccess(claim, userId, Permission.None, ExtraAccessReason.Player)`. При этих аргументах он сводится к «своя заявка либо мастерский доступ» — выписал это явно, с комментарием про эквивалентность, вместо того чтобы тащить в `DomainTypes` весь механизм `ExtraAccessReason`.

## Объём

Пять потребителей модели (`CharacterDetailsViewModel`, `EditCharacterViewModel`, `CheckInClaimModel`, `SecondRoleViewModel`, `ClaimViewModel`) и три контроллера, которые теперь берут `CharacterInfo` из `ICharacterInfoRepository`. Разбить меньше не выходит: тип параметра меняется, и половина модели на двух источниках данных не живёт.

## Что осталось

`LegacyClaimTarget` пока жив: его держит `AddClaimViewModel`, который тянет `CustomFieldsViewModel` — у того все конструкторы принимают EF-`Character`. Третий держатель, `CharacterLinkViewModel`, оказался мёртвым кодом и удалён отдельно в #4790.

## Проверка

`dotnet build` — 0 ошибок, полный `dotnet test` — зелёный, `dotnet format --verify-no-changes --severity warn` — чисто. (`JoinRpg.IntegrationTest` перезапускал: контейнер SQL Server периодически не поднимается — сначала это выглядело как 103 падения DI-тестов, но причина `ContainerNotRunningException`; на повторе 166/166.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY