### PR TITLE
feat: пробросить GetCharactersByIds/ListCharactersByGroup в x-game-api

### DIFF
--- a/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
+++ b/src/JoinRpg.Portal/Controllers/XGameApi/CharacterApiController.cs
@@ -35,6 +35,36 @@ public class CharacterApiController(ICharacterApiViewService characterApiViewSer
     }
 
     /// <summary>
+    /// Character details for several characters at once. Use when you need a specific
+    /// set of characters, not the full project list.
+    /// </summary>
+    [HttpGet]
+    [Route("by-ids")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<CharacterInfo>>> GetByIds(int projectId, [FromQuery] int[] ids)
+    {
+        if (ids is not { Length: > 0 })
+        {
+            return BadRequest("ids is required");
+        }
+
+        return Ok(await characterApiViewService.GetCharactersByIds(new ProjectIdentification(projectId), ids));
+    }
+
+    /// <summary>
+    /// Characters belonging to a group, including nested subgroups
+    /// (and field-variant special groups).
+    /// </summary>
+    [HttpGet]
+    [Route("~/x-game-api/{projectId}/groups/{groupId}/characters")]
+    public async Task<IEnumerable<CharacterInfo>> GetByGroup(int projectId, int groupId)
+    {
+        return await characterApiViewService.ListCharactersByGroup(
+            new CharacterGroupIdentification(new ProjectIdentification(projectId), groupId));
+    }
+
+    /// <summary>
     /// Create new character
     /// </summary>
     [HttpPost]

--- a/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/ICharacterApiViewService.cs
@@ -13,8 +13,6 @@ public interface ICharacterApiViewService
 
     Task<CharacterInfo> GetCharacterInfo(CharacterIdentification characterId);
 
-    // TODO пробросить в x-game-api (сейчас вызывается только будущим MCP-слоем). См. #4798.
-
     /// <summary>Персонажи по конкретным id одного проекта — не выгрузка всех подряд.</summary>
     Task<IReadOnlyCollection<CharacterInfo>> GetCharactersByIds(ProjectIdentification projectId, IReadOnlyCollection<int> characterIds);
 


### PR DESCRIPTION
## Что сделано

В #4796 в `ICharacterApiViewService` были добавлены `GetCharactersByIds` и
`ListCharactersByGroup` — тонкие обёртки над `ICharacterInfoRepository`, но
`CharacterApiController` (x-game-api) их не вызывал.

Добавлены два эндпоинта:
- `GET x-game-api/{projectId}/characters/by-ids?ids=1,2,3` поверх `GetCharactersByIds`;
- `GET x-game-api/{projectId}/groups/{groupId}/characters` поверх `ListCharactersByGroup`.

TODO-комментарий про #4798 в `ICharacterApiViewService` убран.

Closes #4798

## Test plan

- [x] `dotnet build` — без ошибок
- [x] `dotnet format --verify-no-changes --severity warn` — чисто
- [x] `dotnet test src/JoinRpg.WebPortal.Managers.Test --filter CharacterApiViewServiceTests` — 5 passed (доступ проверяется в манагере, контроллер — тонкая обёртка)

Generated with [Claude Code](https://claude.ai/code/session_0182fP3JGVVSSz9VRZMwHLnS)