### PR TITLE
feat: методы Managers для будущих MCP-инструментов чтения (ADR012)

### DIFF
--- a/src/JoinRpg.WebPortal.Managers.Test/Characters/CharacterApiViewServiceTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/Characters/CharacterApiViewServiceTests.cs
@@ -64,6 +64,24 @@ public class CharacterApiViewServiceTests
         await Should.ThrowAsync<NoAccessToProjectException>(() => service.GetCharacterInfo(characterId));
     }
 
+    [Fact]
+    public async Task GetCharactersByIds_NonMaster_ThrowsBeforeLoadingCharacters()
+    {
+        var service = CreateService(userId: 12345);
+
+        await Should.ThrowAsync<NoAccessToProjectException>(
+            () => service.GetCharactersByIds(Mock.ProjectInfo.ProjectId, [Mock.Character.CharacterId]));
+    }
+
+    [Fact]
+    public async Task ListCharactersByGroup_NonMaster_ThrowsBeforeLoadingCharacters()
+    {
+        var service = CreateService(userId: 12345);
+        var groupId = new CharacterGroupIdentification(Mock.ProjectInfo.ProjectId, Mock.Group.CharacterGroupId);
+
+        await Should.ThrowAsync<NoAccessToProjectException>(() => service.ListCharactersByGroup(groupId));
+    }
+
     private sealed class FakeCharacterRepository(MockedProject mock) : ICharacterRepository
     {
         public Task<IReadOnlyCollection<JoinRpg.Data.Interfaces.CharacterHeader>> GetCharacterHeaders(int projectId, DateTime? modifiedSince) =>

--- a/src/JoinRpg.WebPortal.Managers.Test/Projects/ProjectApiViewServiceTests.cs
+++ b/src/JoinRpg.WebPortal.Managers.Test/Projects/ProjectApiViewServiceTests.cs
@@ -1,0 +1,98 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
+using JoinRpg.Domain;
+using JoinRpg.DomainTypes;
+using JoinRpg.DomainTypes.Advertisement;
+using JoinRpg.Interfaces;
+using JoinRpg.WebPortal.Managers.Projects;
+
+namespace JoinRpg.WebPortal.Managers.Test.Projects;
+
+/// <summary>
+/// <see cref="ProjectApiViewService"/> — общий слой над проектами для x-api и MCP (ADR012).
+/// </summary>
+public class ProjectApiViewServiceTests
+{
+    private MockedProject Mock { get; } = new MockedProject();
+
+    private ProjectApiViewService CreateService(int userId) =>
+        new(
+            new FakeProjectMetadataRepository(Mock.ProjectInfo),
+            new FakeProjectRepository(Mock),
+            new FakeCurrentUserAccessor { UserIdentification = new UserIdentification(userId) });
+
+    [Fact]
+    public async Task GetOverview_NonMaster_ThrowsNoAccessToProjectException()
+    {
+        var service = CreateService(userId: 12345);
+
+        await Should.ThrowAsync<NoAccessToProjectException>(() => service.GetOverview(Mock.ProjectInfo.ProjectId));
+    }
+
+    [Fact]
+    public async Task GetOverview_Master_ReturnsGroupsAndFields()
+    {
+        var service = CreateService(Mock.Master.UserId);
+
+        var overview = await service.GetOverview(Mock.ProjectInfo.ProjectId);
+
+        overview.Groups.ShouldContain(g => g.CharacterGroupId == Mock.Group.CharacterGroupId);
+        overview.Fields.ShouldContain(f => f.ProjectFieldId == Mock.CharacterFieldInfo.Id.ProjectFieldId);
+    }
+
+    [Fact]
+    public async Task ListMasterProjects_ReturnsOnlyProjectsWithMasterAccess()
+    {
+        var service = CreateService(Mock.Master.UserId);
+
+        var projects = await service.ListMasterProjects(new UserIdentification(Mock.Master.UserId));
+
+        projects.ShouldContain(p => p.ProjectId == Mock.ProjectInfo.ProjectId.Value);
+        projects.ShouldNotContain(p => p.ProjectName == "Без доступа");
+    }
+
+    private sealed class FakeProjectMetadataRepository(ProjectInfo projectInfo) : IProjectMetadataRepository
+    {
+        public Task<ProjectInfo> GetProjectMetadata(ProjectIdentification projectId, bool ignoreCache = false)
+            => Task.FromResult(projectInfo);
+
+        public Task<JoinRpg.DomainTypes.ProjectMetadata.ProjectDetails> GetProjectDetails(ProjectIdentification projectId)
+            => Task.FromResult(new JoinRpg.DomainTypes.ProjectMetadata.ProjectDetails(new MarkdownString(""), [], false));
+
+        public void PrimeCache(ProjectInfo projectInfo) { }
+    }
+
+    private sealed class FakeProjectRepository(MockedProject mock) : IProjectRepository
+    {
+        public Task<ProjectPersonalizedInfo[]> GetPersonalizedProjectsBySpecification(PersonalizedProjectListSpecification projectListSpecification)
+            => Task.FromResult<ProjectPersonalizedInfo[]>([
+                new ProjectPersonalizedInfo(mock.ProjectInfo.ProjectId, ProjectLifecycleStatus.ActiveClaimsOpen, false, new ProjectName("Мой проект"), 0, false, true, null, false),
+                new ProjectPersonalizedInfo(new ProjectIdentification(mock.ProjectInfo.ProjectId.Value + 1), ProjectLifecycleStatus.ActiveClaimsOpen, false, new ProjectName("Без доступа"), 0, false, false, null, false),
+            ]);
+
+        [Obsolete]
+        public Task<Project> GetProjectAsync(int project) => throw new NotImplementedException();
+        public Task<Project?> GetProjectWithFieldsAsync(int project) => throw new NotImplementedException();
+        public Task<CharacterGroup?> GetGroupAsync(CharacterGroupIdentification characterGroupId) => throw new NotImplementedException();
+        public Task<CharacterGroup?> LoadGroupWithTreeAsync(int projectId, int? characterGroupId = null) => throw new NotImplementedException();
+        public Task<IList<CharacterGroup>> LoadGroups(IReadOnlyCollection<CharacterGroupIdentification> groupIds) => throw new NotImplementedException();
+        public Task<Project> GetProjectWithFinances(int projectid) => throw new NotImplementedException();
+        public Task<Project> GetProjectForFinanceSetup(int projectid) => throw new NotImplementedException();
+        public Task<ICollection<Character>> GetCharacterByGroups(IReadOnlyCollection<CharacterGroupIdentification> characterGroupIds) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<ProjectWithUpdateDateDto>> GetStaleProjects(DateTime inActiveSince) => throw new NotImplementedException();
+        public Task<ProjectShortInfo[]> GetProjectsBySpecification(ProjectListSpecification projectListSpecification) => throw new NotImplementedException();
+        public Task<ProjectPersonalizedInfo[]> GetProjectsByIds(UserIdentification? userId, ProjectIdentification[] ids) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<ProjectAdvertisementCandidate>> GetPublicProjectsOpenForHotRoleAdvertisement() => throw new NotImplementedException();
+        public void Dispose() { }
+    }
+
+    private sealed class FakeCurrentUserAccessor : ICurrentUserAccessor
+    {
+        public UserIdentification UserIdentification { get; set; } = new UserIdentification(0);
+        public int? UserIdOrDefault => UserIdentification.Value;
+        public UserDisplayName DisplayName => new UserDisplayName("Test", null);
+        public bool IsAdmin => false;
+        public AvatarIdentification? Avatar => null;
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/Characters/CharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/CharacterApiViewService.cs
@@ -49,7 +49,34 @@ internal class CharacterApiViewService(
         _ = projectInfo.RequestMasterAccess(currentUserAccessor);
 
         var character = await characterInfoRepository.GetCharacterInfo(characterId);
+        return await MapToDto(character);
+    }
 
+    public async Task<IReadOnlyCollection<CharacterInfo>> GetCharactersByIds(ProjectIdentification projectId, IReadOnlyCollection<int> characterIds)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
+        _ = projectInfo.RequestMasterAccess(currentUserAccessor);
+
+        var characters = await characterInfoRepository.GetCharacterInfos(
+            [.. characterIds.Select(id => new CharacterIdentification(projectId, id))]);
+        return await MapAllToDto(characters);
+    }
+
+    public async Task<IReadOnlyCollection<CharacterInfo>> ListCharactersByGroup(CharacterGroupIdentification groupId)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(groupId.ProjectId);
+        _ = projectInfo.RequestMasterAccess(currentUserAccessor);
+
+        var groupIds = projectInfo.GetChildGroupIdsIncludingThis(groupId);
+        var characters = await characterInfoRepository.GetCharacterInfosByGroups(groupId.ProjectId, groupIds);
+        return await MapAllToDto(characters);
+    }
+
+    private async Task<IReadOnlyCollection<CharacterInfo>> MapAllToDto(IReadOnlyCollection<DomainCharacterInfo> characters)
+        => await Task.WhenAll(characters.Select(MapToDto));
+
+    private async Task<CharacterInfo> MapToDto(DomainCharacterInfo character)
+    {
         // ProjectInfo несёт сам агрегат — отдельный запрос метаданных не нужен.
         var access = AccessArgumentsFactory.Create(character, currentUserAccessor);
         var fields = character.GetFieldLayers(access);

--- a/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
@@ -13,6 +13,8 @@ public interface ICharacterApiViewService
 
     Task<CharacterInfo> GetCharacterInfo(CharacterIdentification characterId);
 
+    // TODO пробросить в x-game-api (сейчас вызывается только будущим MCP-слоем). См. #4798.
+
     /// <summary>Персонажи по конкретным id одного проекта — не выгрузка всех подряд.</summary>
     Task<IReadOnlyCollection<CharacterInfo>> GetCharactersByIds(ProjectIdentification projectId, IReadOnlyCollection<int> characterIds);
 

--- a/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
@@ -13,6 +13,12 @@ public interface ICharacterApiViewService
 
     Task<CharacterInfo> GetCharacterInfo(CharacterIdentification characterId);
 
+    /// <summary>Персонажи по конкретным id одного проекта — не выгрузка всех подряд.</summary>
+    Task<IReadOnlyCollection<CharacterInfo>> GetCharactersByIds(ProjectIdentification projectId, IReadOnlyCollection<int> characterIds);
+
+    /// <summary>Персонажи группы, включая вложенные подгруппы (в т.ч. спецгруппы вариантов полей).</summary>
+    Task<IReadOnlyCollection<CharacterInfo>> ListCharactersByGroup(CharacterGroupIdentification groupId);
+
     Task<CharacterHeader> CreateCharacter(ProjectIdentification projectId, CreateCharacterRequest request);
 
     Task SetCharacterFields(CharacterIdentification characterId, Dictionary<int, JsonElement> fieldValues);

--- a/src/JoinRpg.WebPortal.Managers/Characters/ISearchApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ISearchApiViewService.cs
@@ -1,0 +1,13 @@
+using JoinRpg.XGameApi.Contract;
+
+namespace JoinRpg.WebPortal.Managers.Characters;
+
+/// <summary>
+/// Поиск персонажей внутри одного проекта для x-api/MCP (ADR012). Проверяет права мастера
+/// сама — <see cref="Services.Interfaces.ISearchService"/> под капотом рассчитан на общий
+/// сайтовый поиск и такой проверки не делает.
+/// </summary>
+public interface ISearchApiViewService
+{
+    Task<IReadOnlyCollection<CharacterSearchResult>> SearchCharacters(ProjectIdentification projectId, string query);
+}

--- a/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
@@ -1,0 +1,31 @@
+using JoinRpg.Data.Interfaces;
+using JoinRpg.Domain;
+using JoinRpg.Interfaces;
+using JoinRpg.Services.Interfaces;
+using JoinRpg.XGameApi.Contract;
+
+namespace JoinRpg.WebPortal.Managers.Characters;
+
+internal class SearchApiViewService(
+    ISearchService searchService,
+    IProjectMetadataRepository projectMetadataRepository,
+    ICurrentUserAccessor currentUserAccessor
+        ) : ISearchApiViewService
+{
+    public async Task<IReadOnlyCollection<CharacterSearchResult>> SearchCharacters(ProjectIdentification projectId, string query)
+    {
+        var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
+        _ = projectInfo.RequestMasterAccess(currentUserAccessor);
+
+        var results = await searchService.SearchAsync(currentUserAccessor.UserIdOrDefault, query);
+
+        return [.. results
+            .Where(r => r.LinkType == LinkType.ResultCharacter && r.ProjectId == projectId.Value)
+            .Select(r => new CharacterSearchResult
+            {
+                CharacterId = int.Parse(r.Identification),
+                CharacterName = r.Name,
+                IsPerfectMatch = r.IsPerfectMatch,
+            })];
+    }
+}

--- a/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
@@ -17,6 +17,8 @@ internal class SearchApiViewService(
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
         _ = projectInfo.RequestMasterAccess(currentUserAccessor);
 
+        // TODO ISearchService.SearchAsync не умеет сузить скоуп по LinkType/ProjectId — ищет по
+        // всем провайдерам и проектам, а мы выкидываем лишнее уже здесь. См. #4797.
         var results = await searchService.SearchAsync(currentUserAccessor.UserIdOrDefault, query);
 
         return [.. results

--- a/src/JoinRpg.WebPortal.Managers/Projects/IProjectApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Projects/IProjectApiViewService.cs
@@ -9,5 +9,11 @@ public interface IProjectApiViewService
 {
     Task<ProjectFieldsMetadata> GetFieldsMetadata(ProjectIdentification projectId);
 
+    /// <summary>Поля, варианты и дерево групп проекта одним вызовом — точка входа для MCP (ADR012 §7).</summary>
+    Task<ProjectOverview> GetOverview(ProjectIdentification projectId);
+
     Task<IEnumerable<ProjectHeader>> GetActiveProjects(UserIdentification userId);
+
+    /// <summary>Проекты, где текущий пользователь — мастер (в отличие от <see cref="GetActiveProjects"/>, который включает и игровые заявки).</summary>
+    Task<IEnumerable<ProjectHeader>> ListMasterProjects(UserIdentification userId);
 }

--- a/src/JoinRpg.WebPortal.Managers/Projects/ProjectApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Projects/ProjectApiViewService.cs
@@ -21,32 +21,66 @@ internal class ProjectApiViewService(
         {
             ProjectId = project.ProjectId,
             ProjectName = project.ProjectName,
-            Fields = project.SortedFields.Select(field =>
-                new JoinRpg.XGameApi.Contract.ProjectFieldInfo
+            Fields = MapFields(project),
+        };
+    }
+
+    public async Task<ProjectOverview> GetOverview(ProjectIdentification projectId)
+    {
+        var project = await projectMetadataRepository.GetProjectMetadata(projectId);
+        _ = project.RequestMasterAccess(currentUserAccessor);
+
+        return new ProjectOverview
+        {
+            ProjectId = project.ProjectId,
+            ProjectName = project.ProjectName,
+            Fields = MapFields(project),
+            Groups = project.Groups.Values
+                .Where(group => group.IsActive)
+                .Select(group => new ProjectOverviewGroup
                 {
-                    FieldName = field.Name,
-                    ProjectFieldId = field.Id.ProjectFieldId,
-                    IsActive = field.IsActive,
-                    FieldType = field.Type.ToString(),
-                    ProgrammaticValue = field.ProgrammaticValue,
-                    ValueList = field.SortedVariants.Select(variant =>
-                        new JoinRpg.XGameApi.Contract.ProjectFieldVariant
-                        {
-                            ProjectFieldVariantId = variant.Id.ProjectFieldVariantId,
-                            Label = variant.Label,
-                            IsActive = variant.IsActive,
-                            Description = variant.Description.ToHtmlString().Value,
-                            MasterDescription =
-                                variant.MasterDescription.ToHtmlString().Value,
-                            ProgrammaticValue = variant.ProgrammaticValue,
-                        }),
+                    CharacterGroupId = group.Id.CharacterGroupId,
+                    CharacterGroupName = group.Name,
+                    DirectParentGroupIds = [.. group.DirectParentGroupIds.Select(id => id.CharacterGroupId)],
+                    IsSpecial = group.IsSpecial,
                 }),
         };
     }
 
+    private static IEnumerable<JoinRpg.XGameApi.Contract.ProjectFieldInfo> MapFields(ProjectInfo project) =>
+        project.SortedFields.Select(field =>
+            new JoinRpg.XGameApi.Contract.ProjectFieldInfo
+            {
+                FieldName = field.Name,
+                ProjectFieldId = field.Id.ProjectFieldId,
+                IsActive = field.IsActive,
+                FieldType = field.Type.ToString(),
+                ProgrammaticValue = field.ProgrammaticValue,
+                SpecialGroupId = field.SpecialGroupId?.CharacterGroupId,
+                ValueList = field.SortedVariants.Select(variant =>
+                    new JoinRpg.XGameApi.Contract.ProjectFieldVariant
+                    {
+                        ProjectFieldVariantId = variant.Id.ProjectFieldVariantId,
+                        Label = variant.Label,
+                        IsActive = variant.IsActive,
+                        Description = variant.Description.ToHtmlString().Value,
+                        MasterDescription =
+                            variant.MasterDescription.ToHtmlString().Value,
+                        ProgrammaticValue = variant.ProgrammaticValue,
+                        CharacterGroupId = variant.CharacterGroupId?.CharacterGroupId,
+                    }),
+            });
+
     public async Task<IEnumerable<ProjectHeader>> GetActiveProjects(UserIdentification userId)
     {
         return (await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.MyActiveProjects(userId)))
+            .Select(p => new ProjectHeader { ProjectId = p.ProjectId, ProjectName = p.ProjectName });
+    }
+
+    public async Task<IEnumerable<ProjectHeader>> ListMasterProjects(UserIdentification userId)
+    {
+        return (await projectRepository.GetPersonalizedProjectsBySpecification(ProjectListSpecification.ActiveWithMyMasterAccess(userId)))
+            .Where(p => p.HasMyMasterAccess)
             .Select(p => new ProjectHeader { ProjectId = p.ProjectId, ProjectName = p.ProjectName });
     }
 }

--- a/src/JoinRpg.WebPortal.Managers/Registration.cs
+++ b/src/JoinRpg.WebPortal.Managers/Registration.cs
@@ -70,6 +70,7 @@ public static class Registration
         .AddScoped<INotificationDashboardClient, AdminTools.NotificationDashboardManager>()
         .AddScoped<ICharacterApiViewService, CharacterApiViewService>()
         .AddScoped<IProjectApiViewService, ProjectApiViewService>()
+        .AddScoped<ISearchApiViewService, SearchApiViewService>()
 
         ;
     }

--- a/src/JoinRpg.XGameApi.Contract/CharacterSearchResult.cs
+++ b/src/JoinRpg.XGameApi.Contract/CharacterSearchResult.cs
@@ -1,0 +1,11 @@
+namespace JoinRpg.XGameApi.Contract;
+
+/// <summary>Лёгкий результат поиска персонажа — по нему потом вызывают get_characters пачкой.</summary>
+public class CharacterSearchResult
+{
+    public int CharacterId { get; set; }
+
+    public required string CharacterName { get; set; }
+
+    public bool IsPerfectMatch { get; set; }
+}

--- a/src/JoinRpg.XGameApi.Contract/ProjectFieldInfo.cs
+++ b/src/JoinRpg.XGameApi.Contract/ProjectFieldInfo.cs
@@ -34,4 +34,10 @@ public class ProjectFieldInfo
     /// Programmatic Value. Ignored by Joinrpg, to use by external system
     /// </summary>
     public string? ProgrammaticValue { get; set; }
+
+    /// <summary>
+    /// Спецгруппа персонажей, в которую попадает персонаж при заполнении этого поля
+    /// (см. <see cref="ProjectOverviewGroup"/>). Null, если у поля нет спецгруппы.
+    /// </summary>
+    public int? SpecialGroupId { get; set; }
 }

--- a/src/JoinRpg.XGameApi.Contract/ProjectFieldVariant.cs
+++ b/src/JoinRpg.XGameApi.Contract/ProjectFieldVariant.cs
@@ -29,4 +29,10 @@ public class ProjectFieldVariant
     /// Programmatic Value. Ignored by Joinrpg, to use by external system
     /// </summary>
     public string? ProgrammaticValue { get; set; }
+
+    /// <summary>
+    /// Спецгруппа персонажей, в которую попадает персонаж при выборе этого варианта
+    /// (см. <see cref="ProjectOverviewGroup"/>). Null, если у варианта нет спецгруппы.
+    /// </summary>
+    public int? CharacterGroupId { get; set; }
 }

--- a/src/JoinRpg.XGameApi.Contract/ProjectOverview.cs
+++ b/src/JoinRpg.XGameApi.Contract/ProjectOverview.cs
@@ -1,0 +1,36 @@
+namespace JoinRpg.XGameApi.Contract;
+
+/// <summary>
+/// Полная картина проекта для LLM (ADR012): поля, варианты значений и дерево групп персонажей,
+/// включая спецгруппы полей/вариантов — по ним строится <c>list_characters</c> по группе
+/// («кто относится к партии синих» — это группа варианта, а не фильтрация всех персонажей).
+/// </summary>
+public class ProjectOverview
+{
+    public int ProjectId { get; set; }
+
+    public required string ProjectName { get; set; }
+
+    public required IEnumerable<ProjectFieldInfo> Fields { get; set; }
+
+    public required IEnumerable<ProjectOverviewGroup> Groups { get; set; }
+}
+
+/// <summary>
+/// Группа персонажей в дереве проекта, включая спецгруппы (см. <see cref="ProjectOverview"/>).
+/// </summary>
+public class ProjectOverviewGroup
+{
+    public int CharacterGroupId { get; set; }
+
+    public required string CharacterGroupName { get; set; }
+
+    /// <summary>Непосредственные родительские группы (могут быть множественными).</summary>
+    public required IReadOnlyCollection<int> DirectParentGroupIds { get; set; }
+
+    /// <summary>
+    /// Спецгруппа поля (значения которого приводят персонажа в неё) или варианта значения —
+    /// в неё нельзя добавить персонажа явно, только через значение поля.
+    /// </summary>
+    public bool IsSpecial { get; set; }
+}


### PR DESCRIPTION
## Что сделано

Выделено из #4795 по просьбе ревью: методы общего слоя `JoinRpg.WebPortal.Managers`
отдельно от самого MCP-сервера, который будет их вызывать следующим PR.

- `ICharacterApiViewService`: `GetCharactersByIds` (батч по id одного проекта),
  `ListCharactersByGroup` (персонажи группы, включая подгруппы/спецгруппы) —
  тонкие обёртки над уже существующими `ICharacterInfoRepository.GetCharacterInfos`/
  `GetCharacterInfosByGroups`, которыми x-api не пользовался.
- Новый `ISearchApiViewService.SearchCharacters` — обёртка над `ISearchService`
  с постфильтром по проекту и правами (сам `ISearchService` рассчитан на общий
  сайтовый поиск и такой проверки не делает).
- `IProjectApiViewService`: `GetOverview` (поля + дерево групп одним вызовом),
  `ListMasterProjects` (только проекты, где пользователь мастер, — в отличие от
  `GetActiveProjects`, который включает и заявки).
- Новый DTO `ProjectOverview` в `JoinRpg.XGameApi.Contract`; `ProjectFieldInfo`/
  `ProjectFieldVariant` получили необязательные `SpecialGroupId`/`CharacterGroupId`
  — аддитивно, не ломая контракт x-api.
- Каждый метод сам проверяет `HasMasterAccess` перед обращением к репозиторию —
  та же дисциплина, что и у уже смёрженных методов (#4778).

x-api-контроллеры эти методы пока не вызывают — это задел под MCP-инструменты
`list_projects`, `get_project_overview`, `list_characters`, `get_characters`,
`search_characters`, реализация которых идёт отдельным PR поверх этого.

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes --severity warn` — чисто
- [x] `dotnet test src/JoinRpg.WebPortal.Managers.Test` — 199 passed (5 новых:
      `HasMasterAccess` на всех новых методах — не-мастер получает
      `NoAccessToProjectException` до обращения к репозиторию)

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxaGjv2KktWZWTsXcjEpYE