### PR TITLE
fix: починить и вернуть в солюшен JoinRpg.Common.Telegram.Test

### DIFF
--- a/Joinrpg.slnx
+++ b/Joinrpg.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes.Test/JoinRpg.Common.PrimitiveTypes.Test.csproj" />
     <Project Path="src/Common/JoinRpg.Common.PrimitiveTypes/JoinRpg.Common.PrimitiveTypes.csproj" />
     <Project Path="src/Common/JoinRpg.Common.Telegram/JoinRpg.Common.Telegram.csproj" />
+    <Project Path="src/Common/JoinRpg.Common.Telegram.Test/JoinRpg.Common.Telegram.Test.csproj" />
     <Project Path="src/Common/JoinRpg.Common.WebInfrastructure/JoinRpg.Common.WebInfrastructure.csproj" />
     <Project Path="src/JoinRpg.Helpers/JoinRpg.Helpers.csproj" />
     <Project Path="src/JoinRpg.Markdown/JoinRpg.Markdown.csproj" />

--- a/src/Common/JoinRpg.Common.Telegram.Test/DefaultOnlyTelegramNotificationServiceFactoryTest.cs
+++ b/src/Common/JoinRpg.Common.Telegram.Test/DefaultOnlyTelegramNotificationServiceFactoryTest.cs
@@ -26,7 +26,7 @@ public class DefaultOnlyTelegramNotificationServiceFactoryTest
 
     private sealed class FakeTelegramNotificationService : ITelegramNotificationService
     {
-        public Task<SendingResult> SendTelegramNotification(TelegramId telegramId, TelegramHtmlString contents) => throw new NotSupportedException();
+        public Task<SendingResult> SendTelegramNotification(TelegramChatId chatId, TelegramHtmlString contents) => throw new NotSupportedException();
         public Task<string?> GetMyUserName(CancellationToken cancellationToken) => throw new NotSupportedException();
     }
 }

--- a/src/Common/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
+++ b/src/Common/JoinRpg.Common.Telegram.Test/TelegramNotificationServiceImplTimeoutTest.cs
@@ -1,18 +1,20 @@
 using System.Net;
+using System.Text;
 using JoinRpg.Common.PrimitiveTypes;
-using JoinRpg.Services.Interfaces.Notification;
 using Microsoft.Extensions.Logging.Abstractions;
 using Telegram.Bot;
-using Telegram.Bot.Exceptions;
 
 namespace JoinRpg.Common.Telegram.Test;
 
 public class TelegramNotificationServiceImplTimeoutTest
 {
     [Fact]
-    public async Task SendTelegramNotification_WithBotBlockedException_ReturnsUserRelatedFailure()
+    public async Task SendTelegramNotification_WithBotBlockedResponse_ReturnsUserRelatedFailure()
     {
-        var handler = new ThrowingHttpMessageHandler(new ApiRequestException("Forbidden: bot was blocked by the user", 403));
+        // Телеграм на заблокированного бота отвечает не транспортной ошибкой, а обычным HTTP-ответом с ok=false
+        var handler = new RespondingHttpMessageHandler(
+            HttpStatusCode.Forbidden,
+            """{"ok":false,"error_code":403,"description":"Forbidden: bot was blocked by the user"}""");
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.telegram.org") };
         var botClient = new TelegramBotClient("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11", httpClient);
         var service = new TelegramNotificationServiceImpl(botClient, NullLogger<TelegramNotificationServiceImpl>.Instance);
@@ -54,5 +56,14 @@ public class TelegramNotificationServiceImplTimeoutTest
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromException<HttpResponseMessage>(exception);
+    }
+
+    private sealed class RespondingHttpMessageHandler(HttpStatusCode statusCode, string json) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
     }
 }


### PR DESCRIPTION
## Зачем

Продолжение #4809. `src/Common/JoinRpg.Common.Telegram.Test` отсутствовал в `Joinrpg.slnx`, поэтому не собирался и не гонялся в CI — и незаметно протух: в #4642 `TelegramId` переименовали в `TelegramChatId`, а этот тест остался со старой сигнатурой и просто перестал компилироваться.

## Что сделано

- `FakeTelegramNotificationService` приведён к актуальной сигнатуре `SendTelegramNotification(TelegramChatId, TelegramHtmlString)`.
- Тест на заблокированного бота переписан: теперь фейковый `HttpMessageHandler` отдаёт настоящий ответ Telegram (HTTP 403 + `{"ok":false,"error_code":403,"description":"Forbidden: bot was blocked by the user"}`), а не кидает `ApiRequestException` как транспортную ошибку. Так было неправильно: `Telegram.Bot` заворачивает исключения транспорта в `RequestException`, и `catch (ApiRequestException)` в `TelegramNotificationServiceImpl` до него не доходил — тест проверял не тот путь, которым ошибка приходит в проде.
- Проект добавлен в `Joinrpg.slnx`, убран лишний using (всплыл IDE0005, когда проект наконец попал под `dotnet format`).

Продакшн-код не менялся.

## Проверено
`dotnet build`, `dotnet format --verify-no-changes --severity warn`, `dotnet test` — зелено, 10/10 тестов в `JoinRpg.Common.Telegram.Test` проходят.

Generated with [Claude Code](https://claude.ai/code)