### PR TITLE
feat: строка «Игроки с невыбранным типом поселения» на странице поселения

### DIFF
--- a/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
+++ b/src/JoinRpg.Portal/Controllers/AccommodationTypeController.cs
@@ -1,4 +1,6 @@
 using JoinRpg.Data.Interfaces;
+using JoinRpg.Data.Interfaces.Claims;
+using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.Interfaces;
 using JoinRpg.Portal.Infrastructure.Authorization;
 using JoinRpg.Services.Interfaces;
@@ -12,6 +14,7 @@ namespace JoinRpg.Portal.Controllers;
 public class AccommodationTypeController(
     IAccommodationService accommodationService,
     IAccommodationRepository accommodationRepository,
+    IClaimsRepository claimsRepository,
     IProjectMetadataRepository projectMetadataRepository,
     ICurrentUserAccessor currentUserAccessor) : Common.JoinControllerGameBase
 {
@@ -35,6 +38,7 @@ public class AccommodationTypeController(
 
         return View(new AccommodationListViewModel(project,
             await accommodationRepository.GetRoomTypesForProject(projectId),
+            await claimsRepository.GetClaimsForRoomType(projectId, ClaimStatusSpec.Active, roomTypeId: null),
             currentUserAccessor));
     }
 

--- a/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/Index.cshtml
@@ -54,6 +54,7 @@
     {
       <tr><td colspan="7">Типы размещения не добавлены</td></tr>
     }
+    <partial name="_UnassignedClaimsDetails" model="Model.UnassignedClaims" />
     <tr>
       <td>Итого</td>
       <td class="visible-lg">&nbsp;</td>

--- a/src/JoinRpg.Portal/Views/AccommodationType/_UnassignedClaimsDetails.cshtml
+++ b/src/JoinRpg.Portal/Views/AccommodationType/_UnassignedClaimsDetails.cshtml
@@ -1,0 +1,28 @@
+
+@using JoinRpg.Web.Models.Accommodation
+@model UnassignedClaimsRowViewModel
+
+<tr>
+    <td>Игроки с невыбранным типом поселения</td>
+    <td class="visible-lg">&nbsp;</td>
+    <td class="price-value">&nbsp;</td>
+    <td class="price-value">&nbsp;</td>
+    <td class="price-value">
+        @if (Model.PaidCount != 0 || Model.AcceptedNotPaidCount == 0)
+        {
+            <span title="@RoomTypeListItemViewModel.PaidTooltip">@Model.PaidCount</span>
+        }
+        @if (Model.AcceptedNotPaidCount != 0)
+        {
+            @if (Model.PaidCount != 0 || Model.AcceptedNotPaidCount == 0)
+            {
+                <text>+</text>
+            }
+            <span title="@RoomTypeListItemViewModel.AcceptedNotPaidTooltip">@Model.AcceptedNotPaidCount</span>
+        }
+        = <span title="@RoomTypeListItemViewModel.TotalUnsettledTooltip">@Model.PendingRequests</span>
+        <a title="Показать список заявок с невыбранным типом поселения" class="btn btn-sm btn-default" href="@Url.Action("ListWithoutRoomType", "ClaimList", new { Model.ProjectId })"><join-icon icon="MenuHorizontal" /></a>
+    </td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+</tr>

--- a/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
+++ b/src/JoinRpg.WebPortal.Models/Accommodation/AccommodationListViewModel.cs
@@ -1,4 +1,5 @@
 using JoinRpg.Data.Interfaces;
+using JoinRpg.DataModel;
 using JoinRpg.Domain;
 using JoinRpg.Interfaces;
 using JoinRpg.Markdown;
@@ -32,8 +33,11 @@ public class AccommodationListViewModel
 
     public int TotalAcceptedNotPaid { get; }
 
+    public UnassignedClaimsRowViewModel UnassignedClaims { get; set; }
+
     public AccommodationListViewModel(ProjectInfo project,
         IReadOnlyCollection<RoomTypeInfoRow> roomTypes,
+        IReadOnlyCollection<Claim> claimsWithoutRoomType,
         ICurrentUserAccessor userId)
     {
         ProjectId = project.ProjectId;
@@ -49,10 +53,43 @@ public class AccommodationListViewModel
         FreeCapacity = allInfinite ? (int?)null : RoomTypes.Sum(rt => rt.FreeCapacity);
 
         TotalOccupied = RoomTypes.Sum(x => x.Occupied);
-        TotalPending = RoomTypes.Sum(x => x.PendingRequests);
 
-        TotalPaid = RoomTypes.Sum(rt => rt.PaidCount);
-        TotalAcceptedNotPaid = RoomTypes.Sum(rt => rt.AcceptedNotPaidCount);
+        UnassignedClaims = new UnassignedClaimsRowViewModel(claimsWithoutRoomType, project)
+        {
+            ProjectId = project.ProjectId,
+        };
+
+        TotalPending = RoomTypes.Sum(x => x.PendingRequests) + UnassignedClaims.PendingRequests;
+
+        TotalPaid = RoomTypes.Sum(rt => rt.PaidCount) + UnassignedClaims.PaidCount;
+        TotalAcceptedNotPaid = RoomTypes.Sum(rt => rt.AcceptedNotPaidCount) + UnassignedClaims.AcceptedNotPaidCount;
+    }
+}
+
+/// <summary>
+/// Виртуальная строка для игроков, у которых не выбран тип поселения
+/// </summary>
+public class UnassignedClaimsRowViewModel
+{
+    public int ProjectId { get; set; }
+
+    public int PendingRequests { get; }
+
+    public int PaidCount { get; }
+
+    public int AcceptedNotPaidCount { get; }
+
+    public UnassignedClaimsRowViewModel(IReadOnlyCollection<Claim> claimsWithoutRoomType, ProjectInfo projectInfo)
+    {
+        PendingRequests = claimsWithoutRoomType.Count;
+
+        PaidCount = claimsWithoutRoomType.Count(claim =>
+        {
+            var balance = claim.CalculateClaimBalance(projectInfo);
+            var status = FinanceExtensions.GetClaimPaymentStatus(balance.TotalFee, balance.FeePaid);
+            return status is ClaimPaymentStatus.Paid or ClaimPaymentStatus.Overpaid;
+        });
+        AcceptedNotPaidCount = PendingRequests - PaidCount;
     }
 }
 


### PR DESCRIPTION
## Что сделано

- На странице `/{projectId}/rooms/` добавлена виртуальная строка «Игроки с невыбранным типом поселения» — для активных заявок без `AccommodationRequest` (т.е. без выбранного типа поселения вообще).
- Строка показывает ту же формулу «оплачено + принято = всего», что и обычные типы поселения, со ссылкой на список этих заявок (`ClaimList/ListWithoutRoomType`).
- Их количество учтено в итоговой строке «Итого» (Нерасселено).

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes` на изменённых файлах — чисто
- [x] Проверено вручную в браузере на тестовом проекте «Тестовая песочница»: включена система поселения, добавлен тип размещения, строка «Игроки с невыбранным типом поселения» отображается корректно с формулой и ссылкой, а её количество попадает в «Итого»

Generated with [Claude Code](https://claude.ai/code)