### PR TITLE
refactor: ClaimServiceImpl валидирует заявки поверх CharacterInfo

### DIFF
--- a/src/JoinRpg.Domain.Test/AddClaim/ClaimValidationTestExtensions.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/ClaimValidationTestExtensions.cs
@@ -1,4 +1,7 @@
+using JoinRpg.DataModel;
+using JoinRpg.DataModel.Mocks;
 using JoinRpg.DomainTypes.Characters.Claims;
+using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Domain.Test.AddClaim;
 
@@ -11,4 +14,21 @@ internal static class ClaimValidationTestExtensions
     public static IReadOnlyCollection<AddClaimForbideReason> Kinds(
         this IReadOnlyCollection<ClaimForbiddenReason> reasons)
         => [.. reasons.Select(r => r.Kind)];
+
+    /// <summary>
+    /// Правила переноса заявки поверх доменного агрегата.
+    /// </summary>
+    /// <remarks>
+    /// Раньше это был extension-метод на EF-сущности в продакшн-коде. После перевода
+    /// <c>ClaimServiceImpl</c> на <c>CharacterInfo</c> у него не осталось вызывающих, кроме тестов,
+    /// поэтому он живёт здесь — собирать агрегат из мока и звать общий валидатор.
+    /// </remarks>
+    public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanMoveClaim(
+        this Character claimSource, MockedProject mock, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
+        => ClaimValidator.Validate(
+            mock.GetCharacterInfo(claimSource),
+            userInfo,
+            new UserClaimInfo(claim.GetId(), claim.ClaimStatus),
+            projectInfo,
+            ClaimOperation.MoveByMaster);
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/MasterBypassTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MasterBypassTest.cs
@@ -102,7 +102,9 @@ public class MasterBypassTest
         => Mock.Character.ValidateIfCanAddClaim(Mock.PlayerInfo, ClaimsClosed, ClaimOperation.DisplayForPlayer).Kinds()
             .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
 
+    // Тот же показ, но без известного игрока — как при построении списков доступных персонажей.
     [Fact]
-    public void IsAcceptingClaimsNeverBypasses()
-        => Mock.Character.IsAcceptingClaims(ClaimsClosed).ShouldBeFalse();
+    public void DisplayWithoutUserNeverBypasses()
+        => Mock.Character.ValidateIfCanAddClaim(userInfo: null, ClaimsClosed, ClaimOperation.DisplayForPlayer).Kinds()
+            .ShouldBe([AddClaimForbideReason.ProjectClaimsClosed]);
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/MoveClaimValidationRulesTest.cs
@@ -64,7 +64,7 @@ public class MoveClaimValidationRulesTest
         var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
 
         Mock.CreateCharacter("another")
-            .ValidateIfCanMoveClaim(claim, playerWithoutPhone, projectInfo)
+            .ValidateIfCanMoveClaim(Mock, claim, playerWithoutPhone, projectInfo)
             .ShouldBeEmpty();
     }
 
@@ -75,7 +75,7 @@ public class MoveClaimValidationRulesTest
         var claim = Mock.CreateClaim(Mock.Character, Mock.Player);
 
         Mock.CreateCharacter("another")
-            .ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, claimsClosed)
+            .ValidateIfCanMoveClaim(Mock, claim, Mock.PlayerInfo, claimsClosed)
             .ShouldBeEmpty();
     }
 
@@ -87,7 +87,7 @@ public class MoveClaimValidationRulesTest
         var claim = Mock.CreateCheckedInClaim(Mock.Character, Mock.Player);
 
         Mock.CreateCharacter("another")
-            .ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, claimsClosed).Kinds()
+            .ValidateIfCanMoveClaim(Mock, claim, Mock.PlayerInfo, claimsClosed).Kinds()
             .ShouldBe([AddClaimForbideReason.CheckedInClaimCantBeMoved]);
     }
 
@@ -104,8 +104,8 @@ public class MoveClaimValidationRulesTest
             .ShouldNotContain(AddClaimForbideReason.ApprovedClaimMovedToSlot);
     }
 
-    private void ShouldAllowMove(Claim claim, Character character) => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBeEmpty();
+    private void ShouldAllowMove(Claim claim, Character character) => character.ValidateIfCanMoveClaim(Mock, claim, Mock.PlayerInfo, Mock.ProjectInfo).ShouldBeEmpty();
 
     private void ShouldDisAllowMove(Claim claim, Character character, AddClaimForbideReason reason)
-        => character.ValidateIfCanMoveClaim(claim, Mock.PlayerInfo, Mock.ProjectInfo).Kinds().ShouldBe([reason]);
+        => character.ValidateIfCanMoveClaim(Mock, claim, Mock.PlayerInfo, Mock.ProjectInfo).Kinds().ShouldBe([reason]);
 }

--- a/src/JoinRpg.Domain.Test/AddClaim/OnlyOneCharacterRuleTest.cs
+++ b/src/JoinRpg.Domain.Test/AddClaim/OnlyOneCharacterRuleTest.cs
@@ -77,7 +77,7 @@ public class OnlyOneCharacterRuleTest
         var userInfo = WithClaims(new UserClaimInfo(claim.GetId(), ClaimStatus.Approved));
 
         Mock.CreateCharacter("another")
-            .ValidateIfCanMoveClaim(claim, userInfo, Mock.ProjectInfo).Kinds()
+            .ValidateIfCanMoveClaim(Mock, claim, userInfo, Mock.ProjectInfo).Kinds()
             .ShouldNotContain(AddClaimForbideReason.OnlyOneCharacter);
     }
 
@@ -90,7 +90,7 @@ public class OnlyOneCharacterRuleTest
             new UserClaimInfo(ClaimIn(Mock.ProjectInfo.ProjectId, 999), ClaimStatus.Approved));
 
         Mock.CreateCharacter("another")
-            .ValidateIfCanMoveClaim(claim, userInfo, Mock.ProjectInfo).Kinds()
+            .ValidateIfCanMoveClaim(Mock, claim, userInfo, Mock.ProjectInfo).Kinds()
             .ShouldContain(AddClaimForbideReason.OnlyOneCharacter);
     }
 

--- a/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
+++ b/src/JoinRpg.Domain/ClaimAcceptOrMoveValidationExtensions.cs
@@ -1,23 +1,20 @@
-using System.Diagnostics.CodeAnalysis;
 using JoinRpg.DomainTypes.Characters.Claims;
 using JoinRpg.DomainTypes.Users;
 
 namespace JoinRpg.Domain;
 
 /// <summary>
-/// Правила заявки поверх EF-сущности <see cref="Character"/>: тонкая обёртка над
-/// <see cref="ClaimValidator"/>.
+/// Правила заявки поверх EF-сущности <see cref="Character"/>.
 /// </summary>
 /// <remarks>
-/// Сами правила и трансляция причин в исключения живут в <c>JoinRpg.DomainTypes</c>
-/// (<see cref="ClaimValidator"/>). Здесь остаётся только то, что без EF не работает: адаптер
-/// <see cref="LegacyClaimTarget"/> и преобразование EF-<see cref="Claim"/> в <see cref="UserClaimInfo"/>.
+/// Сами правила живут в <c>JoinRpg.DomainTypes</c> (<see cref="ClaimValidator"/>). Здесь остался
+/// только адаптер <see cref="LegacyClaimTarget"/> для тех мест, которые ещё не умеют работать с
+/// <c>CharacterInfo</c>: <c>AddClaimViewModel</c> (упирается в <c>CustomFieldsViewModel</c>) и
+/// <c>CharacterListViewService</c>. Удалить вместе с ними — тогда правила везде будут принимать
+/// агрегат напрямую (ADR013).
 /// </remarks>
 public static class ClaimAcceptOrMoveValidationExtensions
 {
-    public static bool IsAcceptingClaims(this Character character, ProjectInfo projectInfo)
-        => !ValidateIfCanAddClaim(character, userInfo: null, projectInfo, ClaimOperation.DisplayForPlayer).Any();
-
     /// <summary>
     /// Причины, по которым нельзя создать заявку на этого персонажа.
     /// </summary>
@@ -32,46 +29,12 @@ public static class ClaimAcceptOrMoveValidationExtensions
     public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanAddClaim(
         this Character claimSource,
         UserInfo? userInfo, ProjectInfo projectInfo, ClaimOperation operation)
-        => Validate(claimSource, userInfo, movedClaim: null, projectInfo, operation);
-
-    public static IReadOnlyCollection<ClaimForbiddenReason> ValidateIfCanMoveClaim(this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
-        => Validate(claimSource, userInfo, ToMovedClaim(claim), projectInfo, ClaimOperation.MoveByMaster);
-
-    /// <param name="userInfo">
-    /// Игрок, на которого оформляется заявка. При <see cref="ClaimOperation.AddByMaster"/> это не
-    /// тот, кто выполняет операцию: правила про контакты и уже поданные заявки относятся к игроку.
-    /// </param>
-    public static void EnsureCanAddClaim([NotNull] this Character claimSource, UserInfo userInfo, ProjectInfo projectInfo, ClaimOperation operation)
     {
         ArgumentNullException.ThrowIfNull(claimSource);
-        ThrowIfValidationFailed(
-            claimSource.ValidateIfCanAddClaim(userInfo, projectInfo, operation),
-            claim: null,
-            projectInfo);
-    }
 
-    public static void EnsureCanMoveClaim([NotNull] this Character claimSource, Claim claim, UserInfo userInfo, ProjectInfo projectInfo)
-    {
-        ArgumentNullException.ThrowIfNull(claimSource);
-        ThrowIfValidationFailed(claimSource.ValidateIfCanMoveClaim(claim, userInfo, projectInfo), ToMovedClaim(claim), projectInfo);
-    }
-
-#pragma warning disable CS0618 // Пока часть вызывающего кода живёт на EF-сущности, см. LegacyClaimTarget
-    private static IReadOnlyCollection<ClaimForbiddenReason> Validate(
-        Character character, UserInfo? userInfo, UserClaimInfo? movedClaim, ProjectInfo projectInfo, ClaimOperation operation)
-        => ClaimValidator.Validate(new LegacyClaimTarget(character), userInfo, movedClaim, projectInfo, operation);
+#pragma warning disable CS0618 // Пока эти вызывающие живут на EF-сущности, см. LegacyClaimTarget
+        return ClaimValidator.Validate(
+            new LegacyClaimTarget(claimSource), userInfo, movedClaim: null, projectInfo, operation);
 #pragma warning restore CS0618
-
-    private static UserClaimInfo ToMovedClaim(Claim claim) => new(claim.GetId(), claim.ClaimStatus);
-
-    private static void ThrowIfValidationFailed(
-        IReadOnlyCollection<ClaimForbiddenReason> validation,
-        UserClaimInfo? claim,
-        ProjectInfo projectInfo)
-    {
-        if (validation.Count > 0)
-        {
-            ClaimValidator.ThrowForReason(validation.First(), claim, projectInfo);
-        }
     }
 }

--- a/src/JoinRpg.DomainTypes/Characters/Claims/ClaimValidator.cs
+++ b/src/JoinRpg.DomainTypes/Characters/Claims/ClaimValidator.cs
@@ -168,6 +168,40 @@ public static class ClaimValidator
         };
 
     /// <summary>
+    /// Бросает исключение, если заявку создать нельзя.
+    /// </summary>
+    /// <param name="userInfo">
+    /// Игрок, на которого оформляется заявка. При <see cref="ClaimOperation.AddByMaster"/> это не
+    /// тот, кто выполняет операцию.
+    /// </param>
+    public static void EnsureCanAddClaim(
+        IClaimTarget target, UserInfo userInfo, ProjectInfo projectInfo, ClaimOperation operation)
+        => ThrowIfForbidden(
+            Validate(target, userInfo, movedClaim: null, projectInfo, operation),
+            movedClaim: null,
+            projectInfo);
+
+    /// <summary>
+    /// Бросает исключение, если заявку нельзя перенести на этого персонажа.
+    /// </summary>
+    /// <param name="userInfo">Игрок, которому принадлежит переносимая заявка.</param>
+    public static void EnsureCanMoveClaim(
+        IClaimTarget target, UserClaimInfo movedClaim, UserInfo userInfo, ProjectInfo projectInfo)
+        => ThrowIfForbidden(
+            Validate(target, userInfo, movedClaim, projectInfo, ClaimOperation.MoveByMaster),
+            movedClaim,
+            projectInfo);
+
+    private static void ThrowIfForbidden(
+        IReadOnlyCollection<ClaimForbiddenReason> reasons, UserClaimInfo? movedClaim, ProjectInfo projectInfo)
+    {
+        if (reasons.Count > 0)
+        {
+            ThrowForReason(reasons.First(), movedClaim, projectInfo);
+        }
+    }
+
+    /// <summary>
     /// Бросает исключение, соответствующее причине запрета.
     /// </summary>
     /// <param name="claim">

--- a/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Claims/ClaimServiceImpl.cs
@@ -1,3 +1,4 @@
+using JoinRpg.Data.Interfaces.Characters;
 using JoinRpg.Data.Write.Interfaces;
 using JoinRpg.DataModel;
 using JoinRpg.Domain;
@@ -16,6 +17,7 @@ internal class ClaimServiceImpl(
     IAccommodationInviteService accommodationInviteService,
     ICurrentUserAccessor currentUserAccessor,
     IProjectMetadataRepository projectMetadataRepository,
+    ICharacterInfoRepository characterInfoRepository,
     IProblemValidator<Claim> claimValidator,
     ILogger<CharacterServiceImpl> logger,
     ClaimNotificationService claimNotificationService,
@@ -152,7 +154,8 @@ internal class ClaimServiceImpl(
         var projectInfo = await ProjectMetadataRepository.GetProjectMetadata(characterId.ProjectId);
         var user = await UserRepository.GetRequiredUserInfo(currentUserAccessor.UserIdentification);
 
-        source.EnsureCanAddClaim(user, projectInfo, ClaimOperation.AddByPlayer);
+        ClaimValidator.EnsureCanAddClaim(
+            await characterInfoRepository.GetCharacterInfo(characterId), user, projectInfo, ClaimOperation.AddByPlayer);
 
         User responsibleMaster = source.GetResponsibleMaster();
 
@@ -688,7 +691,11 @@ internal class ClaimServiceImpl(
 
         var oldCharacterId = claim.GetCharacterId(); // Сохраняем, так как он изменится
 
-        source.EnsureCanMoveClaim(claim, userInfo, projectInfo);
+        ClaimValidator.EnsureCanMoveClaim(
+            await characterInfoRepository.GetCharacterInfo(characterId),
+            new UserClaimInfo(claim.GetId(), claim.ClaimStatus),
+            userInfo,
+            projectInfo);
 
         MarkCharacterChangedIfApproved(claim); // before move
 
@@ -994,7 +1001,8 @@ internal class ClaimServiceImpl(
         // Проверяем, что персонаж может принимать заявки. Приглашение от мастера проходит мимо
         // причин с MasterCanOverride: закрытый приём заявок и незаполненные контакты игрока
         // мастера не останавливают — контакты игрок дозаполнит позже.
-        source.EnsureCanAddClaim(playerUser, projectInfo, ClaimOperation.AddByMaster);
+        ClaimValidator.EnsureCanAddClaim(
+            await characterInfoRepository.GetCharacterInfo(characterId), playerUser, projectInfo, ClaimOperation.AddByMaster);
 
         User responsibleMaster = source.GetResponsibleMaster();
 


### PR DESCRIPTION
Последний шаг ADR013-миграции правил заявки на стороне сервиса.

## Что сделано

Три write-пути — `AddClaimFromUser`, `AddClaimFromMaster`, `MoveByMaster` — звали правила через extension-методы на EF-сущности `Character`, то есть через `LegacyClaimTarget`. Теперь берут агрегат из `ICharacterInfoRepository` и зовут `ClaimValidator` напрямую.

`Ensure*` переехали в `ClaimValidator` и принимают `IClaimTarget`; переносимая заявка описывается `UserClaimInfo`.

## Что удалось удалить

Других вызывающих у них не осталось, поэтому из `JoinRpg.Domain` ушли `EnsureCanAddClaim`, `EnsureCanMoveClaim`, `ValidateIfCanMoveClaim`, `IsAcceptingClaims`, `ThrowIfValidationFailed` и `ToMovedClaim`.

От `ClaimAcceptOrMoveValidationExtensions` остался **один метод** — `ValidateIfCanAddClaim`. Его держат `AddClaimViewModel` и `CharacterListViewService`.

## Тесты

Тесты переноса заявки пользовались продакшн-методом, у которого после этой правки не осталось других вызывающих. Переведены на агрегат: собирают `CharacterInfo` из мока и зовут общий валидатор. Хелпер лежит в тестах, а не в продакшн-коде — держать там метод ради тестов неправильно.

## Плата

На write-путях персонаж грузится дважды: EF нужен для записи (`claim.Character = source`, `source.ApprovedClaim = claim`, `GetResponsibleMaster()`), агрегат — для валидации. Один дополнительный однострочный запрос на операцию, не в цикле. Уйдёт, когда сам write-путь переедет на агрегат.

## Что осталось до удаления LegacyClaimTarget

- `AddClaimViewModel` — упирается в `CustomFieldsViewModel`, а тот тянет EF-`Project` ради `JoinrpgMarkdownLinkRenderer` и EF-`Character` ради `IsAvailableForTarget`. Отдельный проект.
- `CharacterListViewService` — там вопрос про префильтр на стороне агрегатного репозитория.

## Проверка

`dotnet build` — 0 ошибок, `dotnet format --verify-no-changes --severity warn` — чисто. Все тестовые проекты зелёные, **кроме** `JoinRpg.IntegrationTest`: в этой среде Docker разладился, контейнер SQL Server падает с `ContainerNotRunningException`, и набор падающих тестов меняется от прогона к прогону (лучший результат — 165/167, худший — 65/167, все ошибки контейнерные). Перезапуск Docker и очистка контейнеров не помогли.

Регистрацию `ICharacterInfoRepository` проверил чтением — она в `Registraton.cs` рядом с `ICharacterRepository`, тем же `AddTransient`; те же контроллеры уже брали её в #4793. Рассчитываю на CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iDrJy1EPS5fZT7DakTtyY