### PR TITLE
fix: .editorconfig — глоб без пробелов, убраны дубли и конфликт

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 max_line_length = 140
 
-[*.{cs, cshtml, js}]
+[*.{cs,cshtml,js}]
 charset = utf-8
 indent_size = 4
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
@@ -55,8 +55,6 @@ csharp_preserve_single_line_blocks = true
 
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
-
-dotnet_style_require_accessibility_modifiers = always:warning
 
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
@@ -196,11 +194,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix =
-dotnet_naming_style.pascal_case.required_suffix =
-dotnet_naming_style.pascal_case.word_separator =
-dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.pascal_case.required_prefix =
 dotnet_naming_style.pascal_case.required_suffix =

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
 
         <UseArtifactsOutput>true</UseArtifactsOutput>
 
-        <NoWarn>${NoWarn};CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
 
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
@@ -31,8 +31,6 @@
 
         <TargetFramework>net10.0</TargetFramework>
         <NoWarn>$(NoWarn);NU1507</NoWarn>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
 
     </PropertyGroup>
     <!--


### PR DESCRIPTION
## Что сделано

- **Глоб с пробелом.** `[*.{cs, cshtml, js}]` → `[*.{cs,cshtml,js}]`. В EditorConfig пробелы внутри `{}` не отбрасываются, поэтому секция матчила `*.cs`, `*. cshtml` и `*. js` — на `.cshtml`/`.js` её правила не применялись вообще.
- **Конфликт accessibility modifiers.** Убран `dotnet_style_require_accessibility_modifiers = always:warning` из `[*.cs]`; осталось `for_non_interface_members:warning` в `[*.{cs,vb}]` — то значение, которое и побеждало фактически (более поздняя секция).
- **Дубликаты.** Убрана вторая копия блока `dotnet_naming_style.pascal_case.*`; в `Directory.Build.props` убраны повторные `Nullable` и `ImplicitUsings`.
- **Бонус той же природы:** в `Directory.Build.props` `<NoWarn>${NoWarn};CS1591</NoWarn>` → `$(NoWarn)`. `${...}` — не подстановка MSBuild, в список попадала литеральная строка `${NoWarn}`.

## Проверка

`dotnet build` — 0 ошибок, `dotnet format --verify-no-changes --severity warn` — чисто.

Closes #4804

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJQ9or7ncoBN3akFb92DAu