### PR TITLE
fix: включить WarningsAsErrors для NU* и поднять SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,12 +11,17 @@
 
         <UseArtifactsOutput>true</UseArtifactsOutput>
 
-        <NoWarn>${NoWarn};CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
 
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
 
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <!--
+        WarningsAsErrors — это список идентификаторов, а не булево (булево называется
+        TreatWarningsAsErrors). Начинаем с NU* — предупреждений об уязвимостях и проблемах
+        восстановления пакетов; остальные предупреждения пока остаются предупреждениями.
+        -->
+        <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
 
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -44,6 +49,6 @@
     </ItemGroup>
     <ItemGroup>
         <GlobalPackageReference Include="ReferenceTrimmer" Version="3.5.7" />
-        <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+        <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.12" />
         <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
-        <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.303" />
+        <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.401" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.12" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.12" />
         <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.12" />


### PR DESCRIPTION
## Что сделано

- `WarningsAsErrors` принимает список идентификаторов, а не булево, поэтому `true` ничего не включало. Начали с `NU1901;NU1902;NU1903;NU1904` — предупреждений аудита зависимостей.
- Первый же `dotnet restore` после этого упал на NU1902: `Microsoft.Build.Tasks.Git` из `Microsoft.SourceLink.GitHub` 10.0.301 (GHSA-23fw-v26w-5fgq). Подняли SourceLink до 10.0.401 и пин `Microsoft.Build.Tasks.Git` 10.0.303 → 10.0.401 (иначе NU1605 — понижение версии).
- Заодно опечатка `${NoWarn}` → `$(NoWarn)`.

Компиляторные предупреждения (CS*) не включались: их накопилось 435, это отдельная работа.

Проверено: `dotnet restore` чистый, `dotnet build` — 0 ошибок.

Closes #4802

Generated with [Claude Code](https://claude.ai/code)