### PR TITLE
feat: провайдеры поиска сообщают LinkType и project-scoping

### DIFF
--- a/src/JoinRpg.Services.Impl.Test/SearchServiceImplTest.cs
+++ b/src/JoinRpg.Services.Impl.Test/SearchServiceImplTest.cs
@@ -6,9 +6,19 @@ namespace JoinRpg.Services.Impl.Test;
 
 public class SearchServiceImplTest
 {
-    private sealed class FakeSearchProvider(params SearchResult[] results) : ISearchProvider
+    private sealed class FakeSearchProvider(LinkType linkType = LinkType.ResultUser, params SearchResult[] results) : ISearchProvider
     {
+        public LinkType LinkType => linkType;
+
         public Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+            => Task.FromResult<IReadOnlyCollection<SearchResult>>(results);
+    }
+
+    private sealed class FakeProjectScopedSearchProvider(LinkType linkType, params SearchResult[] results) : IProjectScopedSearchProvider
+    {
+        public LinkType LinkType => linkType;
+
+        public Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId)
             => Task.FromResult<IReadOnlyCollection<SearchResult>>(results);
     }
 
@@ -24,6 +34,17 @@ public class SearchServiceImplTest
         IsPerfectMatch = isPerfectMatch,
     };
 
+    private static SearchResult CharacterResult(int characterId, string description) => new()
+    {
+        LinkType = LinkType.ResultCharacter,
+        Name = "Test Character",
+        Description = new MarkdownDbValue(description),
+        Identification = characterId.ToString(),
+        ProjectId = null,
+        IsPublic = true,
+        IsActive = true,
+    };
+
     [Fact]
     public async Task SameUserFoundByTwoProviders_IsReturnedOnce()
     {
@@ -32,8 +53,8 @@ public class SearchServiceImplTest
         // (с разным Description), которые Distinct() не считал дубликатами.
         var service = new SearchServiceImpl(
         [
-            new FakeSearchProvider(UserResult(42, "ID: 42")),
-            new FakeSearchProvider(UserResult(42, "")),
+            new FakeSearchProvider(results: [UserResult(42, "ID: 42")]),
+            new FakeSearchProvider(results: [UserResult(42, "")]),
         ]);
 
         var results = await service.SearchAsync(currentUserId: null, "id42");
@@ -46,8 +67,8 @@ public class SearchServiceImplTest
     {
         var service = new SearchServiceImpl(
         [
-            new FakeSearchProvider(UserResult(42, "ID: 42")),
-            new FakeSearchProvider(UserResult(42, "Найден в контактах")),
+            new FakeSearchProvider(results: [UserResult(42, "ID: 42")]),
+            new FakeSearchProvider(results: [UserResult(42, "Найден в контактах")]),
         ]);
 
         var results = await service.SearchAsync(currentUserId: null, "id42");
@@ -61,8 +82,8 @@ public class SearchServiceImplTest
     {
         var service = new SearchServiceImpl(
         [
-            new FakeSearchProvider(UserResult(42, "ID: 42")),
-            new FakeSearchProvider(UserResult(42, "ID: 42")),
+            new FakeSearchProvider(results: [UserResult(42, "ID: 42")]),
+            new FakeSearchProvider(results: [UserResult(42, "ID: 42")]),
         ]);
 
         var results = await service.SearchAsync(currentUserId: null, "id42");
@@ -76,12 +97,42 @@ public class SearchServiceImplTest
     {
         var service = new SearchServiceImpl(
         [
-            new FakeSearchProvider(UserResult(1, "ID: 1")),
-            new FakeSearchProvider(UserResult(2, "ID: 2")),
+            new FakeSearchProvider(results: [UserResult(1, "ID: 1")]),
+            new FakeSearchProvider(results: [UserResult(2, "ID: 2")]),
         ]);
 
         var results = await service.SearchAsync(currentUserId: null, "test");
 
         results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task LinkTypesFilter_OnlyMatchingProvidersAreCalled()
+    {
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(linkType: LinkType.ResultUser, results: [UserResult(1, "ID: 1")]),
+            new FakeSearchProvider(linkType: LinkType.ResultCharacter, results: [CharacterResult(2, "ID: 2")]),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "test", linkTypes: [LinkType.ResultCharacter]);
+
+        var result = results.ShouldHaveSingleItem();
+        result.LinkType.ShouldBe(LinkType.ResultCharacter);
+    }
+
+    [Fact]
+    public async Task ProjectIdFilter_NonProjectScopedProvidersAreNotCalled()
+    {
+        var service = new SearchServiceImpl(
+        [
+            new FakeSearchProvider(linkType: LinkType.ResultUser, results: [UserResult(1, "ID: 1")]),
+            new FakeProjectScopedSearchProvider(linkType: LinkType.ResultCharacter, results: [CharacterResult(2, "ID: 2")]),
+        ]);
+
+        var results = await service.SearchAsync(currentUserId: null, "test", projectId: new ProjectIdentification(1));
+
+        var result = results.ShouldHaveSingleItem();
+        result.LinkType.ShouldBe(LinkType.ResultCharacter);
     }
 }

--- a/src/JoinRpg.Services.Impl/Search/IProjectScopedSearchProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/IProjectScopedSearchProvider.cs
@@ -1,0 +1,16 @@
+using JoinRpg.Services.Interfaces.Search;
+
+namespace JoinRpg.Services.Impl.Search;
+
+/// <summary>
+/// Провайдер, который умеет сузить поиск до одного проекта. Реализует только этот
+/// (3-арговый) метод — базовый <see cref="ISearchProvider.SearchAsync(int?, string)"/>
+/// достаётся бесплатно через default-реализацию ниже, форвардящую с <c>projectId: null</c>.
+/// </summary>
+internal interface IProjectScopedSearchProvider : ISearchProvider
+{
+    Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId);
+
+    Task<IReadOnlyCollection<SearchResult>> ISearchProvider.SearchAsync(int? currentUserId, string searchString)
+        => SearchAsync(currentUserId, searchString, projectId: null);
+}

--- a/src/JoinRpg.Services.Impl/Search/ISearchProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/ISearchProvider.cs
@@ -4,5 +4,7 @@ namespace JoinRpg.Services.Impl.Search;
 
 internal interface ISearchProvider
 {
+    LinkType LinkType { get; }
+
     Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString);
 }

--- a/src/JoinRpg.Services.Impl/Search/Providers/CharacterGroupsProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/CharacterGroupsProvider.cs
@@ -5,7 +5,7 @@ using JoinRpg.Services.Interfaces.Search;
 
 namespace JoinRpg.Services.Impl.Search;
 
-internal class CharacterGroupsProvider : WorldObjectProviderBase, ISearchProvider
+internal class CharacterGroupsProvider : WorldObjectProviderBase, IProjectScopedSearchProvider
 {
     private readonly IUnitOfWork unitOfWork;
 
@@ -14,7 +14,9 @@ internal class CharacterGroupsProvider : WorldObjectProviderBase, ISearchProvide
         this.unitOfWork = unitOfWork;
     }
 
-    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+    public LinkType LinkType => LinkType.ResultCharacterGroup;
+
+    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId)
     {
         int? characterGroupIdToFind = int.TryParse(searchString.Trim(), out var parsedValue) ? parsedValue : null;
 
@@ -26,6 +28,7 @@ internal class CharacterGroupsProvider : WorldObjectProviderBase, ISearchProvide
                 || cg.CharacterGroupName.Contains(searchString)
                 || (cg.Description.Contents != null && cg.Description.Contents.Contains(searchString)))
                 && cg.IsActive && !cg.IsRoot
+                && (projectId == null || cg.ProjectId == projectId.Value)
               )
               .OrderByDescending(cg => cg.CharacterGroupName.Contains(searchString))
               .ToListAsync();

--- a/src/JoinRpg.Services.Impl/Search/Providers/CharacterProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/CharacterProvider.cs
@@ -5,12 +5,14 @@ using JoinRpg.Services.Interfaces.Search;
 
 namespace JoinRpg.Services.Impl.Search.Providers;
 
-internal class CharacterProvider(IUnitOfWork unitOfWork) : WorldObjectProviderBase, ISearchProvider
+internal class CharacterProvider(IUnitOfWork unitOfWork) : WorldObjectProviderBase, IProjectScopedSearchProvider
 {
     //keep longer strings first to please Regexp
     private static readonly string[] keysForPerfectMath = ["%персонаж", "персонаж",];
 
-    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+    public LinkType LinkType => LinkType.ResultCharacter;
+
+    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId)
     {
         (var characterIdToFind, var matchByIdIsPerfect) = SearchKeywordsResolver.TryGetId(searchString, keysForPerfectMath);
 
@@ -22,6 +24,7 @@ internal class CharacterProvider(IUnitOfWork unitOfWork) : WorldObjectProviderBa
                 (c.CharacterId == characterIdToFind
                 || c.CharacterName.Contains(searchString))
                 && c.IsActive
+                && (projectId == null || c.ProjectId == projectId.Value)
               )
               .OrderByDescending(cg => cg.CharacterName.Contains(searchString))
               .ToListAsync();

--- a/src/JoinRpg.Services.Impl/Search/Providers/ClaimsByIdProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/ClaimsByIdProvider.cs
@@ -7,12 +7,14 @@ using JoinRpg.Services.Interfaces.Search;
 
 namespace JoinRpg.Services.Impl.Search.Providers;
 
-internal class ClaimsByIdProvider(IUnitOfWork unitOfWork) : ISearchProvider
+internal class ClaimsByIdProvider(IUnitOfWork unitOfWork) : IProjectScopedSearchProvider
 {
     //keep longer strings first to please Regexp
     private static readonly string[] keysForPerfectMath = ["%заявка", "заявка",];
 
-    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+    public LinkType LinkType => LinkType.Claim;
+
+    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId)
     {
         (var idToFind, var matchByIdIsPerfect) = SearchKeywordsResolver.TryGetId(searchString, keysForPerfectMath);
 
@@ -25,7 +27,7 @@ internal class ClaimsByIdProvider(IUnitOfWork unitOfWork) : ISearchProvider
         var results =
           await
             unitOfWork.GetDbSet<Claim>()
-              .Where(claim => claim.ClaimId == idToFind)
+              .Where(claim => claim.ClaimId == idToFind && (projectId == null || claim.ProjectId == projectId.Value))
               .ToListAsync();
 
         return results

--- a/src/JoinRpg.Services.Impl/Search/Providers/PlotSearchProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/PlotSearchProvider.cs
@@ -5,9 +5,11 @@ using JoinRpg.Services.Interfaces.Search;
 
 namespace JoinRpg.Services.Impl.Search;
 
-internal class PlotSearchProvider(IUnitOfWork unitOfWork) : ISearchProvider
+internal class PlotSearchProvider(IUnitOfWork unitOfWork) : IProjectScopedSearchProvider
 {
-    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+    public LinkType LinkType => LinkType.Plot;
+
+    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString, ProjectIdentification? projectId)
     {
         if (searchString.Length < 3)
         {
@@ -19,6 +21,7 @@ internal class PlotSearchProvider(IUnitOfWork unitOfWork) : ISearchProvider
             unitOfWork.GetDbSet<PlotFolder>()
              .Where(p =>
                p.IsActive && p.Project.ProjectAcls.Any(acl => acl.UserId == currentUserId) && p.MasterTitle.Contains(searchString)
+               && (projectId == null || p.ProjectId == projectId.Value)
              )
              .ToListAsync();
 

--- a/src/JoinRpg.Services.Impl/Search/Providers/ProjectSearchProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/ProjectSearchProvider.cs
@@ -7,6 +7,8 @@ namespace JoinRpg.Services.Impl.Search.Providers;
 
 internal class ProjectSearchProvider(IUnitOfWork unitOfWork) : ISearchProvider
 {
+    public LinkType LinkType => LinkType.Project;
+
     public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
     {
         if (searchString.Length < 3)

--- a/src/JoinRpg.Services.Impl/Search/Providers/UserSearchByIdProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/UserSearchByIdProvider.cs
@@ -11,6 +11,8 @@ internal class UserSearchByIdProvider(IUnitOfWork unitOfWork) : ISearchProvider
     //keep longer strings first to please Regexp
     private static readonly string[] keysForPerfectMath = ["%контакты", "контакты", "%игрок", "игрок",];
 
+    public LinkType LinkType => LinkType.ResultUser;
+
     public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
     {
         searchString = searchString.Trim();

--- a/src/JoinRpg.Services.Impl/Search/Providers/UserSearchBySocialProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/UserSearchBySocialProvider.cs
@@ -8,6 +8,8 @@ namespace JoinRpg.Services.Impl.Search.Providers;
 
 internal class UserSearchBySocialProvider(IUnitOfWork unitOfWork) : ISearchProvider
 {
+    public LinkType LinkType => LinkType.ResultUser;
+
     public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
     {
         searchString = searchString.Trim();

--- a/src/JoinRpg.Services.Impl/Search/Providers/UserSearchProvider.cs
+++ b/src/JoinRpg.Services.Impl/Search/Providers/UserSearchProvider.cs
@@ -8,6 +8,8 @@ namespace JoinRpg.Services.Impl.Search.Providers;
 
 internal class UserSearchProvider(IUnitOfWork unitOfWork) : ISearchProvider
 {
+    public LinkType LinkType => LinkType.ResultUser;
+
     public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
     {
         if (searchString.Length < 3)

--- a/src/JoinRpg.Services.Impl/Search/SearchServiceImpl.cs
+++ b/src/JoinRpg.Services.Impl/Search/SearchServiceImpl.cs
@@ -5,7 +5,11 @@ namespace JoinRpg.Services.Impl.Search;
 
 internal class SearchServiceImpl(IEnumerable<ISearchProvider> searchProviders) : ISearchService
 {
-    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString)
+    public async Task<IReadOnlyCollection<SearchResult>> SearchAsync(
+        int? currentUserId,
+        string searchString,
+        IReadOnlyCollection<LinkType>? linkTypes = null,
+        ProjectIdentification? projectId = null)
     {
         searchString = searchString.Trim();
         if (searchString.Length == 0)
@@ -13,7 +17,12 @@ internal class SearchServiceImpl(IEnumerable<ISearchProvider> searchProviders) :
             return [];
         }
 
-        var searchTasks = searchProviders.Select(p => p.SearchAsync(currentUserId, searchString));
+        var applicableProviders = searchProviders
+            .Where(p => linkTypes is null || linkTypes.Contains(p.LinkType));
+
+        var searchTasks = projectId is null
+            ? applicableProviders.Select(p => p.SearchAsync(currentUserId, searchString))
+            : applicableProviders.OfType<IProjectScopedSearchProvider>().Select(p => p.SearchAsync(currentUserId, searchString, projectId));
 
         var results = new List<SearchResult>();
         foreach (var task in searchTasks)

--- a/src/JoinRpg.Services.Interfaces/Search/ISearchService.cs
+++ b/src/JoinRpg.Services.Interfaces/Search/ISearchService.cs
@@ -4,5 +4,9 @@ namespace JoinRpg.Services.Interfaces;
 
 public interface ISearchService
 {
-    Task<IReadOnlyCollection<SearchResult>> SearchAsync(int? currentUserId, string searchString);
+    Task<IReadOnlyCollection<SearchResult>> SearchAsync(
+        int? currentUserId,
+        string searchString,
+        IReadOnlyCollection<LinkType>? linkTypes = null,
+        ProjectIdentification? projectId = null);
 }

--- a/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
+++ b/src/JoinRpg.WebPortal.Managers/Characters/SearchApiViewService.cs
@@ -17,12 +17,13 @@ internal class SearchApiViewService(
         var projectInfo = await projectMetadataRepository.GetProjectMetadata(projectId);
         _ = projectInfo.RequestMasterAccess(currentUserAccessor);
 
-        // TODO ISearchService.SearchAsync не умеет сузить скоуп по LinkType/ProjectId — ищет по
-        // всем провайдерам и проектам, а мы выкидываем лишнее уже здесь. См. #4797.
-        var results = await searchService.SearchAsync(currentUserAccessor.UserIdOrDefault, query);
+        var results = await searchService.SearchAsync(
+            currentUserAccessor.UserIdOrDefault,
+            query,
+            linkTypes: [LinkType.ResultCharacter],
+            projectId: projectId);
 
         return [.. results
-            .Where(r => r.LinkType == LinkType.ResultCharacter && r.ProjectId == projectId.Value)
             .Select(r => new CharacterSearchResult
             {
                 CharacterId = int.Parse(r.Identification),


### PR DESCRIPTION
## Что сделано

- `ISearchService.SearchAsync` принимает опциональные `linkTypes`/`projectId`, чтобы вызывающий код мог сузить поиск, не выкидывая лишние результаты постфактум.
- Каждый `ISearchProvider` декларирует свой `LinkType`; провайдеры, завязанные на проект (`CharacterProvider`, `CharacterGroupsProvider`, `PlotSearchProvider`, `ClaimsByIdProvider`), реализуют `IProjectScopedSearchProvider` и толкают фильтр по `ProjectId` в SQL вместо сканирования всех проектов.
- `IProjectScopedSearchProvider` даёт default-реализацию унаследованного 2-арг метода `ISearchProvider.SearchAsync` через C# default interface methods (форвардит с `projectId: null`) — провайдеру не нужно писать два похожих метода.
- `SearchApiViewService.SearchCharacters` (введён в #4796 с TODO на этот issue) переведён на новый API — вместо `SearchAsync(...).Where(r => r.LinkType == ... && r.ProjectId == ...)` теперь просто `SearchAsync(..., linkTypes: [LinkType.ResultCharacter], projectId: projectId)`.
- `SearchController` (сайтовый поиск) не тронут — продолжает искать без фильтров, поведение не изменилось.

Closes #4797

## Test plan
- [x] `dotnet build`
- [x] `dotnet test src/JoinRpg.Services.Impl.Test` (включая новые тесты на фильтрацию по `LinkType`/`ProjectId`)
- [x] `dotnet format --verify-no-changes --severity warn`