### PR TITLE
fix: MSBuild-синтаксис $(NoWarn) вместо shell-подобного ${NoWarn}

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
 
         <UseArtifactsOutput>true</UseArtifactsOutput>
 
-        <NoWarn>${NoWarn};CS1591</NoWarn>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
 
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <Nullable>enable</Nullable>

--- a/src/JoinRpg.Blazor.Client/JoinRpg.Blazor.Client.csproj
+++ b/src/JoinRpg.Blazor.Client/JoinRpg.Blazor.Client.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />

--- a/src/JoinRpg.CommonUI.Models.Test/JoinRpg.CommonUI.Models.Test.csproj
+++ b/src/JoinRpg.CommonUI.Models.Test/JoinRpg.CommonUI.Models.Test.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AssemblyTitle>JoinRpg.CommonUI.Models.Test</AssemblyTitle>
     <Product>JoinRpg.CommonUI.Models.Test</Product>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.CommonUI.Models\JoinRpg.CommonUI.Models.csproj" />

--- a/src/JoinRpg.Dal.Impl.Tests/JoinRpg.Dal.Impl.Tests.csproj
+++ b/src/JoinRpg.Dal.Impl.Tests/JoinRpg.Dal.Impl.Tests.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.Dal.Impl\JoinRpg.Dal.Impl.csproj" />
     <ProjectReference Include="..\JoinRpg.DataModel.Mocks\JoinRpg.DataModel.Mocks.csproj" />

--- a/src/JoinRpg.DataModel.Mocks/JoinRpg.DataModel.Mocks.csproj
+++ b/src/JoinRpg.DataModel.Mocks/JoinRpg.DataModel.Mocks.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.Dal.Impl\JoinRpg.Dal.Impl.csproj" />
     <ProjectReference Include="..\JoinRpg.DataModel\JoinRpg.DataModel.csproj" />

--- a/src/JoinRpg.Domain.Test/JoinRpg.Domain.Test.csproj
+++ b/src/JoinRpg.Domain.Test/JoinRpg.Domain.Test.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.DataModel.Mocks\JoinRpg.DataModel.Mocks.csproj" />
     <ProjectReference Include="..\JoinRpg.DataModel\JoinRpg.DataModel.csproj" />

--- a/src/JoinRpg.Helpers.Test/JoinRpg.Helpers.Test.csproj
+++ b/src/JoinRpg.Helpers.Test/JoinRpg.Helpers.Test.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.Helpers\JoinRpg.Helpers.csproj" />
   </ItemGroup>

--- a/src/JoinRpg.Markdown.Test/JoinRpg.Markdown.Test.csproj
+++ b/src/JoinRpg.Markdown.Test/JoinRpg.Markdown.Test.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.Markdown\JoinRpg.Markdown.csproj" />
   </ItemGroup>

--- a/src/JoinRpg.Portal/JoinRpg.Portal.csproj
+++ b/src/JoinRpg.Portal/JoinRpg.Portal.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DebugType>full</DebugType>
     <UserSecretsId>aspnet-JoinRpg.Portal-D30D89A6-2652-4339-953B-C703F29AE5C7</UserSecretsId>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
     <ContainerRuntimeIdentifier>linux-x64</ContainerRuntimeIdentifier>

--- a/src/JoinRpg.Services.Impl.Test/JoinRpg.Services.Impl.Test.csproj
+++ b/src/JoinRpg.Services.Impl.Test/JoinRpg.Services.Impl.Test.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};CS1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.DataModel.Mocks\JoinRpg.DataModel.Mocks.csproj" />
     <ProjectReference Include="..\JoinRpg.Services.Impl\JoinRpg.Services.Impl.csproj" />

--- a/src/JoinRpg.WebPortal.Models/JoinRpg.WebPortal.Models.csproj
+++ b/src/JoinRpg.WebPortal.Models/JoinRpg.WebPortal.Models.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <NoWarn>${NoWarn};1591</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JoinRpg.DomainTypes\JoinRpg.DomainTypes.csproj" />
     <ProjectReference Include="..\JoinRpg.Web.ProjectCommon\JoinRpg.Web.ProjectCommon.csproj" />


### PR DESCRIPTION
## Что сделано

- `Directory.Build.props` — `${NoWarn};CS1591` → `$(NoWarn);CS1591`. MSBuild не разворачивает `${...}`, поэтому накопленное из SDK и вышестоящих props значение `NoWarn` затиралось, а литерал `${NoWarn}` молча игнорировался как неизвестный идентификатор предупреждения.
- Удалена дублирующая строка `NoWarn` из 10 `.csproj` — свойство наследуется из `Directory.Build.props`, общие свойства не должны дублироваться в проектах (docs/structure.md). В 8 из них `<PropertyGroup>` после этого стал пустым и тоже убран.

## Проверка

`dotnet build` — 0 ошибок, 443 предупреждения; роста нет, так как новый набор `NoWarn` — надмножество прежнего.

Closes #4803

Generated with [Claude Code](https://claude.com/claude-code)